### PR TITLE
Use message severity constant for banner warning

### DIFF
--- a/src/taskpane/taskpane.js
+++ b/src/taskpane/taskpane.js
@@ -697,7 +697,7 @@ async function loadBannerContextForSelectedRange(context, selectedRange, calcula
       upperScanRows: [],
       messages: [
         {
-          severity: "warning",
+          severity: MESSAGE_SEVERITY.WARNING,
           code: "BANNER_NO_ROWS_ABOVE_SELECTION",
           text: "Баннер: над выделенным диапазоном нет строк для анализа.",
         },


### PR DESCRIPTION
## Summary

Replaces a hardcoded banner warning severity string with the existing `MESSAGE_SEVERITY.WARNING` constant.

## Files changed

- `src/taskpane/taskpane.js`

## Behavior changes

No intentional behavior changes.

This is a small cleanup to keep banner status message severity values consistent.

## Not changed

- `src/core/significance.js`
- `src/core/excel-writer.js`
- `src/core/banner-detector.js`
- `src/taskpane/taskpane.html`
- statistical calculation logic
- writer behavior
- taskpane UI markup

## Build

- `npm run build` passed with existing webpack asset-size warnings.