### PR TITLE
Extract shared text normalization utilities

### DIFF
--- a/src/core/banner-detector.js
+++ b/src/core/banner-detector.js
@@ -20,6 +20,7 @@
  */
 
 import { BANNER_DICTIONARY } from "./config/dictionary.config";
+import { normalizeLookupText, normalizeDisplayText } from "./string-utils";
 
 const TOTAL_LABEL_KEYWORDS = BANNER_DICTIONARY.totalLabels;
 const WAVE_GROUP_LABEL_KEYWORDS = BANNER_DICTIONARY.waveGroupLabels;
@@ -556,27 +557,14 @@ function isTotalBannerLabel(normalizedLabel) {
  * Normalizes banner labels for matching.
  */
 function normalizeBannerLabel(rawLabel) {
-  if (rawLabel === null || rawLabel === undefined) {
-    return "";
-  }
-
-  return String(rawLabel)
-    .toLowerCase()
-    .replace(/ё/g, "е")
-    .replace(/[.,:;()]/g, " ")
-    .replace(/\s+/g, " ")
-    .trim();
+  return normalizeLookupText(rawLabel);
 }
 
 /**
  * Normalizes raw cell value but keeps user-facing text.
  */
 function normalizeRawBannerCellValue(rawValue) {
-  if (rawValue === null || rawValue === undefined) {
-    return "";
-  }
-
-  return String(rawValue).trim();
+  return normalizeDisplayText(rawValue);
 }
 
 /**

--- a/src/core/metric-detector.js
+++ b/src/core/metric-detector.js
@@ -1,18 +1,10 @@
 import { METRIC_DICTIONARY } from "./config/dictionary.config"; // Импортируем наш конфиг
+import { normalizeLookupText } from "./string-utils";
 
 export const LABEL_SCAN_COLUMNS_LEFT = 2;
 
 export function normalizeLabelText(rawLabel) {
-  if (rawLabel === null || rawLabel === undefined) {
-    return "";
-  }
-
-  return String(rawLabel)
-    .toLowerCase()
-    .replace(/ё/g, "е")
-    .replace(/[.,:;()]/g, " ")
-    .replace(/\s+/g, " ")
-    .trim();
+  return normalizeLookupText(rawLabel);
 }
 
 function doesKeywordMatchLabel(normalizedLabel, rawKeyword) {

--- a/src/core/string-utils.js
+++ b/src/core/string-utils.js
@@ -1,0 +1,42 @@
+/**
+ * Shared text normalization utilities for lookup and display.
+ *
+ * PURPOSE:
+ * Single source of truth for the two normalization operations used across
+ * metric-detector and banner-detector.
+ *
+ * normalizeLookupText — for dictionary/keyword matching.
+ * normalizeDisplayText — for preserving user-facing text as-is.
+ */
+
+/**
+ * Normalizes a raw value for dictionary/keyword lookup.
+ *
+ * - Lowercases
+ * - Replaces ё → е
+ * - Collapses punctuation to spaces
+ * - Collapses whitespace runs
+ */
+export function normalizeLookupText(rawValue) {
+  if (rawValue === null || rawValue === undefined) {
+    return "";
+  }
+
+  return String(rawValue)
+    .toLowerCase()
+    .replace(/ё/g, "е")
+    .replace(/[.,:;()]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+/**
+ * Normalizes a raw cell value for display — trims whitespace, preserves case.
+ */
+export function normalizeDisplayText(rawValue) {
+  if (rawValue === null || rawValue === undefined) {
+    return "";
+  }
+
+  return String(rawValue).trim();
+}


### PR DESCRIPTION
## Summary

Extracts shared text normalization helpers into `src/core/string-utils.js` and wires existing metric/banner detector normalization through those helpers.

Included:
- new `normalizeLookupText` helper for dictionary/keyword matching;
- new `normalizeDisplayText` helper for display-preserving cell text cleanup;
- `metric-detector.js` keeps the public `normalizeLabelText` wrapper;
- `banner-detector.js` keeps banner-specific local wrapper functions.

## Scope

Changed files:
- `src/core/string-utils.js`
- `src/core/metric-detector.js`
- `src/core/banner-detector.js`

## Behavior

This is intended as a no-behavior-change refactor:
- metric dictionary matching logic unchanged;
- banner dictionary matching logic unchanged;
- row/block detection behavior unchanged;
- banner group/Total/wave logic unchanged.

## Validation

- `npm run build` passes.