### PR TITLE
Fix global Total detection for multi-column banner groups

### DIFF
--- a/src/core/banner-detector.js
+++ b/src/core/banner-detector.js
@@ -802,6 +802,15 @@ function detectGlobalTotalColumnIndex(columnDescriptors) {
   );
 
   if (groupLabelIsTotal) {
+    const firstGroupKey = firstDescriptor.comparisonGroupKey;
+    const firstGroupSize = columnDescriptors.filter(
+      (descriptor) => descriptor.comparisonGroupKey === firstGroupKey
+    ).length;
+
+    if (firstGroupSize > 1) {
+      return null;
+    }
+
     return firstDescriptor.columnIndex;
   }
 


### PR DESCRIPTION
## Summary

Fixes a banner-aware comparison bug where a first banner group named `Total` / `Всего` was incorrectly treated as a global Total column even when that group spanned multiple columns.

This caused column 0 to be added to `totalColumnIndexes`, which excluded it from ordinary intra-group banner comparisons. As a result, the first pair inside a multi-column `Всего` group could be skipped entirely.

## Fix

`detectGlobalTotalColumnIndex` now only promotes a total-like first group label to global Total when that first group contains exactly one column.

## Expected behavior

- Multi-column first group labeled `Всего` / `Total` is treated as an ordinary comparison group.
- Columns 0 and 1 inside that group remain eligible for banner-group comparisons.
- True single-column global Total behavior is preserved.
- One-level local Total behavior is unchanged.

## Scope

Changed file:
- `src/core/banner-detector.js`

## Validation

- `npm run build` passes.