### PR TITLE
Fix banner group detection with vertically merged labels

### DIFF
--- a/src/core/banner-detector.js
+++ b/src/core/banner-detector.js
@@ -420,6 +420,19 @@ function detectReconstructedSpanGroupLevel(
     };
   }
 
+  const hasMergedDownSingleColumnSpan = spans.some(
+    (span) =>
+      span.columnIndexes.length === 1 &&
+      !normalizeRawBannerCellValue(lowerBannerRow[span.startColumnIndex])
+  );
+
+  if (hasMergedDownSingleColumnSpan) {
+    return {
+      groupLevel: null,
+      message: null,
+    };
+  }
+
   const labels = Array(selectedColumnCount).fill("");
   const spansByColumnIndex = {};
 


### PR DESCRIPTION
## Summary

Fixes banner group-level detection for multi-row banners with vertically merged lower labels.

In the real repro, Office.js returns blank text for non-top-left cells in vertically merged banner ranges. This caused `detectReconstructedSpanGroupLevel` to accept the wrong upper row as the group level:

- `2025Q4` and `2026Q1` became separate one-column groups;
- the actual group row above them was never inspected;
- the first pair inside the intended group was never generated.

## Fix

`detectReconstructedSpanGroupLevel` now rejects a candidate group-level row when it contains a single-column span over a blank lower-banner cell.

That pattern indicates a vertically merged lower-level label rather than a true group header, so the detector continues scanning higher rows.

## Expected behavior

- The repro with blank lower cells under vertically merged labels should use the next valid group-level row.
- Columns 0 and 1 should share the intended group and become eligible for banner-group comparison.
- Standard two-level banners with non-blank lower rows are unchanged.
- One-level banners are unchanged.
- Wave auto-detection logic is unchanged.

## Scope

Changed file:
- `src/core/banner-detector.js`

## Validation

- `npm run build` passes.