### PR TITLE
Fix banner-letter writes for merged banner rows

### DIFF
--- a/src/taskpane/taskpane.js
+++ b/src/taskpane/taskpane.js
@@ -1529,8 +1529,18 @@ async function writeBannerMarkersAboveSelectedRangeUsingBannerStructure(
     nextBannerTexts.push(appendOrReplaceTrailingBannerMarker(currentText, label));
   }
 
-  bannerRange.numberFormat = [nextBannerTexts.map(() => "@")];
-  bannerRange.values = [nextBannerTexts];
+  for (let columnIndex = 0; columnIndex < selectedColumnCount; columnIndex++) {
+    const nextText = nextBannerTexts[columnIndex] || "";
+    const currentText = currentBannerTexts[columnIndex] || "";
+
+    if (nextText === "" && currentText === "") {
+      continue;
+    }
+
+    const cell = bannerRange.getCell(0, columnIndex);
+    cell.numberFormat = [["@"]];
+    cell.values = [[nextText]];
+  }
 
   await context.sync();
 }


### PR DESCRIPTION
## Summary

- **Problem:** In banner-structure mode, the lower banner row may contain blank continuation cells created by vertically merged banner ranges. Office.js can reject a bulk write to a row range that overlaps merged areas it does not fully cover, causing banner letters to silently fail to write even when data-cell markers are produced correctly.
- **Fix:** Replace the single full-row `bannerRange.values = [nextBannerTexts]` write in `writeBannerMarkersAboveSelectedRangeUsingBannerStructure` with a cell-by-cell write loop. Each non-empty cell is written individually via `bannerRange.getCell(0, columnIndex)`, avoiding the merged-area rejection. Cells where both the current and next text are empty are skipped to minimise unnecessary API calls.
- **Scope:** Single function in `src/taskpane/taskpane.js`. No changes to significance calculation, banner detection, metric detection, or excel-writer.

## Out of scope

- The non-banner-structure banner-writing path is not modified in this PR.
- Banner label generation (`buildBannerLocalSignificanceLabelMap`) is unchanged.
- Data-cell marker output is unchanged.

## Validation

- `npm run build` - compiled with 0 errors (2 pre-existing size warnings, unchanged).
- Only `src/taskpane/taskpane.js` changed.

## Manual smoke notes

| Scenario | Expected |
|---|---|
| Vertically merged banner repro | Data markers appear; banner letters now written into writable cells |
| Standard two-level banner (no merges) | Unchanged - cell-by-cell writes produce the same result as before |
| One-level / no-banner-structure path | Out of scope; not touched |
| Data cell output | Unchanged |