### PR TITLE
Fix banner-letter targets for merged banner headers

### DIFF
--- a/src/taskpane/taskpane.js
+++ b/src/taskpane/taskpane.js
@@ -1529,6 +1529,8 @@ async function writeBannerMarkersAboveSelectedRangeUsingBannerStructure(
     nextBannerTexts.push(appendOrReplaceTrailingBannerMarker(currentText, label));
   }
 
+  const cellWriteQueue = [];
+
   for (let columnIndex = 0; columnIndex < selectedColumnCount; columnIndex++) {
     const nextText = nextBannerTexts[columnIndex] || "";
     const currentText = currentBannerTexts[columnIndex] || "";
@@ -1537,9 +1539,27 @@ async function writeBannerMarkersAboveSelectedRangeUsingBannerStructure(
       continue;
     }
 
-    const cell = bannerRange.getCell(0, columnIndex);
-    cell.numberFormat = [["@"]];
-    cell.values = [[nextText]];
+    const cell = selectedRange.worksheet.getRangeByIndexes(
+      selectedStartRowIndex - 1,
+      selectedStartColumnIndex + columnIndex,
+      1,
+      1
+    );
+    const mergedArea = cell.getMergedAreasOrNullObject();
+
+    mergedArea.load(["isNullObject", "rowIndex", "columnIndex"]);
+    cellWriteQueue.push({ nextText, cell, mergedArea });
+  }
+
+  await context.sync();
+
+  for (const { nextText, cell, mergedArea } of cellWriteQueue) {
+    const target = mergedArea.isNullObject
+      ? cell
+      : selectedRange.worksheet.getRangeByIndexes(mergedArea.rowIndex, mergedArea.columnIndex, 1, 1);
+
+    target.numberFormat = [["@"]];
+    target.values = [[nextText]];
   }
 
   await context.sync();


### PR DESCRIPTION
## What PR #24 fixed and why it was insufficient

PR #24 replaced a full-row bulk write with per-cell writes to avoid Office.js rejecting writes that overlap merged areas it doesn't fully cover. That resolved the bulk-write rejection, but the written cells were still wrong: each write still targeted the cell in the lower banner row at `selectedStartRowIndex - 1`.

## The actual target-cell issue

In the vertically merged banner repro, the lower banner row (row directly above the data) consists entirely of **merge continuation cells** - slaves of vertical merges whose top-left cells are in the upper banner row. When Office.js loads `text` on a range containing continuation cells, it returns empty string for those positions. When code writes to a continuation cell, Office.js silently discards the write; only the top-left cell of a merged area is writable.

So PR #24's per-cell write still silently failed for every column whose lower banner row cell was a continuation cell.

## Fix

Replace the write loop with a two-phase approach:

**Phase 1** - for each cell that needs a write, call `getMergedAreasOrNullObject()` and batch-load `["isNullObject", "rowIndex", "columnIndex"]`, then `context.sync()`.

**Phase 2** - for each queued write: if the cell is part of a merge (`!mergedArea.isNullObject`), redirect the write to `getRangeByIndexes(mergedArea.rowIndex, mergedArea.columnIndex, 1, 1)` - the actual top-left of the merged area. Otherwise write to the cell directly.

This uses the same `getMergedAreasOrNullObject()` pattern already established in `getCellMergeDiagnosticInfo` in this file.

## Scope

Single function in `src/taskpane/taskpane.js`: `writeBannerMarkersAboveSelectedRangeUsingBannerStructure`. No changes to:
- significance calculation
- banner detection
- metric detection
- excel-writer
- data-cell result writing
- non-banner-structure banner writing

## Validation

- `npm run build` - 0 errors, 2 pre-existing size warnings unchanged.
- Only `src/taskpane/taskpane.js` changed.

## Manual smoke notes

| Scenario | Expected |
|---|---|
| Vertically merged banner repro | Banner letters written to top-left cells of merged areas; data markers unchanged |
| Standard two-level banner (no merges) | `mergedArea.isNullObject` is true for all cells ? behaviour identical to before |
| One-level / no-banner-structure path | Out of scope; not touched |
| Data cell output | Unchanged |

## Limitations / follow-up

- `getMergedAreasOrNullObject()` returns `RangeAreas` in ExcelApi 1.9+; loading `rowIndex`/`columnIndex` directly on it follows the same pattern as the existing diagnostic helper in this file. If the runtime does not expose those properties on `RangeAreas`, the write will fall back to the original cell (same behaviour as PR #24). A follow-up could replace this with the `areas.getItemAt(0)` approach for stricter compliance.
- Merges spanning more than one column are handled correctly: `mergedArea.columnIndex` is the leftmost column of the merge.