### PR TITLE
Fix banner-letter placement for multi-row banner labels

### DIFF
--- a/src/taskpane/taskpane.js
+++ b/src/taskpane/taskpane.js
@@ -1485,6 +1485,8 @@ async function writeBannerMarkersAboveSelectedRangeUsingBannerStructure(
   bannerStructure,
   calculationSettings
 ) {
+  const BANNER_UPPER_SCAN_LIMIT = 5;
+
   selectedRange.load(["rowIndex", "columnIndex", "columnCount"]);
 
   await context.sync();
@@ -1529,6 +1531,32 @@ async function writeBannerMarkersAboveSelectedRangeUsingBannerStructure(
     nextBannerTexts.push(appendOrReplaceTrailingBannerMarker(currentText, label));
   }
 
+  // When a lower banner cell is blank but carries a label, the visible banner
+  // header lives in a row above (multi-row banner layout). Load upper rows so
+  // we can redirect the marker write to the nearest non-empty cell above.
+  const upperScanRowCount = Math.min(BANNER_UPPER_SCAN_LIMIT, selectedStartRowIndex - 1);
+  const needsUpperScan =
+    upperScanRowCount > 0 &&
+    currentBannerTexts.some((text, i) => (text || "") === "" && labelMap.has(i));
+
+  let upperScanTexts = [];
+
+  if (needsUpperScan) {
+    const upperScanRange = selectedRange.worksheet.getRangeByIndexes(
+      selectedStartRowIndex - 1 - upperScanRowCount,
+      selectedStartColumnIndex,
+      upperScanRowCount,
+      selectedColumnCount
+    );
+
+    upperScanRange.load("text");
+
+    await context.sync();
+
+    // Reverse so index 0 = row immediately above the lower banner row.
+    upperScanTexts = upperScanRange.text.slice().reverse();
+  }
+
   const cellWriteQueue = [];
 
   for (let columnIndex = 0; columnIndex < selectedColumnCount; columnIndex++) {
@@ -1539,27 +1567,52 @@ async function writeBannerMarkersAboveSelectedRangeUsingBannerStructure(
       continue;
     }
 
-    const cell = selectedRange.worksheet.getRangeByIndexes(
-      selectedStartRowIndex - 1,
-      selectedStartColumnIndex + columnIndex,
-      1,
-      1
-    );
-    const mergedArea = cell.getMergedAreasOrNullObject();
+    // Lower banner cell is blank but this column has a label: find the nearest
+    // non-empty cell above and write the marker there instead.
+    if (currentText === "" && labelMap.get(columnIndex)) {
+      const label = labelMap.get(columnIndex);
+      let queued = false;
 
-    mergedArea.load(["isNullObject", "rowIndex", "columnIndex"]);
-    cellWriteQueue.push({ nextText, cell, mergedArea });
+      for (let rowOffset = 0; rowOffset < upperScanTexts.length; rowOffset++) {
+        const upperCellText =
+          (upperScanTexts[rowOffset] && upperScanTexts[rowOffset][columnIndex]) || "";
+
+        if (upperCellText !== "") {
+          cellWriteQueue.push({
+            rowIndex: selectedStartRowIndex - 2 - rowOffset,
+            colIndex: selectedStartColumnIndex + columnIndex,
+            text: appendOrReplaceTrailingBannerMarker(upperCellText, label),
+          });
+          queued = true;
+          break;
+        }
+      }
+
+      if (!queued) {
+        // No non-empty cell found above; fall back to the lower banner row.
+        cellWriteQueue.push({
+          rowIndex: selectedStartRowIndex - 1,
+          colIndex: selectedStartColumnIndex + columnIndex,
+          text: nextText,
+        });
+      }
+
+      continue;
+    }
+
+    // Normal case: lower banner cell is non-empty; write in place.
+    cellWriteQueue.push({
+      rowIndex: selectedStartRowIndex - 1,
+      colIndex: selectedStartColumnIndex + columnIndex,
+      text: nextText,
+    });
   }
 
-  await context.sync();
+  for (const { rowIndex, colIndex, text } of cellWriteQueue) {
+    const cell = selectedRange.worksheet.getRangeByIndexes(rowIndex, colIndex, 1, 1);
 
-  for (const { nextText, cell, mergedArea } of cellWriteQueue) {
-    const target = mergedArea.isNullObject
-      ? cell
-      : selectedRange.worksheet.getRangeByIndexes(mergedArea.rowIndex, mergedArea.columnIndex, 1, 1);
-
-    target.numberFormat = [["@"]];
-    target.values = [[nextText]];
+    cell.numberFormat = [["@"]];
+    cell.values = [[text]];
   }
 
   await context.sync();


### PR DESCRIPTION
## What diagnostics showed (PR #26)

`
labelMap size: 4
currentBannerTexts: ["", "", "2025Q4 (a)", "2026Q1 (b)"]
nextBannerTexts:    ["(a)", "(b)", "2025Q4 (a)", "2026Q1 (b)"]
isMerged=false
final context.sync() succeeded
`

Writes for columns 0 and 1 were succeeding - but targeting genuinely blank cells in the lower banner row. The visible labels "2025Q4" and "2026Q1" live one row higher (the header above the lower banner row in a multi-row banner layout). The writer was writing bare `"(a)"` / `"(b)"` into invisible blank cells instead of appending to the visible labels.

Additionally, the merge-detection redirect introduced in PR #25 (`getMergedAreasOrNullObject`) never fired (`isMerged=false` for all cells), confirming the cells are not merged - just blank.

## Fix

When a lower banner row cell is blank but its column has a label to write, the function now:

1. Loads up to `BANNER_UPPER_SCAN_LIMIT` (5) rows above the lower banner row.
2. Scans those rows from bottom to top (nearest-first) looking for a non-empty cell in that column.
3. If found: calls `appendOrReplaceTrailingBannerMarker(foundText, label)` and writes the result to that upper cell.
4. If not found: falls back to writing the bare marker into the lower banner row (same as before).

For columns where the lower banner cell is already non-empty, behavior is unchanged.

The now-unnecessary merge-detection code from PR #25 is removed; the upper-scan sync is conditional (only fires when at least one blank-labeled column exists).

## Scope

- `src/taskpane/taskpane.js` only - `writeBannerMarkersAboveSelectedRangeUsingBannerStructure`.
- No changes to significance calculation, banner detection, metric detection, or data-cell writing.
- Diagnostic code from PR #26 removed.

## Validation

- `npm run build` - 0 errors, 2 pre-existing size warnings unchanged.
- Only `src/taskpane/taskpane.js` changed.

## Manual smoke notes

| Scenario | Expected |
|---|---|
| Vertically merged / multi-row banner repro (cols 0,1 blank lower row) | Markers appended to "2025Q4" / "2026Q1" in the upper row: "2025Q4 (a)", "2026Q1 (b)" |
| Standard two-level banner (non-empty lower row) | `needsUpperScan=false`; no extra sync; behaviour identical to pre-PR #24 |
| Data-cell markers / fills | Unchanged |

## Assumptions / limitations

- The upper scan reads the full selected column width for up to 5 rows; this matches the existing `maxBannerScanRows = 5` used elsewhere in banner detection.
- If multiple upper rows are non-empty in the same column, the nearest one wins (correct for most layouts).
- If the banner structure uses more than 5 rows above the data, the constant can be raised in a follow-up.