### PR TITLE
Preserve numeric values for unmarked output cells

### DIFF
--- a/src/core/excel-writer.js
+++ b/src/core/excel-writer.js
@@ -44,8 +44,18 @@ export function writeCellResultsToSelectedRange(
           : "";
 
       if (!cellResult) {
-        valueRow.push(currentText);
-        numberFormatRow.push("@");
+        const parsedCurrent = parseOutputNumber(currentText);
+
+        if (parsedCurrent !== null) {
+          valueRow.push(
+            parsedCurrent.hasPercentSign ? parsedCurrent.numericValue / 100 : parsedCurrent.numericValue
+          );
+          numberFormatRow.push(getNumberFormatForRowType(rowTypeByIndex.get(rowIndex), calculationSettings));
+        } else {
+          valueRow.push(currentText);
+          numberFormatRow.push("@");
+        }
+
         boldRow.push(false);
         fillReasonRow.push("none");
         continue;
@@ -70,8 +80,22 @@ export function writeCellResultsToSelectedRange(
         ? `${roundedDisplayedValue} ${outputMarkerText}`.trim()
         : roundedDisplayedValue;
 
-      valueRow.push(nextValue);
-      numberFormatRow.push("@");
+      if (outputMarkerText) {
+        valueRow.push(nextValue);
+        numberFormatRow.push("@");
+      } else {
+        const parsedRounded = parseOutputNumber(roundedDisplayedValue);
+
+        if (parsedRounded !== null) {
+          valueRow.push(
+            parsedRounded.hasPercentSign ? parsedRounded.numericValue / 100 : parsedRounded.numericValue
+          );
+          numberFormatRow.push(getNumberFormatForRowType(rowTypeByIndex.get(rowIndex), calculationSettings));
+        } else {
+          valueRow.push(roundedDisplayedValue);
+          numberFormatRow.push("@");
+        }
+      }
 
       boldRow.push(
         Boolean(
@@ -232,6 +256,30 @@ function getDecimalPlacesForRowType(rowType, calculationSettings) {
   }
 
   return null;
+}
+
+/**
+ * Returns an Excel number format string for a given row type.
+ *
+ * PURPOSE:
+ * Unmarked output cells should be written as numeric values rather than text.
+ * This helper provides the appropriate display format so the visible output
+ * matches what formatDisplayedValueForOutput would have shown as a string.
+ */
+function getNumberFormatForRowType(rowType, calculationSettings) {
+  const shouldRound = calculationSettings && calculationSettings.roundCellValues;
+
+  const shareLikeTypes = ["proportion", "nps", "promoters", "detractors"];
+
+  if (shareLikeTypes.includes(rowType)) {
+    return shouldRound ? "0%" : "0.0%";
+  }
+
+  if (rowType === "mean" || rowType === "standardDeviation" || rowType === "variance") {
+    return shouldRound ? "0.0" : "0.00";
+  }
+
+  return "General";
 }
 
 function applyGroupedBoldFormatting(selectedRange, boldMask) {


### PR DESCRIPTION
## Diagnosis

`writeCellResultsToSelectedRange` in `excel-writer.js` applied `numberFormat = "@"` (Excel text format) and string values to **every** cell in the selected range - unconditionally. Only cells that receive an appended significance marker (e.g. `"21.3% b"`) actually require text format; a mixed string cannot be stored as an Excel number. All other cells - base rows, total rows, unmarked proportion and mean cells, small-base skipped cells - were being stored as text unnecessarily, triggering Excel's "numbers stored as text" warning across the entire processed range.

## Product rule applied

| Cell type | Value written | Format |
|---|---|---|
| Has appended marker (`"21.3% b"`) | Text string as-is | `"@"` |
| No marker, numeric (e.g. proportion, mean, base) | Parsed numeric value | Row-type format (`"0.0%"`, `"0.00"`, `"General"`) |
| No marker, non-numeric (text label, empty) | Text string as-is | `"@"` |

## Implementation

### New private helper: `getNumberFormatForRowType`

Returns the Excel format string matching the row type and `roundCellValues` setting:
- proportion / nps / promoters / detractors: `"0.0%"` (or `"0%"` if rounded)
- mean / standardDeviation / variance: `"0.00"` (or `"0.0"` if rounded)
- all other row types (base, total, unknown): `"General"`

This mirrors the decimal-place logic already in `getDecimalPlacesForRowType`.

### Changed in the build loop

**`!cellResult` branch** (cells not participating in any comparison - base rows, ignored rows, etc.):
`parseOutputNumber(currentText)` - if parseable, write the numeric value with row-type format; if not, write the text string with `"@"`.

**`cellResult` branch, no marker** (cells participating in comparisons but not significantly different):
`parseOutputNumber(roundedDisplayedValue)` - same logic. For percentage values (`hasPercentSign`), divides by 100 to recover the Excel-stored decimal (`"21.3%"` ? `0.213`).

**`cellResult` branch, has marker** (significantly different cells):
Unchanged - text string with `"@"`.

No parameters added to `writeCellResultsToSelectedRange`. No changes outside `excel-writer.js`.

## Scope

- `src/core/excel-writer.js` only.
- No changes to marker generation, fill logic, significance calculation, banner detection, or taskpane.

## Validation

- `npm run build` - 0 errors, 2 pre-existing size warnings unchanged.
- Only `src/core/excel-writer.js` changed.

## Manual smoke notes

| Scenario | Expected |
|---|---|
| Proportion cell WITH marker (`"21.3% b"`) | Stored as text, format `"@"` - unchanged |
| Proportion cell WITHOUT marker | Stored as `0.213`, format `"0.0%"`, displays `"21.3%"`, no warning |
| Mean WITHOUT marker | Stored as numeric with `"0.00"` format, no warning |
| Base row | Stored as integer with `"General"` format, no warning |
| Total excluded from comparisons | Stored as number, no warning |
| Small-base skipped cell (fill only) | Numeric with fill color intact |
| Re-run (cells already text from prior RIT run) | `"21.3%"` parsed back to `0.213`, stored numeric |
| Clear significance | Markers removed, cells restored to numeric - natural improvement |
| Empty cells | Text empty string with `"@"` - no change |
| Non-numeric text labels | Not parseable ? remain text with `"@"` |

## Known limitations

- **Thousands-separated means** (e.g. `"1,234.56"`): `parseOutputNumber` replaces only the first comma with a period, so `"1,234.56"` yields NaN and falls back to the previous text-write behaviour. These cells will still show the warning. A follow-up can extend `parseOutputNumber` to strip thousands separators before parsing.
- **Custom user formats lost after first run**: once a cell has been written with `"0.0%"` (by this fix), subsequent re-runs apply the same row-type format. The user's original format (e.g. `"#,##0.0%"`) is not recovered. This is a pre-existing limitation of the writer's approach.