### PR TITLE
Preserve numeric output display conventions

### DIFF
--- a/src/core/excel-writer.js
+++ b/src/core/excel-writer.js
@@ -44,13 +44,11 @@ export function writeCellResultsToSelectedRange(
           : "";
 
       if (!cellResult) {
-        const parsedCurrent = parseOutputNumber(currentText);
+        const resolvedCurrent = resolveNumericOutput(currentText);
 
-        if (parsedCurrent !== null) {
-          valueRow.push(
-            parsedCurrent.hasPercentSign ? parsedCurrent.numericValue / 100 : parsedCurrent.numericValue
-          );
-          numberFormatRow.push(getNumberFormatForRowType(rowTypeByIndex.get(rowIndex), calculationSettings));
+        if (resolvedCurrent !== null) {
+          valueRow.push(resolvedCurrent.value);
+          numberFormatRow.push(resolvedCurrent.format);
         } else {
           valueRow.push(currentText);
           numberFormatRow.push("@");
@@ -84,13 +82,11 @@ export function writeCellResultsToSelectedRange(
         valueRow.push(nextValue);
         numberFormatRow.push("@");
       } else {
-        const parsedRounded = parseOutputNumber(roundedDisplayedValue);
+        const resolvedRounded = resolveNumericOutput(roundedDisplayedValue);
 
-        if (parsedRounded !== null) {
-          valueRow.push(
-            parsedRounded.hasPercentSign ? parsedRounded.numericValue / 100 : parsedRounded.numericValue
-          );
-          numberFormatRow.push(getNumberFormatForRowType(rowTypeByIndex.get(rowIndex), calculationSettings));
+        if (resolvedRounded !== null) {
+          valueRow.push(resolvedRounded.value);
+          numberFormatRow.push(resolvedRounded.format);
         } else {
           valueRow.push(roundedDisplayedValue);
           numberFormatRow.push("@");
@@ -259,27 +255,40 @@ function getDecimalPlacesForRowType(rowType, calculationSettings) {
 }
 
 /**
- * Returns an Excel number format string for a given row type.
+ * Resolves numeric value and Excel format for an unmarked output cell.
  *
  * PURPOSE:
- * Unmarked output cells should be written as numeric values rather than text.
- * This helper provides the appropriate display format so the visible output
- * matches what formatDisplayedValueForOutput would have shown as a string.
+ * Unmarked cells should be written as numeric Excel values to avoid
+ * "number stored as text" warnings. The format is derived from the display
+ * string itself so the visible convention is preserved exactly:
+ * - strings with "%" use percent format and divide by 100 for Excel storage;
+ * - strings without "%" use a plain decimal format matching the string's precision;
+ * - integers use "General";
+ * - non-numeric strings (labels, empty) return null → caller falls back to text.
+ *
+ * This ensures "28%" stays "28%" and "0.281" stays "0.281" regardless of row type.
  */
-function getNumberFormatForRowType(rowType, calculationSettings) {
-  const shouldRound = calculationSettings && calculationSettings.roundCellValues;
+function resolveNumericOutput(displayString) {
+  const parsed = parseOutputNumber(displayString);
 
-  const shareLikeTypes = ["proportion", "nps", "promoters", "detractors"];
-
-  if (shareLikeTypes.includes(rowType)) {
-    return shouldRound ? "0%" : "0.0%";
+  if (parsed === null) {
+    return null;
   }
 
-  if (rowType === "mean" || rowType === "standardDeviation" || rowType === "variance") {
-    return shouldRound ? "0.0" : "0.00";
+  const cleanText = String(displayString).trim().replace("%", "").trim();
+  const dotIndex = cleanText.indexOf(".");
+  const decimalPlaces = dotIndex >= 0 ? cleanText.length - dotIndex - 1 : 0;
+
+  if (parsed.hasPercentSign) {
+    const format = decimalPlaces === 0 ? "0%" : `0.${"0".repeat(decimalPlaces)}%`;
+    return { value: parsed.numericValue / 100, format };
   }
 
-  return "General";
+  if (decimalPlaces === 0) {
+    return { value: parsed.numericValue, format: "General" };
+  }
+
+  return { value: parsed.numericValue, format: `0.${"0".repeat(decimalPlaces)}` };
 }
 
 function applyGroupedBoldFormatting(selectedRange, boldMask) {


### PR DESCRIPTION
## What PR #29 did and why it caused a regression

PR #29 wrote unmarked cells as numeric Excel values (good - removes "number stored as text" warnings), but chose the format using `getNumberFormatForRowType`: proportion rows always got `"0.0%"` or `"0%"` regardless of whether the original display string used a percent sign. This forced `0.28` to display as `28%` and `28.1` to display as `28.1%`.

## Root cause

`getNumberFormatForRowType` used the **row type** to pick percent vs decimal format. Row type is not reliable for this choice: a proportion row can contain values in percent scale (`28%`), plain-100 scale (`28.1`), or decimal share scale (`0.281`). The decision must be based on what the cell actually shows, not on which calculation block owns it.

## Fix

Replace `getNumberFormatForRowType` with `resolveNumericOutput(displayString)`.

`resolveNumericOutput` derives both the numeric value and the Excel format directly from the output display string:

| Display string | Stored value | Format | Displays as |
|---|---|---|---|
| `"28%"` | `0.28` | `"0%"` | `28%` |
| `"28.1%"` | `0.281` | `"0.0%"` | `28.1%` |
| `"28.1"` | `28.1` | `"0.0"` | `28.1` |
| `"0.281"` | `0.281` | `"0.000"` | `0.281` |
| `"500"` | `500` | `"General"` | `500` |
| `""` / `"label"` | (text fallback) | `"@"` | unchanged |

Rules:
- String ends with `%` ? use percent format; divide by 100 for Excel storage.
- String has decimal places ? use `"0.000..."` format matching those decimal places.
- Integer string (no dot) ? use `"General"`.
- Non-numeric string ? return `null`; caller writes text with `"@"` (unchanged behaviour).

Marker-bearing cells (`outputMarkerText !== ""`) are unchanged: text + `"@"`.

Applied in both the `!cellResult` branch (using `currentText`) and the `cellResult` no-marker branch (using `roundedDisplayedValue`).

## Scope

- `src/core/excel-writer.js` only.
- No changes to marker generation, fill logic, significance calculation, banner detection, or taskpane.

## Validation

- `npm run build` - 0 errors, 2 pre-existing size warnings unchanged.
- Only `src/core/excel-writer.js` changed.

## Manual smoke notes

| Scenario | Expected |
|---|---|
| `"28%"` without marker | Stored `0.28` with `"0%"` format, displays `28%` |
| `"28.1%"` without marker | Stored `0.281` with `"0.0%"` format, displays `28.1%` |
| `"28.1"` without marker | Stored `28.1` with `"0.0"` format, displays `28.1` |
| `"0.281"` without marker | Stored `0.281` with `"0.000"` format, displays `0.281` |
| `"28% b"` (marker) | Text string `"28% b"` with `"@"` format - unchanged |
| Base row (e.g. `"500"`) | Stored `500` with `"General"` format - no warning |
| Mean (e.g. `"1234.56"`) | Stored `1234.56` with `"0.00"` format - no warning |
| Re-run after prior RIT output | Display text reparsed correctly - no warning reintroduced |
| Empty / text-label cells | Remain text with `"@"` - unchanged |

## Known limitations

- **Thousands-separated values** (e.g. `"1,234.56"`): `parseOutputNumber` treats the first comma as a decimal separator; thousands-formatted means will not parse and will fall back to text write. Pre-existing limitation.