### PR TITLE
Restore numeric values when clearing significance

### DIFF
--- a/src/core/excel-writer.js
+++ b/src/core/excel-writer.js
@@ -268,7 +268,7 @@ function getDecimalPlacesForRowType(rowType, calculationSettings) {
  *
  * This ensures "28%" stays "28%" and "0.281" stays "0.281" regardless of row type.
  */
-function resolveNumericOutput(displayString) {
+export function resolveNumericOutput(displayString) {
   const parsed = parseOutputNumber(displayString);
 
   if (parsed === null) {

--- a/src/taskpane/taskpane.js
+++ b/src/taskpane/taskpane.js
@@ -15,6 +15,7 @@ import {
   compareNpsStructureBlockByRowIndexes,
   compareNpsSpreadBlockByRowIndexes,
   removeSignificanceMarkersFromMatrix,
+  removeSignificanceMarkersFromText,
   generateSignificanceLabels,
   buildBannerLocalSignificanceLabelMap,
 } from "../core/significance";
@@ -27,7 +28,7 @@ import {
   getAllowedMarkerRowIndexes,
 } from "../core/metric-detector";
 
-import { writeCellResultsToSelectedRange } from "../core/excel-writer";
+import { writeCellResultsToSelectedRange, resolveNumericOutput } from "../core/excel-writer";
 
 import { detectBannerStructure, formatBannerDetectionDiagnostics } from "../core/banner-detector";
 
@@ -588,24 +589,55 @@ function calculateBlockResults(cleanedValues, calculationBlock, calculationSetti
  */
 async function clearSignificanceFromSelection() {
   await Excel.run(async (context) => {
-    const selectedRange = context.workbook.getSelectedRange(); // Current selected Excel range.
+    const selectedRange = context.workbook.getSelectedRange();
 
-    selectedRange.load("values"); // Load current cell values.
+    selectedRange.load(["values", "numberFormat"]);
 
     await context.sync();
 
-    const selectedValues = selectedRange.values; // Current values, possibly with markers.
-    const cleanedValues = removeSignificanceMarkersFromMatrix(selectedValues); // Values without markers.
+    const selectedValues = selectedRange.values;
+    const selectedNumberFormats = selectedRange.numberFormat;
 
-    selectedRange.values = cleanedValues;
+    const nextValues = [];
+    const nextNumberFormats = [];
 
-    // Reset formatting applied by significance macro.
+    for (let rowIndex = 0; rowIndex < selectedValues.length; rowIndex++) {
+      const valueRow = [];
+      const formatRow = [];
+
+      for (let columnIndex = 0; columnIndex < selectedValues[rowIndex].length; columnIndex++) {
+        const rawValue = selectedValues[rowIndex][columnIndex];
+
+        if (typeof rawValue === "number") {
+          valueRow.push(rawValue);
+          formatRow.push(selectedNumberFormats[rowIndex][columnIndex]);
+          continue;
+        }
+
+        const cleanedText = removeSignificanceMarkersFromText(rawValue);
+        const resolved = resolveNumericOutput(cleanedText);
+
+        if (resolved !== null) {
+          valueRow.push(resolved.value);
+          formatRow.push(resolved.format);
+        } else {
+          valueRow.push(cleanedText);
+          formatRow.push("@");
+        }
+      }
+
+      nextValues.push(valueRow);
+      nextNumberFormats.push(formatRow);
+    }
+
+    selectedRange.numberFormat = nextNumberFormats;
+    selectedRange.values = nextValues;
+
     selectedRange.format.font.bold = false;
     selectedRange.format.fill.clear();
 
     await context.sync();
 
-    const outputElement = document.getElementById("significance-result");
     setStatusMessage("Significance markers removed.");
   });
 }


### PR DESCRIPTION
## Summary

- Export esolveNumericOutput from excel-writer.js so the clear path can share the same numeric-resolution logic as the write path.
- Rewrite clearSignificanceFromSelection in 	askpane.js:
  - Load both alues and 
umberFormat from the selection.
  - Preserve cells that are already numeric (pass-through value + existing format).
  - For text cells: strip significance markers, then call esolveNumericOutput; if numeric, write as number with derived format; otherwise write as text with "@".

## Test plan

- [ ] Run significance ? markers appear + cells bold/filled.
- [ ] Click Clear ? markers removed, bold/fill cleared, numeric cells remain numeric (no "number stored as text" warnings).
- [ ] Cells that were always text (labels, blanks) remain text.
- [ ] Proportion cells with percent display (28%) clear to 28% stored as numeric with  % format.
- [ ] Proportion cells with decimal display ( .28) clear to  .28 stored as numeric with  .00 format.
- [ ] Means/NPS cells clear correctly.
- [ ] Previously numeric cells (not marked) are not corrupted.

?? Generated with [Claude Code](https://claude.com/claude-code)