### PR TITLE
Improve taskpane layout and move primary actions up

### DIFF
--- a/src/taskpane/taskpane.css
+++ b/src/taskpane/taskpane.css
@@ -37,8 +37,8 @@ b {
 .settings-panel {
   width: 100%;
   box-sizing: border-box;
-  margin-bottom: 16px;
-  padding: 12px;
+  margin-bottom: 0;
+  padding: 10px 12px;
   border: 1px solid #ddd;
   border-radius: 8px;
   background: #fafafa;
@@ -53,7 +53,7 @@ b {
 }
 
 .settings-group {
-  margin-bottom: 12px;
+  margin-bottom: 10px;
 }
 
 .settings-group label {
@@ -270,8 +270,8 @@ b {
 .action-panel {
   width: 100%;
   box-sizing: border-box;
-  margin-top: 12px;
-  padding: 12px;
+  margin: 0 0 12px 0;
+  padding: 10px 12px;
   border: 1px solid #ddd;
   border-radius: 8px;
   background: #fff;

--- a/src/taskpane/taskpane.html
+++ b/src/taskpane/taskpane.html
@@ -26,6 +26,24 @@
 
   <body class="ms-font-m ms-welcome ms-Fabric">
     <main id="app-body" class="ms-welcome__main" style="display: none">
+      <section class="action-panel">
+        <div class="action-panel-header">
+          <h3>Расчёт значимости</h3>
+        </div>
+
+        <div class="action-buttons-row">
+          <button id="calculate-significance" class="primary-action-button">Запустить</button>
+          <button id="clear-significance" class="secondary-action-button">
+            Очистить значимости
+          </button>
+        </div>
+
+        <section id="status-panel" class="status-panel" style="display: none">
+          <h4>Статус</h4>
+          <pre id="significance-result"></pre>
+        </section>
+      </section>
+
       <section class="settings-panel">
         <button type="button" id="settings-toggle" class="settings-toggle">
           <span>Настройки</span>
@@ -179,24 +197,6 @@
             >Справка об использовании</a
           >
         </div>
-      </section>
-
-      <section class="action-panel">
-        <div class="action-panel-header">
-          <h3>Расчёт значимости</h3>
-        </div>
-
-        <div class="action-buttons-row">
-          <button id="calculate-significance" class="primary-action-button">Запустить</button>
-          <button id="clear-significance" class="secondary-action-button">
-            Очистить значимости
-          </button>
-        </div>
-
-        <section id="status-panel" class="status-panel" style="display: none">
-          <h4>Статус</h4>
-          <pre id="significance-result"></pre>
-        </section>
       </section>
     </main>
   </body>


### PR DESCRIPTION
## Summary
- Move the existing Run / Clear action panel above taskpane settings.
- Keep existing button IDs and event binding behavior unchanged.
- Slightly tighten panel and settings-group spacing for a denser taskpane layout.

Closes #33

## Validation
- `npm.cmd run build` passes. (`npm run build` is blocked by the local PowerShell execution policy for `npm.ps1`.)
- Confirmed no `src/core` files changed.

## Manual smoke notes
- Run significance button still works.
- Clear significance button still works.
- Settings are still read correctly.
- Banner settings still work.
- Small-base setting still works.

## Broader smoke checklist
- basic proportions
- Total
- local Total banner
- global Total banner
- previous-column
- wave auto off/on
- small bases
- means/NPS