### PR TITLE
Add warning-only selected range guardrails

### DIFF
--- a/src/taskpane/taskpane.js
+++ b/src/taskpane/taskpane.js
@@ -42,6 +42,9 @@ const USER_VISIBLE_BANNER_MESSAGE_CODES = new Set([
   "BANNER_NO_ROWS_ABOVE_SELECTION",
 ]);
 
+const SELECTED_RANGE_GUARDRAIL_WARNING_TEXT =
+  "Похоже, вы выделили лейблы строк или шапку вместе с данными. Сейчас RIT ожидает выделение только числовой части таблицы.";
+
 function formatBannerUserMessages(bannerStructure) {
   if (!bannerStructure || !bannerStructure.messages) {
     return "";
@@ -60,6 +63,34 @@ function formatBannerUserMessages(bannerStructure) {
   }
 
   return ["Сообщения:", ...visibleMessages.map((message) => `- ${message.text}`)].join("\n");
+}
+
+function formatSelectedRangeGuardrailMessages(warnings) {
+  if (!warnings || warnings.length === 0) {
+    return "";
+  }
+
+  const uniqueTexts = Array.from(new Set(warnings.map((warning) => warning.text).filter(Boolean)));
+
+  if (uniqueTexts.length === 1) {
+    return uniqueTexts[0];
+  }
+
+  return ["Предупреждения:", ...uniqueTexts.map((text) => `- ${text}`)].join("\n");
+}
+
+function appendSelectedRangeGuardrailMessages(statusMessages, warnings) {
+  const guardrailMessage = formatSelectedRangeGuardrailMessages(warnings);
+
+  if (!guardrailMessage) {
+    return statusMessages;
+  }
+
+  return [...statusMessages, "", guardrailMessage];
+}
+
+function formatStatusWithSelectedRangeGuardrails(message, warnings) {
+  return appendSelectedRangeGuardrailMessages([message], warnings).join("\n");
 }
 
 function formatBannerUserMessagesExcludingCodes(bannerStructure, excludedCodes = []) {
@@ -294,6 +325,205 @@ Office.onReady((info) => {
 });
 
 /**
+ * Detects high-confidence signs that labels or header rows were included in the data range.
+ */
+function detectSelectedRangeGuardrails(selectedText, cleanedValues) {
+  const values = Array.isArray(cleanedValues) ? cleanedValues : [];
+  const rowCount = values.length;
+  const columnCount = rowCount > 0 && Array.isArray(values[0]) ? values[0].length : 0;
+
+  if (rowCount < 2 || columnCount < 2) {
+    return [];
+  }
+
+  const warnings = [];
+  const allCells = getSelectedRangeCells(selectedText, values, 0, 0, rowCount, columnCount);
+  const allStats = analyzeSelectedRangeCells(allCells);
+
+  if (rowCount >= 3 && columnCount >= 3) {
+    const firstColumnStats = analyzeSelectedRangeCells(
+      getSelectedRangeCells(selectedText, values, 0, 0, rowCount, 1)
+    );
+    const rightSideStats = analyzeSelectedRangeCells(
+      getSelectedRangeCells(selectedText, values, 0, 1, rowCount, columnCount - 1)
+    );
+
+    if (
+      firstColumnStats.nonEmptyCount >= Math.max(2, Math.ceil(rowCount * 0.5)) &&
+      firstColumnStats.textRatio >= 0.7 &&
+      rightSideStats.nonEmptyCount >= Math.max(4, Math.ceil(rowCount * (columnCount - 1) * 0.5)) &&
+      rightSideStats.numericRatio >= 0.7
+    ) {
+      warnings.push({
+        code: "SELECTED_RANGE_LIKELY_LEFT_LABEL_COLUMN",
+        severity: "warning",
+        text: SELECTED_RANGE_GUARDRAIL_WARNING_TEXT,
+        rowIndex: null,
+        columnIndex: 0,
+        evidence: {
+          firstColumnTextRatio: roundGuardrailRatio(firstColumnStats.textRatio),
+          rightSideNumericRatio: roundGuardrailRatio(rightSideStats.numericRatio),
+          firstColumnTextCount: firstColumnStats.textCount,
+          rightSideNumericCount: rightSideStats.numericCount,
+        },
+      });
+    }
+
+    const firstRowStats = analyzeSelectedRangeCells(
+      getSelectedRangeCells(selectedText, values, 0, 0, 1, columnCount)
+    );
+    const lowerRowsStats = analyzeSelectedRangeCells(
+      getSelectedRangeCells(selectedText, values, 1, 0, rowCount - 1, columnCount)
+    );
+
+    if (
+      firstRowStats.nonEmptyCount >= Math.max(2, Math.ceil(columnCount * 0.5)) &&
+      firstRowStats.textRatio >= 0.6 &&
+      lowerRowsStats.nonEmptyCount >= Math.max(4, Math.ceil((rowCount - 1) * columnCount * 0.5)) &&
+      lowerRowsStats.numericRatio >= 0.7
+    ) {
+      warnings.push({
+        code: "SELECTED_RANGE_LIKELY_TOP_HEADER_ROW",
+        severity: "warning",
+        text: SELECTED_RANGE_GUARDRAIL_WARNING_TEXT,
+        rowIndex: 0,
+        columnIndex: null,
+        evidence: {
+          firstRowTextRatio: roundGuardrailRatio(firstRowStats.textRatio),
+          lowerRowsNumericRatio: roundGuardrailRatio(lowerRowsStats.numericRatio),
+          firstRowTextCount: firstRowStats.textCount,
+          lowerRowsNumericCount: lowerRowsStats.numericCount,
+        },
+      });
+    }
+  }
+
+  if (
+    warnings.length === 0 &&
+    allStats.totalCount >= 12 &&
+    allStats.textCount >= 4 &&
+    allStats.textRatio >= 0.25 &&
+    allStats.numericRatio >= 0.5
+  ) {
+    warnings.push({
+      code: "SELECTED_RANGE_TEXT_HEAVY",
+      severity: "warning",
+      text: SELECTED_RANGE_GUARDRAIL_WARNING_TEXT,
+      rowIndex: null,
+      columnIndex: null,
+      evidence: {
+        textRatio: roundGuardrailRatio(allStats.textRatio),
+        numericRatio: roundGuardrailRatio(allStats.numericRatio),
+        textCount: allStats.textCount,
+        numericCount: allStats.numericCount,
+      },
+    });
+  }
+
+  return warnings;
+}
+
+function getSelectedRangeCells(selectedText, values, startRow, startColumn, rowCount, columnCount) {
+  const cells = [];
+
+  for (let rowOffset = 0; rowOffset < rowCount; rowOffset++) {
+    const rowIndex = startRow + rowOffset;
+
+    for (let columnOffset = 0; columnOffset < columnCount; columnOffset++) {
+      const columnIndex = startColumn + columnOffset;
+
+      cells.push({
+        value: values && values[rowIndex] ? values[rowIndex][columnIndex] : undefined,
+        text: selectedText && selectedText[rowIndex] ? selectedText[rowIndex][columnIndex] : undefined,
+      });
+    }
+  }
+
+  return cells;
+}
+
+function analyzeSelectedRangeCells(cells) {
+  const stats = {
+    totalCount: cells.length,
+    nonEmptyCount: 0,
+    blankCount: 0,
+    numericCount: 0,
+    textCount: 0,
+    numericRatio: 0,
+    textRatio: 0,
+  };
+
+  for (const cell of cells) {
+    const cellValue = getGuardrailCellValue(cell);
+
+    if (isBlankLikeCellValue(cellValue)) {
+      stats.blankCount++;
+      continue;
+    }
+
+    stats.nonEmptyCount++;
+
+    if (isNumericLikeCellValue(cellValue)) {
+      stats.numericCount++;
+      continue;
+    }
+
+    if (isTextLikeCellValue(cellValue)) {
+      stats.textCount++;
+    }
+  }
+
+  if (stats.nonEmptyCount > 0) {
+    stats.numericRatio = stats.numericCount / stats.nonEmptyCount;
+    stats.textRatio = stats.textCount / stats.nonEmptyCount;
+  }
+
+  return stats;
+}
+
+function getGuardrailCellValue(cell) {
+  if (!cell) {
+    return "";
+  }
+
+  if (!isBlankLikeCellValue(cell.value)) {
+    return cell.value;
+  }
+
+  return cell.text;
+}
+
+function isBlankLikeCellValue(value) {
+  return value === null || value === undefined || String(value).trim() === "";
+}
+
+function isNumericLikeCellValue(value) {
+  if (isBlankLikeCellValue(value)) {
+    return false;
+  }
+
+  if (typeof value === "number") {
+    return Number.isFinite(value);
+  }
+
+  const normalizedValue = String(value)
+    .trim()
+    .replace(/\s/g, "")
+    .replace("%", "")
+    .replace(",", ".");
+
+  return normalizedValue !== "" && !Number.isNaN(Number(normalizedValue));
+}
+
+function isTextLikeCellValue(value) {
+  return !isBlankLikeCellValue(value) && !isNumericLikeCellValue(value);
+}
+
+function roundGuardrailRatio(value) {
+  return Math.round(value * 100) / 100;
+}
+
+/**
  * Reads selected Excel range, detects metric blocks, calculates pairwise significance,
  * and writes significance letters only into actual value rows.
  *
@@ -381,6 +611,7 @@ async function runSignificanceFromSelection() {
     }
 
     const cleanedValues = removeSignificanceMarkersFromMatrix(selectedValues);
+    const selectedRangeGuardrailWarnings = detectSelectedRangeGuardrails(selectedText, cleanedValues);
 
     selectedRange.values = cleanedValues;
 
@@ -402,7 +633,12 @@ async function runSignificanceFromSelection() {
     const calculationBlocks = buildCalculationBlocks(detectionResult); // List of metric blocks to calculate.
 
     if (!calculationBlocks || calculationBlocks.length === 0) {
-      setStatusMessage("Could not detect any calculation blocks.");
+      setStatusMessage(
+        formatStatusWithSelectedRangeGuardrails(
+          "Could not detect any calculation blocks.",
+          selectedRangeGuardrailWarnings
+        )
+      );
       return;
     }
 
@@ -443,7 +679,12 @@ async function runSignificanceFromSelection() {
       );
 
       if (smallBaseResult.errorMessage) {
-        setStatusMessage(smallBaseResult.errorMessage);
+        setStatusMessage(
+          formatStatusWithSelectedRangeGuardrails(
+            smallBaseResult.errorMessage,
+            selectedRangeGuardrailWarnings
+          )
+        );
         return;
       }
 
@@ -473,7 +714,11 @@ async function runSignificanceFromSelection() {
           statusMessages.push(bannerUserMessages);
         }
 
-        setStatusMessage(statusMessages.join("\n"));
+        setStatusMessage(
+          appendSelectedRangeGuardrailMessages(statusMessages, selectedRangeGuardrailWarnings).join(
+            "\n"
+          )
+        );
         return;
       }
 
@@ -524,7 +769,9 @@ async function runSignificanceFromSelection() {
       statusMessages.push(bannerUserMessages);
     }
 
-    setStatusMessage(statusMessages.join("\n"));
+    setStatusMessage(
+      appendSelectedRangeGuardrailMessages(statusMessages, selectedRangeGuardrailWarnings).join("\n")
+    );
   });
 }
 


### PR DESCRIPTION
## Summary
- Add local selected-range guardrail helpers in `src/taskpane/taskpane.js`.
- Detect high-confidence signs of included left label columns, top header/banner rows, and text-heavy selected ranges.
- Append user-facing warnings to existing status output.

Closes #36

## Warning-only behavior
- Does not block Run.
- Does not auto-trim or modify the selected range.
- Does not change metric detection, banner detection, calculation blocks, or writer behavior.
- Existing calculation output is preserved, with guardrail warnings appended when present.

## Scope
- Changed only `src/taskpane/taskpane.js`.
- No changes to core calculation, writer, banner detector, metric detector, table preview model, taskpane HTML/CSS, docs, package files, or assets.

## Validation
- `npm run build` is blocked locally by PowerShell execution policy for `npm.ps1`.
- `npm.cmd run build` passes with the existing webpack asset-size warnings.
- Confirmed only `src/taskpane/taskpane.js` changed.

## Manual smoke notes
- basic proportions still run;
- banner-aware run still works;
- previous-column mode still works;
- means/NPS still run;
- accidental left label column produces warning but still runs;
- accidental top header row produces warning but still runs;
- normal selected data range does not produce noisy warnings.

## Known false-positive risks
- NPS scale rows;
- text answer labels;
- empty spacer rows;
- multi-column row labels;
- small tables;
- tables with deliberately selected text columns;
- means/NPS tables with mixed row types.

The implementation uses conservative thresholds and remains warning-only to limit impact.