### PR TITLE
docs: update project documentation after stabilization release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 ## [Current Development Stage]
 
+### Stabilization Release
+
+#### Added
+- Warning-only selected range guardrails (temporary safety net).
+- Shared agent instructions added to `AGENTS.md` and referenced in `CLAUDE.md`.
+
+#### Improved
+- Numeric output preservation for unmarked cells (avoids converting the whole selected range to text).
+- Preservation of display conventions: `28` remains plain, `28%` remains percent, `0.28` remains decimal-share.
+- Clear significance numeric restoration (`21% b` clears to `21%`, `28.1 b` clears to `28.1`, `0.281 b` clears to `0.281`).
+- Run / Clear actions moved near the top of the taskpane.
+
+#### Fixed
+- Banner-aware comparisons now handle the first pair inside a multi-column group more correctly.
+- Multi-row / merged-like banner group detection was improved.
+- Banner letters are now written to visible banner labels when labels are located above the row directly adjacent to the data.
+
+#### Notes
+- Selected range normalization is not implemented yet.
+- Worksheet/workbook auto-scan is not implemented.
+- Full-table selection support is future product/spec work.
+
+
 ### 30.04.2026 — Banner-aware MVP and completed UI settings logic
 
 #### Added

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -5,6 +5,7 @@ Research Insights Toolkit is an Excel-first Office Add-in designed for research 
 
 ## Current Stable Workflow
 The current stable workflow relies on manual selected-range calculation. The user selects a table range manually in Excel and clicks "Run". The add-in then detects metrics, calculates significance, and writes markers directly into cells.
+Automatic worksheet/workbook scanning is still not implemented.
 
 ## High-Level Pipeline
 1. **Selection:** Read the user-selected table range from Excel.
@@ -13,17 +14,18 @@ The current stable workflow relies on manual selected-range calculation. The use
 4. **Output:** Write the calculated markers, letters, and formatting back to the Excel spreadsheet.
 
 ## Module Responsibilities
-- `src/taskpane/taskpane.js` — Excel/UI controller. Orchestrates the flow. No statistical calculations.
+- `src/taskpane/taskpane.js` — Excel/UI controller. Orchestrates the flow. No statistical calculations. Owns Office.js interaction and selected range reads.
 - `src/core/metric-detector.js` — Detects metric rows and constructs block plans.
 - `src/core/banner-detector.js` — Platform-independent banner structure detection.
 - `src/core/significance.js` — Statistical tests, comparison routing, marker creation, and fill reasons.
 - `src/core/stat-thresholds.js` — Determines statistical critical thresholds.
 - `src/core/config/dictionary.config.js` — Config-driven metric and banner dictionaries.
-- `src/core/excel-writer.js` — Handles writing values and formatting back to Excel.
+- `src/core/excel-writer.js` — Handles writing values and formatting back to Excel. Owns data-cell output behavior (including numeric output preservation).
+- Banner detection and banner-letter placement are separate concerns.
 
 ## Core vs Office.js Boundary
 - `src/taskpane/taskpane.js` interacts directly with Office.js to read from and write to Excel.
-- `src/core/*` modules (like `significance.js`, `metric-detector.js`, `banner-detector.js`) are pure JavaScript logic. They should not contain direct Office.js API calls or UI DOM access.
+- `src/core/*` modules (like `significance.js`, `metric-detector.js`, `banner-detector.js`) are pure JavaScript logic and should remain Office.js-free. They should not contain direct Office.js API calls or UI DOM access.
 - **Architectural Constraints:** No statistical calculations in `taskpane.js` (UI orchestration only). No Excel range writing in `significance.js`. No UI DOM access in core modules.
 
 ## High-Risk Files
@@ -37,6 +39,7 @@ Changes to these files require extra care:
 ## Manual Selected-Range Workflow Guardrails
 - **Do not break the manual selected-range workflow.** This is the core stable feature.
 - Ensure the selected range bounds are respected during reading and writing.
+- Selected range guardrails currently live in taskpane as a warning-only MVP. Future selected range normalization should be designed before implementation.
 
 ## Excel Writer Performance Guardrails
 - **Do not return `excel-writer.js` to per-cell writes.** Maintain block-level or optimized writes to avoid degrading Excel performance.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -24,7 +24,6 @@ Automatic worksheet/workbook scanning is still not implemented.
 - Banner detection and banner-letter placement are separate concerns.
 
 ## Core vs Office.js Boundary
-- `src/taskpane/taskpane.js` interacts directly with Office.js to read from and write to Excel.
 - `src/core/*` modules (like `significance.js`, `metric-detector.js`, `banner-detector.js`) are pure JavaScript logic and should remain Office.js-free. They should not contain direct Office.js API calls or UI DOM access.
 - **Architectural Constraints:** No statistical calculations in `taskpane.js` (UI orchestration only). No Excel range writing in `significance.js`. No UI DOM access in core modules.
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -2,6 +2,22 @@
 
 Рабочий roadmap проекта. Это не публичное обещание сроков, а список направлений развития от текущего MVP к более стабильному продукту.
 
+## Completed/stabilized
+- [x] read-only table preview model exists as a core model but is not yet wired into UI
+- [x] shared text normalization utilities exist
+- [x] banner-aware stabilization
+- [x] numeric output preservation
+- [x] Clear significance numeric restoration
+- [x] taskpane primary action layout improvement
+- [x] warning-only selected range guardrails
+
+## High-priority future/spec work
+- [ ] Design selected range normalization for full-table selections.
+- [ ] Decide whether and how to wire table preview UI.
+- [ ] Continue base placement product/spec work.
+- [ ] Multi-column row labels and weighted/effective bases remain discovery/spec first.
+- [ ] Custom modal dialogs remain separate and should not be mixed into selection normalization.
+
 ## Фаза 1: Очистка и стабильность (Текущий этап)
 - [ ] **Рефакторинг UI-слоя**: Выделение `ui-controller.js` для работы с DOM и настройками. Очистка `taskpane.js`.
 - [ ] **Кастомные диалоги**: Замена нестабильных `window.confirm/alert` на HTML-модальные окна для консистентной работы в Excel Desktop и Web.
@@ -21,3 +37,10 @@
 ## Фаза 4: Масштабирование
 - [ ] **Google Sheets Support**: Портирование платформонезависимого ядра на Google Apps Script.
 - [ ] **Облачное хранение настроек**: Синхронизация предпочтений пользователя (цвета, пороги) между разными книгами и устройствами.
+
+
+## Deferred
+- [ ] worksheet/workbook auto-scan
+- [ ] row-wise comparisons
+- [ ] weighted base calculation support
+- [ ] broad taskpane redesign

--- a/docs/TEST_CASES.md
+++ b/docs/TEST_CASES.md
@@ -1923,3 +1923,11 @@ Expected:
 - calculation stops;
 - status shows concise user-facing error;
 - no technical diagnostics dump.
+
+## Means + SD/Base
+## Means + variance/Base
+## NPS-first
+## extended NPS
+## Run → Clear significance
+## numeric output conventions: 28, 28%, 0.28
+## selected range guardrail warning-only behavior

--- a/docs/TEST_CASES.md
+++ b/docs/TEST_CASES.md
@@ -1925,9 +1925,36 @@ Expected:
 - no technical diagnostics dump.
 
 ## Means + SD/Base
+Setup: Table containing a Mean row and a Standard Deviation (SD) or Base row directly beneath it.
+Expected behavior: The Mean row receives significance markers or spread indicators based on calculations. The SD and Base rows receive no significance markers.
+Key regression risk: Markers accidentally appearing on the SD or Base rows instead of the Mean row.
+
 ## Means + variance/Base
+Setup: Table containing a Mean row and a Variance or Base row directly beneath it.
+Expected behavior: The Mean row receives significance markers or spread indicators based on calculations. The Variance and Base rows receive no significance markers.
+Key regression risk: Markers accidentally appearing on the Variance or Base rows.
+
 ## NPS-first
+Setup: Table with an NPS row followed immediately by Promoters, Detractors, and Base rows.
+Expected behavior: The NPS row receives specific NPS significance spread markers. Promoters and Detractors receive ordinary proportion markers. The Base row receives no markers.
+Key regression risk: The NPS row failing to receive markers, or Promoters/Detractors receiving the wrong marker type.
+
 ## extended NPS
+Setup: Table with an NPS row, alongside Scale rows, buckets, support rows, and a Base row.
+Expected behavior: Scale rows, buckets, and support rows receive ordinary proportion markers. The NPS row receives NPS significance markers. The Base row receives no markers.
+Key regression risk: Ordinary proportion markers incorrectly applying to the NPS row instead of the specific NPS markers.
+
 ## Run → Clear significance
+Setup: A table that has already been calculated (markers and fills exist). Select the range and click the clear significance button.
+Expected behavior: All significance markers (letters, arrows) and formatting (bolding, fills) are completely removed from the selected cells.
+Key regression risk: Leftover formatting or trailing marker artifacts (e.g. ` b`) remaining in cells.
+
 ## numeric output conventions: 28, 28%, 0.28
+Setup: A table containing values typed as plain numbers (28), formatted as percentages (28%), and formatted as decimals (0.28). Select the table and Run significance.
+Expected behavior: Unmarked cells perfectly preserve their original Excel numeric values and display formats. Marker-bearing cells maintain the visual numeric string convention before the appended letter (e.g., `28% b` instead of `0.28 b`).
+Key regression risk: The add-in converting the entire selected range (including unmarked cells) to text, or breaking percentage formatting into plain decimals.
+
 ## selected range guardrail warning-only behavior
+Setup: Manually select a range that inadvertently includes the table title, question text, or top header row (outside the numeric data area). Click Run.
+Expected behavior: The calculation proceeds normally based on the selection. A warning is displayed in the taskpane status output indicating that non-data rows may have been included, but the Run is not blocked or aborted. The selection is not automatically trimmed.
+Key regression risk: The guardrail warning blocking the calculation, or the add-in attempting to automatically resize the user's manual selection.


### PR DESCRIPTION
Updates project documentation to reflect the recent stabilization release.

**Files changed:**
- `CHANGELOG.md`
- `docs/ROADMAP.md`
- `docs/ARCHITECTURE.md`
- `docs/TEST_CASES.md`

**Summary of documentation updates:**
- **CHANGELOG.md:** Added a new `Stabilization Release` entry documenting banner-aware comparison fixes, numeric output preservation, Clear significance numeric restoration, taskpane UI layout improvements, and warning-only selected range guardrails. Explicitly noted that selected range normalization and auto-scan are not implemented.
- **ARCHITECTURE.md:** Clarified that the taskpane owns Office.js interaction/selection reads while `excel-writer.js` owns data-cell output behavior. Added notes about warning-only guardrails currently existing as an MVP.
- **ROADMAP.md:** Updated the Completed/Stabilized section with the stabilization release features. Added "Design selected range normalization for full-table selections" to High-priority future spec work. Added deferred items like auto-scan and row-wise comparisons.
- **TEST_CASES.md:** Appended placeholder headers to document smoke test coverage for features like Means + SD/Base, NPS-first, numeric output conventions, and warning-only guardrails.

**Assumptions / limitations:**
- Assumed placeholder `##` headers in `TEST_CASES.md` without full markdown tables are sufficient to indicate smoke test coverage notes per the request.
- The Russian user help page (`assets/rit-help-ru.html`) was explicitly excluded and not updated.

---
*PR created automatically by Jules for task [13086810878189093620](https://jules.google.com/task/13086810878189093620) started by @hedgef0g*