### PR TITLE
docs: Update validation artifacts for multi-column labels and weighted/effective bases

### DIFF
--- a/docs/GOLD_STANDARD_TEST_SUITE.md
+++ b/docs/GOLD_STANDARD_TEST_SUITE.md
@@ -656,9 +656,6 @@ A case is considered valid when:
                                      weighted / effective bases. Cases GST-067,
                                      GST-068, GST-069, and GST-072 depend on
                                      the behavior described in that spec.
-                                     Note: spec is on branch
-                                     chore/spec-issue-17-multi-col-and-weighted-bases
-                                     and is not yet merged to main.
 
 ---
 
@@ -675,9 +672,8 @@ A case is considered valid when:
   or BLOCKED-BY-SPEC. None can be marked COMPLETE until the relevant runtime feature
   reaches SUPPORTED status in STATUS.md.
 - Extended base priority cases (GST-067, GST-072) and multi-column label cases
-  (GST-068, GST-069) are FUTURE. All depend on docs/MULTI_COLUMN_LABELS_AND_WEIGHTED_BASES.md,
-  which is not yet merged. None can be marked COMPLETE until the runtime feature
-  reaches SUPPORTED status.
+  (GST-068, GST-069) are FUTURE. All depend on docs/MULTI_COLUMN_LABELS_AND_WEIGHTED_BASES.md.
+  None can be marked COMPLETE until the runtime feature reaches SUPPORTED status.
 - Count row cases (GST-100 to GST-103) are included as FUTURE or BLOCKED-BY-SPEC.
   GST-102 additionally requires a spec decision before expected output can be written.
 - Google Sheets and cloud settings are excluded as they are not implemented.

--- a/docs/GOLD_STANDARD_TEST_SUITE.md
+++ b/docs/GOLD_STANDARD_TEST_SUITE.md
@@ -379,7 +379,61 @@ ladder. Cases GST-060 and GST-061 cover edge conditions.
                            be specified and implemented before expected output can
                            be defined.
 
-### 4.8. Messy table cases
+    GST-067  Effective Base + Unweighted Base + Weighted Base all present in one
+             selection. Status: FUTURE.
+             Matrix ref: 4 (Effective Base, Unweighted Base, Weighted Base)
+             Spec ref: docs/MULTI_COLUMN_LABELS_AND_WEIGHTED_BASES.md
+             Covers: priority ladder is exercised end-to-end: Effective Base is
+                     selected as the denominator; Unweighted Base and Weighted Base
+                     rows are present but not used for calculation; markers are
+                     correct; no spurious warnings from the lower-priority rows.
+             Prerequisite: Effective Base keyword, detection, and the full base
+                           priority logic must be implemented before expected output
+                           can be defined.
+
+    GST-072  Small base on Effective Base column while the displayed Weighted Base
+             value for the same column is above the small-base threshold.
+             Status: FUTURE.
+             Matrix ref: 4 (Effective Base, Base row with small base)
+             Spec ref: docs/MULTI_COLUMN_LABELS_AND_WEIGHTED_BASES.md
+             Covers: small-base exclusion is driven by the priority-selected base
+                     (Effective Base in this case), not the displayed Weighted Base;
+                     the column is correctly excluded even though the Weighted Base
+                     value alone would not trigger exclusion.
+             Prerequisite: same as GST-067.
+
+### 4.8. Multi-column label cases
+
+Background: TABLE_STRUCTURE_MATRIX.md section 3.2 defines multi-column label support
+as FUTURE. Spec is in docs/MULTI_COLUMN_LABELS_AND_WEIGHTED_BASES.md. Cases GST-068
+and GST-069 cover label disambiguation and span-fill behavior. Both are FUTURE cases;
+no runtime support for multi-column labels exists yet.
+
+    GST-068  Multi-column label area disambiguates two blocks that share the same
+             primary label text "%". Status: FUTURE.
+             Matrix ref: 3.2 (Multi-column label area)
+             Spec ref: docs/MULTI_COLUMN_LABELS_AND_WEIGHTED_BASES.md
+             Covers: when the first label column contains "%" for two separate
+                     metric blocks, the second label column provides a disambiguating
+                     sub-label; the detector uses the combined label to assign the
+                     correct row type to each block; each block receives correct
+                     markers independently.
+             Prerequisite: multi-column label reading must be implemented and
+                           two-column label concatenation logic must be specified
+                           before expected output can be defined.
+
+    GST-069  Two-column label with span-fill on continuation rows.
+             Status: FUTURE.
+             Matrix ref: 3.2 (Multi-column label area)
+             Spec ref: docs/MULTI_COLUMN_LABELS_AND_WEIGHTED_BASES.md
+             Covers: a label block where the first label column has a value only on
+                     the first row and continuation rows are blank (span-fill
+                     pattern); the detector propagates the first-row label to
+                     continuation rows correctly; row-type assignment is correct
+                     for all rows in the span.
+             Prerequisite: same as GST-068.
+
+### 4.9. Messy table cases
 
     GST-070  Selection includes empty rows between blocks (PARTIAL).
              Matrix ref: 3.1 (Selection includes empty rows between blocks)
@@ -389,7 +443,7 @@ ladder. Cases GST-060 and GST-061 cover edge conditions.
              Matrix ref: 3.1 (Selection includes title / question text row)
              Covers: guardrail warning emitted; Run proceeds; selection not trimmed.
 
-### 4.9. Numeric output and display cases
+### 4.10. Numeric output and display cases
 
     GST-080  Plain numeric values (28), percent values (28%), decimal values (0.28)
              mixed in one table.
@@ -402,14 +456,14 @@ ladder. Cases GST-060 and GST-061 cover edge conditions.
              Covers: display decimal precision per metric type; calculations use
                      original values.
 
-### 4.10. Mixed block cases
+### 4.11. Mixed block cases
 
     GST-090  Table with Proportion + Mean + NPS blocks sharing one Base row.
              Matrix ref: 1.1, 1.2, 1.3 (mixed)
              Covers: all three block types detected and calculated correctly;
                      shared Base resolved; no markers on service rows.
 
-### 4.11. Count row cases
+### 4.12. Count row cases
 
 Background: TABLE_STRUCTURE_MATRIX.md section 5.1 defines count rows (n=,
 count-equivalent keywords) as a FUTURE metric type. Count rows are distinct from
@@ -597,6 +651,15 @@ A case is considered valid when:
                                      Cases GST-070 and GST-071 depend on the
                                      behavior described in that spec.
 
+    docs/MULTI_COLUMN_LABELS_AND_WEIGHTED_BASES.md
+                                     Spec for multi-column row labels and
+                                     weighted / effective bases. Cases GST-067,
+                                     GST-068, GST-069, and GST-072 depend on
+                                     the behavior described in that spec.
+                                     Note: spec is on branch
+                                     chore/spec-issue-17-multi-col-and-weighted-bases
+                                     and is not yet merged to main.
+
 ---
 
 ## 8. Known limitations of this plan
@@ -611,6 +674,10 @@ A case is considered valid when:
 - Base priority ladder cases (GST-062 to GST-066) are included as PLANNED, FUTURE,
   or BLOCKED-BY-SPEC. None can be marked COMPLETE until the relevant runtime feature
   reaches SUPPORTED status in STATUS.md.
+- Extended base priority cases (GST-067, GST-072) and multi-column label cases
+  (GST-068, GST-069) are FUTURE. All depend on docs/MULTI_COLUMN_LABELS_AND_WEIGHTED_BASES.md,
+  which is not yet merged. None can be marked COMPLETE until the runtime feature
+  reaches SUPPORTED status.
 - Count row cases (GST-100 to GST-103) are included as FUTURE or BLOCKED-BY-SPEC.
   GST-102 additionally requires a spec decision before expected output can be written.
 - Google Sheets and cloud settings are excluded as they are not implemented.

--- a/docs/TABLE_STRUCTURE_MATRIX.md
+++ b/docs/TABLE_STRUCTURE_MATRIX.md
@@ -119,7 +119,7 @@
 | Single label column immediately left of selection | SUPPORTED | Default behavior. | -- |
 | Labels separated from data by numeric columns | SUPPORTED | Detector skips numeric intermediate columns when searching for text labels. | -- |
 | Labels in leftmost sheet columns (labels-on-left-side mode) | SUPPORTED | Enabled via labels-on-left-side setting; reads labels from left edge of sheet. | -- |
-| Multi-column label area (spanning two text columns) | UNSUPPORTED | Only one label column is read. Second label column is ignored. | FUTURE: multi-column label support. Spec: docs/MULTI_COLUMN_LABELS_AND_WEIGHTED_BASES.md (unmerged). GST coverage: GST-068, GST-069. |
+| Multi-column label area (spanning two text columns) | UNSUPPORTED | Only one label column is read. Second label column is ignored. | FUTURE: multi-column label support. Spec: docs/MULTI_COLUMN_LABELS_AND_WEIGHTED_BASES.md. GST coverage: GST-068, GST-069. |
 | No label column anywhere | PARTIAL | Detector proceeds without row-type keywords; may fall back to heuristics or misidentify rows. | Metric detection accuracy degrades. Ensure labels are present. |
 
 ### 3.3. Adjacent Tables
@@ -134,13 +134,13 @@
 
 ## 4. Base Structures
 
-Planned base priority order (not fully implemented yet): Effective Base > Unweighted Base > plain Base > Weighted Base fallback with warning. Effective Base and Weighted Base support are core correctness features, not premium or deferred features. Full spec: docs/MULTI_COLUMN_LABELS_AND_WEIGHTED_BASES.md (unmerged, branch chore/spec-issue-17-multi-col-and-weighted-bases). GST coverage: GST-062 to GST-067, GST-072.
+Planned base priority order (not fully implemented yet): Effective Base > Unweighted Base > plain Base > Weighted Base fallback with warning. Effective Base and Weighted Base support are core correctness features, not premium or deferred features. Full spec: docs/MULTI_COLUMN_LABELS_AND_WEIGHTED_BASES.md. GST coverage: GST-062 to GST-067, GST-072.
 
 | Structure | Status | Current behavior | Risk / notes |
 |---|---|---|---|
 | Unweighted Base (plain integer counts) | SUPPORTED | Standard behavior. | -- |
-| Weighted Base (non-integer, e.g. 487.3) | PARTIAL | No explicit weighted-base path. Value is used as-is in z-test denominator. Statistical validity depends on weighting method used by the researcher. | FUTURE: weighted base support planned. Intended role: fallback with warning when no Effective Base is present. Spec: docs/MULTI_COLUMN_LABELS_AND_WEIGHTED_BASES.md (unmerged). GST: GST-062, GST-063, GST-066. |
-| Effective Base | FUTURE | No dedicated effective-base row keyword or logic yet. | Core correctness feature. Planned MVP-core support. Intended as the highest-priority base type. Spec: docs/MULTI_COLUMN_LABELS_AND_WEIGHTED_BASES.md (unmerged). GST: GST-064, GST-067, GST-072. |
+| Weighted Base (non-integer, e.g. 487.3) | PARTIAL | No explicit weighted-base path. Value is used as-is in z-test denominator. Statistical validity depends on weighting method used by the researcher. | FUTURE: weighted base support planned. Intended role: fallback with warning when no Effective Base is present. Spec: docs/MULTI_COLUMN_LABELS_AND_WEIGHTED_BASES.md. GST: GST-062, GST-063, GST-066. |
+| Effective Base | FUTURE | No dedicated effective-base row keyword or logic yet. | Core correctness feature. Planned MVP-core support. Intended as the highest-priority base type. Spec: docs/MULTI_COLUMN_LABELS_AND_WEIGHTED_BASES.md. GST: GST-064, GST-067, GST-072. |
 | Shared Base (one Base row for multiple metric rows above) | SUPPORTED | Detector resolves shared Base correctly. | -- |
 | Missing Base row | UNSUPPORTED | Block cannot be formed. Calculation skipped for that block. | Always include a Base row per block or as shared Base. |
 | Base row with small base (below threshold) | SUPPORTED | Column excluded from comparisons; small-base fill applied across block; Total small-base stops calculation with message. | -- |
@@ -241,6 +241,6 @@ Planned base priority order (not fully implemented yet): Effective Base > Unweig
 - **Total outside selection** is partially designed but may need edge-case hardening.
 - **Check-table / data quality validation** mode is specified in docs/table-preview-model.md but not yet implemented.
 - **Selected range normalization** spec is in docs/SELECTED_RANGE_NORMALIZATION.md; implementation not started.
-- **Effective Base and Weighted Base** support are core correctness features. Planned base priority: Effective > Unweighted > plain Base > Weighted with warning. Full spec: docs/MULTI_COLUMN_LABELS_AND_WEIGHTED_BASES.md (unmerged).
-- **Multi-column label area** support is FUTURE. Spec: docs/MULTI_COLUMN_LABELS_AND_WEIGHTED_BASES.md (unmerged). GST coverage: GST-068, GST-069.
+- **Effective Base and Weighted Base** support are core correctness features. Planned base priority: Effective > Unweighted > plain Base > Weighted with warning. Full spec: docs/MULTI_COLUMN_LABELS_AND_WEIGHTED_BASES.md.
+- **Multi-column label area** support is FUTURE. Spec: docs/MULTI_COLUMN_LABELS_AND_WEIGHTED_BASES.md. GST coverage: GST-068, GST-069.
 - This matrix reflects the current stabilization state. Update this document when new structures are implemented or when validation behavior changes.

--- a/docs/TABLE_STRUCTURE_MATRIX.md
+++ b/docs/TABLE_STRUCTURE_MATRIX.md
@@ -119,7 +119,7 @@
 | Single label column immediately left of selection | SUPPORTED | Default behavior. | -- |
 | Labels separated from data by numeric columns | SUPPORTED | Detector skips numeric intermediate columns when searching for text labels. | -- |
 | Labels in leftmost sheet columns (labels-on-left-side mode) | SUPPORTED | Enabled via labels-on-left-side setting; reads labels from left edge of sheet. | -- |
-| Multi-column label area (spanning two text columns) | UNSUPPORTED | Only one label column is read. Second label column is ignored. | FUTURE: multi-column label support. |
+| Multi-column label area (spanning two text columns) | UNSUPPORTED | Only one label column is read. Second label column is ignored. | FUTURE: multi-column label support. Spec: docs/MULTI_COLUMN_LABELS_AND_WEIGHTED_BASES.md (unmerged). GST coverage: GST-068, GST-069. |
 | No label column anywhere | PARTIAL | Detector proceeds without row-type keywords; may fall back to heuristics or misidentify rows. | Metric detection accuracy degrades. Ensure labels are present. |
 
 ### 3.3. Adjacent Tables
@@ -134,13 +134,13 @@
 
 ## 4. Base Structures
 
-Planned base priority order (not fully implemented yet): Effective Base > Unweighted Base > plain Base > Weighted Base fallback with warning. Effective Base and Weighted Base support are core correctness features, not premium or deferred features.
+Planned base priority order (not fully implemented yet): Effective Base > Unweighted Base > plain Base > Weighted Base fallback with warning. Effective Base and Weighted Base support are core correctness features, not premium or deferred features. Full spec: docs/MULTI_COLUMN_LABELS_AND_WEIGHTED_BASES.md (unmerged, branch chore/spec-issue-17-multi-col-and-weighted-bases). GST coverage: GST-062 to GST-067, GST-072.
 
 | Structure | Status | Current behavior | Risk / notes |
 |---|---|---|---|
 | Unweighted Base (plain integer counts) | SUPPORTED | Standard behavior. | -- |
-| Weighted Base (non-integer, e.g. 487.3) | PARTIAL | No explicit weighted-base path. Value is used as-is in z-test denominator. Statistical validity depends on weighting method used by the researcher. | FUTURE: weighted base support planned. Intended role: fallback with warning when no Effective Base is present. |
-| Effective Base | FUTURE | No dedicated effective-base row keyword or logic yet. | Core correctness feature. Planned MVP-core support. Intended as the highest-priority base type. |
+| Weighted Base (non-integer, e.g. 487.3) | PARTIAL | No explicit weighted-base path. Value is used as-is in z-test denominator. Statistical validity depends on weighting method used by the researcher. | FUTURE: weighted base support planned. Intended role: fallback with warning when no Effective Base is present. Spec: docs/MULTI_COLUMN_LABELS_AND_WEIGHTED_BASES.md (unmerged). GST: GST-062, GST-063, GST-066. |
+| Effective Base | FUTURE | No dedicated effective-base row keyword or logic yet. | Core correctness feature. Planned MVP-core support. Intended as the highest-priority base type. Spec: docs/MULTI_COLUMN_LABELS_AND_WEIGHTED_BASES.md (unmerged). GST: GST-064, GST-067, GST-072. |
 | Shared Base (one Base row for multiple metric rows above) | SUPPORTED | Detector resolves shared Base correctly. | -- |
 | Missing Base row | UNSUPPORTED | Block cannot be formed. Calculation skipped for that block. | Always include a Base row per block or as shared Base. |
 | Base row with small base (below threshold) | SUPPORTED | Column excluded from comparisons; small-base fill applied across block; Total small-base stops calculation with message. | -- |
@@ -241,5 +241,6 @@ Planned base priority order (not fully implemented yet): Effective Base > Unweig
 - **Total outside selection** is partially designed but may need edge-case hardening.
 - **Check-table / data quality validation** mode is specified in docs/table-preview-model.md but not yet implemented.
 - **Selected range normalization** spec is in docs/SELECTED_RANGE_NORMALIZATION.md; implementation not started.
-- **Effective Base and Weighted Base** support are core correctness features. Planned base priority: Effective > Unweighted > plain Base > Weighted with warning.
+- **Effective Base and Weighted Base** support are core correctness features. Planned base priority: Effective > Unweighted > plain Base > Weighted with warning. Full spec: docs/MULTI_COLUMN_LABELS_AND_WEIGHTED_BASES.md (unmerged).
+- **Multi-column label area** support is FUTURE. Spec: docs/MULTI_COLUMN_LABELS_AND_WEIGHTED_BASES.md (unmerged). GST coverage: GST-068, GST-069.
 - This matrix reflects the current stabilization state. Update this document when new structures are implemented or when validation behavior changes.


### PR DESCRIPTION
## Summary

- Adds GST-067, GST-068, GST-069, GST-072 as FUTURE planned cases to `docs/GOLD_STANDARD_TEST_SUITE.md`
- Inserts new section 4.8 (Multi-column label cases) and renumbers downstream sections (4.9–4.12)
- Updates `docs/TABLE_STRUCTURE_MATRIX.md` to reference `docs/MULTI_COLUMN_LABELS_AND_WEIGHTED_BASES.md` spec on: base priority rules, Weighted Base row, Effective Base row, and multi-column label area
- Adds spec and GST cross-references in the matrix Notes section

Closes #60

## GST cases added

| ID | Title | Status |
|---|---|---|
| GST-067 | Effective Base + Unweighted Base + Weighted Base in one block | FUTURE |
| GST-068 | Multi-column label disambiguates two blocks sharing primary label "%" | FUTURE |
| GST-069 | Two-column label with span-fill on continuation rows | FUTURE |
| GST-072 | Small base on Effective Base while displayed Weighted Base is above threshold | FUTURE |

## Matrix sections updated

- Section 3.2 Multi-Column Labels — added spec ref and GST cross-references to the UNSUPPORTED/FUTURE row
- Section 4 Base Structures — updated opening note, Weighted Base row, and Effective Base row with spec refs and GST IDs
- Notes section — added bullet for Effective/Weighted Base spec and new bullet for multi-column label spec

## Assumptions / limitations

- `docs/MULTI_COLUMN_LABELS_AND_WEIGHTED_BASES.md` is referenced but not yet merged to main (it lives on `chore/spec-issue-17-multi-col-and-weighted-bases`). All new GST cases are marked FUTURE and carry a `Spec ref:` annotation noting this. The relationship document in section 7 of the GST also notes the unmerged state.
- No statuses were promoted. All new cases are FUTURE; no existing PARTIAL or UNSUPPORTED rows were changed to SUPPORTED.
- No runtime code, tests, or AGENTS.md were modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)