### PR TITLE
feat: weighted/unweighted/effective base subtype detection (#62)

### DIFF
--- a/src/core/config/dictionary.config.js
+++ b/src/core/config/dictionary.config.js
@@ -55,6 +55,36 @@ export const METRIC_DICTIONARY = [
   },
   {
     rowType: "base",
+    baseSubtype: "effective",
+    keywords: [
+      "effective base",
+      "effective n",
+      "эффективная база",
+      "эффективное n",
+    ],
+  },
+  {
+    rowType: "base",
+    baseSubtype: "unweighted",
+    keywords: [
+      "unweighted base",
+      "unweighted n",
+      "невзвешенная база",
+      "невзвешенное n",
+    ],
+  },
+  {
+    rowType: "base",
+    baseSubtype: "weighted",
+    keywords: [
+      "weighted base",
+      "weighted n",
+      "взвешенная база",
+      "взвешенное n",
+    ],
+  },
+  {
+    rowType: "base",
     keywords: ["base", "база", "основание", "выборка", "количество", "кол во"],
   },
   {

--- a/src/core/metric-detector.js
+++ b/src/core/metric-detector.js
@@ -58,10 +58,14 @@ export function classifyMetricLabel(rawLabel) {
   // Проходимся по словарю. Как только находим совпадение — возвращаем тип.
   for (const dictionaryEntry of METRIC_DICTIONARY) {
     if (labelContainsAnyKeyword(normalizedLabel, dictionaryEntry.keywords)) {
-      return {
+      const result = {
         rowType: dictionaryEntry.rowType,
         normalizedLabel,
       };
+      if (dictionaryEntry.baseSubtype !== undefined) {
+        result.baseSubtype = dictionaryEntry.baseSubtype;
+      }
+      return result;
     }
   }
 
@@ -131,13 +135,17 @@ export function detectMetricRowsFromLeftLabels(selectedValues, leftLabelValues) 
     const rawLabel = extractRowLabelFromLeftCells(leftLabelRowValues); // Best label candidate.
     const classification = classifyMetricLabel(rawLabel); // Row type detection result.
 
-    rowDiagnostics.push({
+    const rowDiagnostic = {
       rowIndex,
       displayRowNumber: rowIndex + 1,
       rawLabel,
       normalizedLabel: classification.normalizedLabel,
       rowType: classification.rowType,
-    });
+    };
+    if (classification.baseSubtype !== undefined) {
+      rowDiagnostic.baseSubtype = classification.baseSubtype;
+    }
+    rowDiagnostics.push(rowDiagnostic);
   }
 
   return {
@@ -236,6 +244,24 @@ function isNeutralLabel(normalizedLabel) {
 }
 
 /**
+ * Returns the baseSubtype for a detected base row, if any.
+ */
+function getBaseSubtype(rowDiagnostics, baseRowIndex) {
+  return rowDiagnostics[baseRowIndex]?.baseSubtype;
+}
+
+/**
+ * Attaches baseSubtype to a block object when the base row carries one.
+ */
+function attachBaseSubtype(block, rowDiagnostics, baseRowIndex) {
+  const baseSubtype = getBaseSubtype(rowDiagnostics, baseRowIndex);
+  if (baseSubtype !== undefined) {
+    block.baseSubtype = baseSubtype;
+  }
+  return block;
+}
+
+/**
  * Builds calculation blocks from detected row labels.
  *
  * PURPOSE:
@@ -262,11 +288,12 @@ export function buildCalculationBlocks(detectionResult) {
     // 2. Строка Базы: закрываем висящие проценты, если они есть
     if (currentRowType === "base") {
       if (pendingProportionRows.length > 0) {
-        calculationBlocks.push({
-          metricType: "proportion",
-          valueRowIndexes: [...pendingProportionRows],
-          baseRowIndex: rowIndex,
-        });
+        calculationBlocks.push(
+          attachBaseSubtype(
+            { metricType: "proportion", valueRowIndexes: [...pendingProportionRows], baseRowIndex: rowIndex },
+            rowDiagnostics, rowIndex
+          )
+        );
         pendingProportionRows.length = 0;
       }
       rowIndex++;
@@ -284,20 +311,20 @@ export function buildCalculationBlocks(detectionResult) {
       const baseRowIndex = findNextBaseRowIndex(rowDiagnostics, spreadRowIndex);
 
       if (baseRowIndex !== null) {
-        calculationBlocks.push({
-          metricType: "mean",
-          valueRowIndex: rowIndex,
-          spreadRowIndex,
-          spreadType: rowDiagnostics[spreadRowIndex].rowType,
-          baseRowIndex,
-        });
+        calculationBlocks.push(
+          attachBaseSubtype(
+            { metricType: "mean", valueRowIndex: rowIndex, spreadRowIndex, spreadType: rowDiagnostics[spreadRowIndex].rowType, baseRowIndex },
+            rowDiagnostics, baseRowIndex
+          )
+        );
 
         if (pendingProportionRows.length > 0) {
-          calculationBlocks.push({
-            metricType: "proportion",
-            valueRowIndexes: [...pendingProportionRows],
-            baseRowIndex,
-          });
+          calculationBlocks.push(
+            attachBaseSubtype(
+              { metricType: "proportion", valueRowIndexes: [...pendingProportionRows], baseRowIndex },
+              rowDiagnostics, baseRowIndex
+            )
+          );
           pendingProportionRows.length = 0;
         }
 
@@ -320,27 +347,28 @@ export function buildCalculationBlocks(detectionResult) {
       const baseRowIndex = rowIndex + 3;
 
       if (pendingProportionRows.length > 0) {
-        calculationBlocks.push({
-          metricType: "proportion",
-          valueRowIndexes: [...pendingProportionRows],
-          baseRowIndex,
-        });
+        calculationBlocks.push(
+          attachBaseSubtype(
+            { metricType: "proportion", valueRowIndexes: [...pendingProportionRows], baseRowIndex },
+            rowDiagnostics, baseRowIndex
+          )
+        );
         pendingProportionRows.length = 0;
       }
 
-      calculationBlocks.push({
-        metricType: "proportion",
-        valueRowIndexes: [promotersIdx, detractorsIdx],
-        baseRowIndex,
-      });
+      calculationBlocks.push(
+        attachBaseSubtype(
+          { metricType: "proportion", valueRowIndexes: [promotersIdx, detractorsIdx], baseRowIndex },
+          rowDiagnostics, baseRowIndex
+        )
+      );
 
-      calculationBlocks.push({
-        metricType: "npsStructure",
-        valueRowIndex: rowIndex,
-        promotersRowIndex: promotersIdx,
-        detractorsRowIndex: detractorsIdx,
-        baseRowIndex,
-      });
+      calculationBlocks.push(
+        attachBaseSubtype(
+          { metricType: "npsStructure", valueRowIndex: rowIndex, promotersRowIndex: promotersIdx, detractorsRowIndex: detractorsIdx, baseRowIndex },
+          rowDiagnostics, baseRowIndex
+        )
+      );
 
       rowIndex = baseRowIndex + 1;
       continue;
@@ -361,27 +389,28 @@ export function buildCalculationBlocks(detectionResult) {
       const baseRowIndex = rowIndex + 4;
 
       if (pendingProportionRows.length > 0) {
-        calculationBlocks.push({
-          metricType: "proportion",
-          valueRowIndexes: [...pendingProportionRows],
-          baseRowIndex,
-        });
+        calculationBlocks.push(
+          attachBaseSubtype(
+            { metricType: "proportion", valueRowIndexes: [...pendingProportionRows], baseRowIndex },
+            rowDiagnostics, baseRowIndex
+          )
+        );
         pendingProportionRows.length = 0;
       }
 
-      calculationBlocks.push({
-        metricType: "proportion",
-        valueRowIndexes: [promotersIdx, neutralIdx, detractorsIdx],
-        baseRowIndex,
-      });
+      calculationBlocks.push(
+        attachBaseSubtype(
+          { metricType: "proportion", valueRowIndexes: [promotersIdx, neutralIdx, detractorsIdx], baseRowIndex },
+          rowDiagnostics, baseRowIndex
+        )
+      );
 
-      calculationBlocks.push({
-        metricType: "npsStructure",
-        valueRowIndex: rowIndex,
-        promotersRowIndex: promotersIdx,
-        detractorsRowIndex: detractorsIdx,
-        baseRowIndex,
-      });
+      calculationBlocks.push(
+        attachBaseSubtype(
+          { metricType: "npsStructure", valueRowIndex: rowIndex, promotersRowIndex: promotersIdx, detractorsRowIndex: detractorsIdx, baseRowIndex },
+          rowDiagnostics, baseRowIndex
+        )
+      );
 
       rowIndex = baseRowIndex + 1;
       continue;
@@ -398,20 +427,20 @@ export function buildCalculationBlocks(detectionResult) {
       const baseRowIndex = findNextBaseRowIndex(rowDiagnostics, spreadRowIndex);
 
       if (baseRowIndex !== null) {
-        calculationBlocks.push({
-          metricType: "npsSpread",
-          valueRowIndex: rowIndex,
-          spreadRowIndex,
-          spreadType: rowDiagnostics[spreadRowIndex].rowType,
-          baseRowIndex,
-        });
+        calculationBlocks.push(
+          attachBaseSubtype(
+            { metricType: "npsSpread", valueRowIndex: rowIndex, spreadRowIndex, spreadType: rowDiagnostics[spreadRowIndex].rowType, baseRowIndex },
+            rowDiagnostics, baseRowIndex
+          )
+        );
 
         if (pendingProportionRows.length > 0) {
-          calculationBlocks.push({
-            metricType: "proportion",
-            valueRowIndexes: [...pendingProportionRows],
-            baseRowIndex,
-          });
+          calculationBlocks.push(
+            attachBaseSubtype(
+              { metricType: "proportion", valueRowIndexes: [...pendingProportionRows], baseRowIndex },
+              rowDiagnostics, baseRowIndex
+            )
+          );
           pendingProportionRows.length = 0;
         }
 
@@ -436,21 +465,21 @@ export function buildCalculationBlocks(detectionResult) {
 
         if (baseRowIndex !== null) {
           // All buffered rows, including Detractors and Promoters, receive proportion markers.
-          calculationBlocks.push({
-            metricType: "proportion",
-            valueRowIndexes: [...pendingProportionRows],
-            baseRowIndex,
-          });
+          calculationBlocks.push(
+            attachBaseSubtype(
+              { metricType: "proportion", valueRowIndexes: [...pendingProportionRows], baseRowIndex },
+              rowDiagnostics, baseRowIndex
+            )
+          );
           pendingProportionRows.length = 0;
 
           // NPS row uses NPS significance logic; Detractors and Promoters are its support inputs.
-          calculationBlocks.push({
-            metricType: "npsStructure",
-            valueRowIndex: rowIndex,
-            promotersRowIndex: promotersIdx,
-            detractorsRowIndex: detractorsIdx,
-            baseRowIndex,
-          });
+          calculationBlocks.push(
+            attachBaseSubtype(
+              { metricType: "npsStructure", valueRowIndex: rowIndex, promotersRowIndex: promotersIdx, detractorsRowIndex: detractorsIdx, baseRowIndex },
+              rowDiagnostics, baseRowIndex
+            )
+          );
 
           rowIndex++;
           continue;


### PR DESCRIPTION
## Summary

- Adds three new `dictionary.config.js` entries (effective, unweighted, weighted base) placed **before** the plain `base` entry so substring matching picks the most-specific variant first.
- `classifyMetricLabel` now forwards `baseSubtype` from the matched dictionary entry.
- `detectMetricRowsFromLeftLabels` attaches `baseSubtype` to the row diagnostic when present.
- `buildCalculationBlocks` propagates `baseSubtype` to every calculation block (proportion, mean, npsStructure, npsSpread) that references a typed base row via a new `attachBaseSubtype` helper.
- Plain Base detection is entirely unchanged — the new entries only match phrases like "weighted base", "effective n", "взвешенная база", etc.
- No changes to `significance.js`, `excel-writer.js`, or any taskpane file.

## Affected table-structure matrix areas

Base row detection for all block types. No calculation path changes.

## Affected gold-standard cases

None changed. New cases for weighted/effective/unweighted base detection should be added in a follow-up GST update.

## Regression checklist

- [x] Plain Base rows: still match via the unchanged plain-base dictionary entry
- [x] Shared Base (proportion + mean sharing one base): `attachBaseSubtype` applied to all blocks referencing that base
- [x] Means + SD/variance + Base: case 3 updated
- [x] NPS-first formats 1 and 2: cases 4/4b updated
- [x] NPS spread + Base: case 5 updated
- [x] Extended NPS: case 6 updated
- [x] Russian labels: взвешенная база / невзвешенная база / эффективная база added
- [x] False positives: subtype keywords are multi-word phrases (≥ 4 chars); no risk of matching ordinary labels

## Technical debt / limitations

- `baseSubtype` is additive metadata only. `significance.js` does not read it yet (by design for this issue).
- Base priority selection (Effective > Unweighted > plain > Weighted) is a follow-up issue.
- GST cases for subtype detection are not yet added — should be a separate docs PR.

## Test plan

- [ ] Build passes ✅ (webpack compiled with 2 pre-existing size warnings, 0 errors)
- [ ] Human smoke test: open a table with "Weighted Base" label → confirm row diagnostic shows `rowType=base, baseSubtype=weighted`; verify Run behavior identical to before
- [ ] Human smoke test: plain "Base" row → `rowType=base`, no `baseSubtype` field

Closes #62

🤖 Generated with [Claude Code](https://claude.com/claude-code)