### PR TITLE
feat: add pure selected range normalizer

### DIFF
--- a/docs/SELECTED_RANGE_NORMALIZATION.md
+++ b/docs/SELECTED_RANGE_NORMALIZATION.md
@@ -1,4 +1,4 @@
-# Selected Range Normalization Spec
+﻿# Selected Range Normalization Spec
 
 ## Overview
 
@@ -6,109 +6,322 @@ The Research Insights Toolkit (RIT) currently relies on a manual selected-range 
 
 The desired end-state is a **forgiving full-table selection** model: the user selects the visible table, and RIT identifies the data, labels, and banner internally.
 
-**Important Note:** This document is an architecture spec. Selected range normalization is **not** currently implemented. The existing manual selected-range workflow remains the stable baseline.
+**Important Note:** `src/core/range-normalizer.js` implements Phase 1 (pure model module). The existing manual selected-range workflow remains the stable baseline and is not changed.
 
-## 1. Supported Selection Patterns
+---
 
-The normalization engine must recognize and correctly partition the following selection patterns:
-- **Strict Data Selection:** The current baseline. The user selects only the numeric body.
-- **Data + Row Labels:** The user selects the numeric body and the left-hand text labels.
-- **Data + Banner:** The user selects the numeric body and the top banner headers.
-- **Full Table Selection:** The user selects the entire visual table, including row labels, banner headers, and the numeric body.
-- **Full Table + Title/Headers:** The user selects the entire visual table along with preceding title/header rows.
+## 1. Three Output States
+
+The normalized selection model must distinguish three states. Callers **must** branch on these before using any output.
+
+### State 1 — Pass-through (normalization not needed)
+
+```
+normalizationNeeded:  false
+normalizationApplied: false
+blockingReasons:      []
+```
+
+**Meaning:** The selection already looks like numeric data only. Future integrations **must** preserve the existing strict workflow unchanged. No coordinate offsets or sliced grids are produced.
+
+### State 2 — Normalization succeeded
+
+```
+normalizationNeeded:  true
+normalizationApplied: true
+blockingReasons:      []
+```
+
+**Meaning:** The selection appeared to contain extra structure (title rows, banner rows, label columns). Decomposition succeeded. Future integrations may use `valuesForCalculation`, `leftLabelValues`, `bannerContext`, `dataRowOffset`, and `dataColOffset`.
+
+### State 3 — Normalization needed but blocked
+
+```
+normalizationNeeded:  true
+normalizationApplied: false
+blockingReasons:      ["BODY_TOO_SHORT", ...]   ← one or more codes
+blockingMessage:      "..."                     ← human-readable message
+```
+
+**Meaning:** The selection appeared broad / full-table-like, but the normalizer could not safely decompose it.
+
+**Future integrations MUST stop and show `blockingMessage`.** They **must not** silently fall back to running the strict workflow on the original broad selection. Running significance on a broad unpartitioned selection can write markers to title cells, label cells, or banner cells — that is silent data corruption, not a safe degradation.
+
+---
 
 ## 2. Normalized Selection Data Model
 
-The normalized model separates the user's raw visual selection into logical areas required by the core engines.
+```
+{
+  // ── State flags ─────────────────────────────────────────────────────────
+  normalizationNeeded:  boolean
+  normalizationApplied: boolean
 
-- `originalRange`: The raw Excel coordinates.
-- `normalizedDataWindow`: The subset of `originalRange` containing the numeric data body.
-- `rowLabelArea`: The left-hand column(s) containing metric names.
-- `bannerArea`: The top row(s) containing group definitions.
-- `titleArea`: (Optional) Leading rows containing report titles or metadata, ignored in calculations.
+  // ── Input dimensions ────────────────────────────────────────────────────
+  originalRowCount:    number
+  originalColumnCount: number
 
-## 3. Original Selection vs. Normalized Data Window
+  // ── Classification (indices relative to rawValues) ──────────────────────
+  titleRows:    number[]    // sparse text-only rows stripped from top
+  subtitleRows: number[]    // second sparse text-only row (if present)
+  bannerRows:   number[]    // wide text-heavy header rows
+  labelColumns: number[]    // row-label columns (0, or [0,1])
+  dataColumns:  number[]    // numeric data columns
+  bodyRows:     number[]    // rows after title/subtitle/banner stripping
 
-- **Original Selection:** The exact cells the user highlighted. This is passed from `taskpane.js` to the core.
-- **Normalized Data Window:** A computed sub-grid of the original selection. All subsequent block construction, statistical calculations (`significance.js`), and cell writes (`excel-writer.js`) operate *exclusively* within this window.
+  // ── Sliced grids (populated only when normalizationApplied: true) ────────
+  valuesForCalculation:        Array[][]   // bodyRows × dataColumns, numeric values
+  textForCalculation:          Array[][]   // bodyRows × dataColumns, text representation
+  leftLabelValues:             Array[][]   // bodyRows × labelColumns
+  bannerContext: {
+    scanRows:    Array[][]   // bannerRows × data columns (aligned with valuesForCalculation)
+    columnCount: number      // data column count
+  }
 
-## 4. Row Label Area
+  // ── Coordinate mapping (populated only when normalizationApplied: true) ──
+  dataRowOffset: number   // selectedRange row index of valuesForCalculation[0]
+  dataColOffset: number   // selectedRange col index of valuesForCalculation[0][0]
 
-- Defined as the leftmost column(s) within the `originalRange` but outside the `normalizedDataWindow`.
-- Usually contains text identifying the metric type (e.g., "NPS", "Mean", "%").
-- Normalization must identify the boundary between string-heavy columns and numeric-heavy columns.
+  // ── Confidence ───────────────────────────────────────────────────────────
+  confidence: "high" | "medium" | "low"
 
-## 5. Banner Area
+  // ── Diagnostics ──────────────────────────────────────────────────────────
+  warnings: {
+    code:         string    // TITLE_ROWS_DETECTED | SUBTITLE_ROWS_DETECTED |
+                            // BANNER_ROWS_DETECTED | LABEL_COLUMNS_DETECTED |
+                            // NORMALIZATION_CONFIDENCE_MEDIUM
+    severity:     "info" | "warning"
+    rowIndexes?:  number[]
+    columnIndexes?: number[]
+  }[]
 
-- Defined as the top row(s) within the `originalRange` but outside the `normalizedDataWindow` (and below any `titleArea`).
-- Contains categorical column headers.
-- Normalization must detect where header strings stop and the numeric data matrix begins.
+  blockingReasons: string[]   // blocking reason codes (empty when not blocked)
+  blockingMessage: string     // human-readable message (empty when not blocked)
+}
+```
 
-## 6. Title/Header Area
+---
 
-- Defined as any rows at the very top of the `originalRange` that span the table but do not participate in the banner hierarchy.
-- Often contain single-cell strings or wide merged cells (e.g., "Q4 Brand Tracker").
-- These rows are excluded from both the `bannerArea` and the `normalizedDataWindow`.
+## 3. Detection Strategy
 
-## 7. Coordinate Mapping Back to Worksheet
+### Step 0 — Pass-through gate
 
-Because core modules like `significance.js` will operate on the `normalizedDataWindow` grid, any markers or fills generated must map back to the correct absolute Excel coordinates.
-- The system must maintain a mapping function: `(normalizedRow, normalizedCol) -> (excelRow, excelCol)`.
-- This coordinate mapping is a requirement for future Run integration, with the exact integration point left to a dedicated implementation issue.
+Structural analysis requires at minimum a 3×3 selection. Smaller selections return State 1 immediately.
 
-## 8. Confidence and Ambiguity Policy
+For qualifying selections, four patterns trigger normalization:
 
-- **High Confidence:** If the normalization engine clearly identifies the boundaries (e.g., solid numeric block surrounded by text), it proceeds silently.
-- **Low Confidence / Ambiguity:** Low-confidence cases should fall back to current strict selected-range behavior and surface a non-blocking warning. Blocking confirmation belongs to a separate UX/modal issue if ever needed.
-- **Rule of Least Surprise:** When in doubt, prefer the current manual behavior over guessing incorrectly.
+1. **Left-column pattern:** col[0] has ≥70% text AND cols[1..N] have ≥70% numeric content.
+2. **Wide top-row pattern:** row[0] has ≥60% text AND rows[1..N] have ≥70% numeric content.
+3. **Sparse title-row pattern:** row[0] is title-like (sparse, text-only, ≤3 non-empty cells) AND rows[1..N] have ≥70% numeric content. This covers merged-like title rows above numeric bodies.
+4. **Overall text-heavy fallback:** ≥12 cells total, ≥25% text fraction, ≥50% numeric fraction.
 
-## 9. Relationship to Current Warning-Only Guardrails
+If none fire → State 1 (pass-through). If any fire → proceed to structural decomposition.
 
-- Current warning-only guardrails are a temporary safety net.
-- Once normalization proves reliable, they may be reduced, reframed, or reused as fallback diagnostics.
-- They should not become the primary product solution.
+### Step 1 — Title / subtitle row detection
 
-## 10. Relationship to Table Preview Model
+A row is **title-like** when:
+- At least one non-empty non-numeric text cell is present
+- No numeric cells are present
+- Non-empty cell count is ≤ 3 (sparse — distinguishes title from wide banner)
 
-- Normalization is a prerequisite for a robust Table Preview feature.
-- The output of the normalization model (`normalizedDataWindow`, `rowLabelArea`, `bannerArea`) will populate the Preview UI, allowing the user to verify the boundaries before running calculations.
+Applied to the top of the selection: up to one title row, then optionally one subtitle row. Both must appear consecutively at the very top.
 
-## 11. Implementation Phases
+### Step 2 — Banner / header row detection
 
-We recommend a **model-first implementation path**:
-1.  **Phase 1: Pure model / diagnostics only.** Build the normalization engine. Run it silently alongside the current workflow. Expose its output only through dev diagnostics or future preview, without changing Run behavior.
-2.  **Phase 2: Preview UI Integration.** Expose the normalized model in a read-only Table Preview UI. Allow users to confirm the engine's guesses.
-3.  **Phase 3: Opt-in Execution.** Add a setting to "Auto-detect table boundaries" that wires the normalized model into the core execution flow.
-4.  **Phase 4: Default Behavior.** Consider default Run integration only after preview/opt-in behavior proves reliable, while preserving strict selected-range workflow.
+Applied immediately after title/subtitle rows. A row is a **banner row** when:
+- Non-empty cells span ≥ 50% of the total column count (wide — distinguishes from sparse title rows)
+- Text fraction ≥ 60%
 
-## 12. First Safe Coding Issue
+Consecutive qualifying rows are all collected. Multi-level banners are captured naturally.
 
-**Issue: Create the Normalization Engine (Pure Read-Only Module)**
-- Implement the boundary detection logic in a new pure read-only normalized selection model module.
-- Write unit tests for the engine using mock Excel data grids covering the supported selection patterns.
-- Explicitly forbidden: Changes to taskpane Run flow, `excel-writer.js`, `significance.js`, `banner-detector` behavior, and `metric-detector` behavior.
+These rows are extracted into `bannerContext.scanRows` for future use by `detectBannerStructure()`.
 
-## 13. Major Regression Risks
+### Step 3 — Label column detection
 
-Implementing this feature carries significant risks:
-- **Calculation Shifts:** If the `normalizedDataWindow` is off by one row or column, all subsequent significance calculations will be performed on the wrong cells, potentially overwriting labels with markers.
-- **Coordinate Mapping Failures:** Incorrect mapping back to the worksheet could result in formatting or letters being applied to the wrong areas of the spreadsheet.
-- **Banner Detection Breakage:** `banner-detector.js` might fail if fed an incorrect `bannerArea`.
-- **Metric Detection Breakage:** `metric-detector.js` relies heavily on left-aligned row labels; an incorrect `rowLabelArea` will break metric type identification.
+Applied over body rows only (after title/subtitle/banner stripping). Inspects leftmost columns:
 
-## 14. Smoke-Test Scenarios
+| col[0] text fraction | col[1] text fraction | Result |
+|---|---|---|
+| < 0.5 | — | 0 label columns, confident |
+| 0.5 – 0.6 | — | 0 label columns, **uncertain** |
+| ≥ 0.6 | ≥ 0.6 | 2 label columns, confident |
+| ≥ 0.6 | < 0.6 | 1 label column, confident |
 
-Before any normalization logic is merged into the execution path, these scenarios must pass:
-1.  **Baseline strict data:** Select only numbers. Ensure calculations map perfectly as they do today.
-2.  **Clean full table:** Select labels, banner, and data. Ensure markers land only in the data area.
-3.  **Full table with title:** Select a table including a top-row report title. Ensure the title is ignored and the banner is correctly identified below it.
-4.  **Numeric labels:** A table where the row labels are numeric (e.g., years: 2021, 2022). The engine must not consume these as the data body.
-5.  **Small base tables:** Ensure small-base formatting correctly targets the `normalizedDataWindow` and doesn't bleed into the `rowLabelArea`.
-6.  **Data + two left row-label columns:** Ensure both columns are identified as labels and not data.
-7.  **Multi-row / merged-like banner:** Ensure multi-level headers are correctly identified as the banner area.
-8.  **NPS-first:** Ensure normal metric detection works.
-9.  **Extended NPS:** Ensure multi-row scales are correctly isolated.
-10. **Means + SD/Base:** Ensure base/SD are correctly excluded from markers.
-11. **Local/global Total banner:** Ensure total columns are correctly mapped in coordinate system.
-12. **Previous-column / wave layout:** Ensure automatic wave behavior maps correctly.
-13. **Values already containing significance markers from a previous run:** Ensure the normalization engine is not confused by text markers within the numeric data area.
+Never consumes a column with < 50% text content as a label column.
+
+### Step 4 — Body validation
+
+After stripping, the candidate body (body rows × data columns) is validated:
+
+| Code | Condition |
+|---|---|
+| `BODY_TOO_SHORT` | < 2 body rows remain after stripping |
+| `DATA_TOO_NARROW` | < 2 data columns remain after label stripping |
+| `BODY_APPEARS_MULTI_TABLE` | An all-empty row gap exists inside the body |
+| `NO_NUMERIC_BODY` | No numeric cells found in the body at all |
+| `LABEL_SPLIT_BLOCKING` | Label split is uncertain AND body text fraction ≥ 40% |
+
+Any of these returns State 3 (blocked).
+
+### Step 5 — Confidence scoring
+
+Computed on the body numeric fraction only when validation passes:
+
+| Body numeric fraction | Label split | Confidence |
+|---|---|---|
+| ≥ 70% | confident | **high** |
+| 50–70% | confident | **medium** |
+| ≥ 70% | uncertain | **medium** |
+| < 50% | any | **low** → `LOW_CONFIDENCE` blocking |
+
+`low` confidence adds `LOW_CONFIDENCE` to `blockingReasons` and returns State 3. `medium` returns State 2 with a `NORMALIZATION_CONFIDENCE_MEDIUM` warning.
+
+---
+
+## 4. Blocking Conditions Summary
+
+| Code | Trigger | State |
+|---|---|---|
+| `BODY_TOO_SHORT` | < 2 body rows after stripping | 3 — Blocked |
+| `DATA_TOO_NARROW` | < 2 data columns after label stripping | 3 — Blocked |
+| `BODY_APPEARS_MULTI_TABLE` | All-empty row gap inside body | 3 — Blocked |
+| `NO_NUMERIC_BODY` | No numeric cells in body | 3 — Blocked |
+| `LABEL_SPLIT_BLOCKING` | Uncertain split + body text fraction ≥ 40% | 3 — Blocked |
+| `LOW_CONFIDENCE` | Body numeric fraction < 50% | 3 — Blocked |
+
+---
+
+## 5. Warning-only Diagnostics (non-blocking)
+
+Produced only in State 2 (normalization succeeded):
+
+| Code | Meaning |
+|---|---|
+| `TITLE_ROWS_DETECTED` | One title row was stripped |
+| `SUBTITLE_ROWS_DETECTED` | One subtitle row was stripped |
+| `BANNER_ROWS_DETECTED` | Banner/header rows were extracted |
+| `LABEL_COLUMNS_DETECTED` | Label column(s) were separated from data |
+| `NORMALIZATION_CONFIDENCE_MEDIUM` | Decomposition succeeded but with reduced certainty |
+
+---
+
+## 6. Behavior Matrix
+
+| State | `normalizationNeeded` | `normalizationApplied` | `blockingReasons` | Required caller action |
+|---|---|---|---|---|
+| Pure numeric-only | `false` | `false` | `[]` | Preserve existing strict workflow |
+| Normalized (high/medium) | `true` | `true` | `[]` | Use normalized grids; show any warnings |
+| Low confidence | `true` | `false` | `["LOW_CONFIDENCE"]` | **Stop. Show blockingMessage. Do not run.** |
+| Structurally blocked | `true` | `false` | `["BODY_TOO_SHORT", ...]` | **Stop. Show blockingMessage. Do not run.** |
+
+---
+
+## 7. Coordinate Mapping
+
+When a future integration wires `normalizeSelectedRange()` into Run significance:
+
+```
+absoluteExcelRow = selectedRange.rowIndex    + dataRowOffset + normalizedBodyRow
+absoluteExcelCol = selectedRange.columnIndex + dataColOffset + normalizedBodyCol
+```
+
+`dataRowOffset` and `dataColOffset` are pre-computed in every State 2 result. This mapping is required because `excel-writer.js` currently assumes the result matrix is 1:1 aligned with `selectedRange`. With normalization, the result matrix covers only the body, so the writer must apply the offset.
+
+Coordinate mapping integration is explicitly scoped to Phase 3 (opt-in Run significance). It must not be implemented in the Phase 1 or Phase 2 PRs.
+
+---
+
+## 8. Relationship to Existing Components
+
+### `detectSelectedRangeGuardrails` (taskpane.js)
+
+The pass-through gate in `range-normalizer.js` uses the same structural heuristics as the existing guardrails (left-column text fraction, top-row text fraction, overall text-heavy fallback). In future phases, the guardrail warnings can be replaced by normalization info messages when normalization succeeds. They remain in place for Phase 1.
+
+### `buildTablePreviewModel` (table-preview-model.js)
+
+Accepts `{values, leftLabelValues, bannerContext, settings}`. The normalized model's `valuesForCalculation`, `leftLabelValues`, and `bannerContext` map directly onto these parameters. Phase 2 integration feeds the normalized grids to `buildTablePreviewModel` with no changes to `table-preview-model.js`.
+
+### `detectBannerStructure` (banner-detector.js)
+
+Expects a banner context built from rows above the selected range. Phase 2/3 integration will pass `bannerContext.scanRows` from the normalized model instead of (or in addition to) the rows loaded above the selection. No changes to `banner-detector.js`.
+
+### `table-inventory-scanner.js`
+
+Uses the same cell classification and text fraction heuristics independently. The normalizer implements its own copies of these primitives; shared extraction is a future refactor, not part of this issue.
+
+---
+
+## 9. Accepted / Rejected Selection Examples
+
+### Accepted — State 1 (pass-through)
+
+| Selection | Result |
+|---|---|
+| 5×4 all numeric | Pass-through; strict workflow unchanged |
+| 4×2 grid (too small for structural analysis) | Pass-through; too small |
+
+### Accepted — State 2 (normalization succeeded)
+
+| Selection content | Detected layout | Confidence |
+|---|---|---|
+| Col A text labels + cols B–E numeric | `labelColumns=[0]`, `dataColOffset=1` | high |
+| Cols A–B text + cols C–E numeric | `labelColumns=[0,1]`, `dataColOffset=2` | high |
+| Row 1 sparse title + rows 2–10 body | `titleRows=[0]`, `dataRowOffset=1` | high |
+| Row 1 title + row 2 subtitle + body | `titleRows=[0]`, `subtitleRows=[1]`, `dataRowOffset=2` | high |
+| Row 1 title + row 2 wide banner + col A labels + body | Full decomposition | high |
+| Full NPS table (title + banner + labels + metric rows) | All areas extracted | high |
+
+### Rejected — State 3 (blocked, caller must stop)
+
+| Selection content | Blocking reason | Message |
+|---|---|---|
+| Two tables, empty row between them | `BODY_APPEARS_MULTI_TABLE` | "...пустые строки...несколько таблиц..." |
+| After stripping, 1 body row | `BODY_TOO_SHORT` | "Недостаточно строк данных..." |
+| After stripping, 1 data column | `DATA_TOO_NARROW` | "Недостаточно столбцов данных..." |
+| No numeric cells in body | `NO_NUMERIC_BODY` | "...не найдено числовых данных..." |
+| Ambiguous label split + text-heavy body | `LABEL_SPLIT_BLOCKING` | "...Выделите только числовую область данных." |
+| Body < 50% numeric | `LOW_CONFIDENCE` | "...Выделите только числовую область данных." |
+
+---
+
+## 10. Implementation Phases
+
+### Phase 1 — Pure module (complete)
+
+`src/core/range-normalizer.js` exports `normalizeSelectedRange(rawValues, rawText, options)`.
+
+No runtime wiring. No changes to high-risk files. No test framework added.
+
+### Phase 2 — Check table preview integration
+
+Wire `normalizeSelectedRange()` into `runCheckTable()` in `taskpane.js`.
+
+When `normalizationApplied: true`, pass the normalized grids to `buildTablePreviewModel()`. When blocked, show `blockingMessage` in the Check table result panel.
+
+Allowed file: `taskpane.js` (`runCheckTable()` function only). No Excel writes. No coordinate mapping needed.
+
+### Phase 3 — Opt-in Run significance integration
+
+Wire `normalizeSelectedRange()` into `runSignificanceFromSelection()` behind an opt-in setting. Implement coordinate mapping so `writeCellResultsToSelectedRange()` offsets by `(dataRowOffset, dataColOffset)`.
+
+Allowed files: `taskpane.js` (Run path), `excel-writer.js` (offset parameter).
+
+---
+
+## 11. Regression Risks
+
+- **Calculation shifts:** If `dataRowOffset` or `dataColOffset` is off by one, markers land in wrong cells.
+- **Coordinate mapping failures:** Incorrect offset in `excel-writer.js` corrupts the entire output range.
+- **Banner detection breakage:** `detectBannerStructure()` may fail on an incorrect `bannerContext`.
+- **Metric detection breakage:** `detectMetricRowsFromLeftLabels()` relies on label text being in `leftLabelValues`; an incorrect label split breaks row-type detection.
+- **Strict workflow regression:** The pass-through gate must fire correctly for pure-numeric selections or the existing behavior changes.
+
+---
+
+## 12. Known Limitations (Phase 1)
+
+- A sparse title row (1 text cell, ≤3 non-empty) in an otherwise pure-numeric selection may not trigger the pass-through gate; the normalizer will not detect it. This is an acceptable gap for Phase 1 — such a selection is nearly-numeric and the existing strict workflow handles it with the same limitation it has today.
+- `rawText` is optional; if omitted, `textForCalculation` is an empty array.
+- `options` parameter is reserved and unused in Phase 1.
+- No test framework is included. Manual validation uses inline console checks or the fixture approach described in the implementation issue.
+

--- a/docs/TABLE_STRUCTURE_MATRIX.md
+++ b/docs/TABLE_STRUCTURE_MATRIX.md
@@ -230,7 +230,7 @@ Planned base priority order (not fully implemented yet): Effective Base > Unweig
 | Automatic worksheet/workbook scanning | FUTURE | Not implemented. User must manually select the numeric data range and click Run. | Planned as automatic runner for the MVP path. Required pipeline: scan -> processing plan -> preview/warnings -> controlled write. Must not re-use repeated manual pipeline calls. |
 | Google Sheets (platform) | FUTURE | Excel-first only. See section 8. | Planned first-class platform after parity phase. |
 | Check-table / data quality validation mode | FUTURE | Not implemented. Specified in docs/table-preview-model.md. | -- |
-| Selected range normalization | FUTURE | Spec in docs/SELECTED_RANGE_NORMALIZATION.md; implementation not started. | -- |
+| Selected range normalization | PARTIAL | Phase 1 pure model implemented in src/core/range-normalizer.js. No runtime wiring yet. Spec in docs/SELECTED_RANGE_NORMALIZATION.md. | Blocked state must stop execution; must not fall back to strict Run on broad selection. |
 
 ---
 
@@ -240,7 +240,7 @@ Planned base priority order (not fully implemented yet): Effective Base > Unweig
 - **Automatic worksheet/workbook scanning** is not implemented. User must always select the numeric data range manually. Planned as automatic runner with a scan -> processing plan -> preview/warnings -> controlled write pipeline; must not repeat the existing manual pipeline.
 - **Total outside selection** is partially designed but may need edge-case hardening.
 - **Check-table / data quality validation** mode is specified in docs/table-preview-model.md but not yet implemented.
-- **Selected range normalization** spec is in docs/SELECTED_RANGE_NORMALIZATION.md; implementation not started.
+- **Selected range normalization** Phase 1 pure model is in src/core/range-normalizer.js. Spec in docs/SELECTED_RANGE_NORMALIZATION.md. No runtime wiring yet.
 - **Effective Base and Weighted Base** support are core correctness features. Planned base priority: Effective > Unweighted > plain Base > Weighted with warning. Full spec: docs/MULTI_COLUMN_LABELS_AND_WEIGHTED_BASES.md.
 - **Multi-column label area** support is FUTURE. Spec: docs/MULTI_COLUMN_LABELS_AND_WEIGHTED_BASES.md. GST coverage: GST-068, GST-069.
 - This matrix reflects the current stabilization state. Update this document when new structures are implemented or when validation behavior changes.

--- a/src/core/range-normalizer.js
+++ b/src/core/range-normalizer.js
@@ -1,0 +1,732 @@
+/**
+ * Selected range normalizer for Research Insights Toolkit.
+ *
+ * Analyzes a 2D grid (already loaded from Excel, markers already removed)
+ * and returns a NormalizedSelectionModel that partitions the selection into:
+ *   - title / subtitle rows   (stripped from calculation)
+ *   - banner / header rows    (extracted into bannerContext)
+ *   - row label columns       (extracted into leftLabelValues)
+ *   - numeric data body       (returned as valuesForCalculation)
+ *
+ * Three output states:
+ *
+ *   1. normalizationNeeded: false, normalizationApplied: false
+ *      The selection already looks like numeric data only.
+ *      Future integrations MUST preserve the existing strict workflow unchanged.
+ *
+ *   2. normalizationNeeded: true, normalizationApplied: true
+ *      Decomposition succeeded.
+ *      Future integrations MAY use valuesForCalculation, leftLabelValues,
+ *      bannerContext, dataRowOffset, and dataColOffset.
+ *
+ *   3. normalizationNeeded: true, normalizationApplied: false
+ *      The selection appeared broad / full-table-like, but the normalizer
+ *      could not safely decompose it.
+ *      Future integrations MUST stop and show blockingMessage.
+ *      They MUST NOT silently fall back to running the strict workflow on
+ *      the original broad selection — that can write markers to wrong cells.
+ *
+ * Pure module constraints:
+ *   - No Office.js
+ *   - No Excel writes
+ *   - No significance calculation
+ *   - No taskpane DOM access
+ *   - No imports from other RIT modules
+ */
+
+// ─── Detection thresholds ─────────────────────────────────────────────────────
+
+// Minimum selection size for structural analysis.
+// Smaller selections are always treated as pass-through.
+const GATE_MIN_ROWS = 3;
+const GATE_MIN_COLS = 3;
+
+// Pass-through gate: left-column pattern.
+// First column is text-heavy AND the remaining columns are numeric-heavy.
+const GATE_LEFT_COL_TEXT_FRACTION    = 0.7;
+const GATE_REST_COLS_NUMERIC_FRACTION = 0.7;
+
+// Pass-through gate: top-row pattern.
+// First row is text-heavy AND the lower rows are numeric-heavy.
+const GATE_TOP_ROW_TEXT_FRACTION      = 0.6;
+const GATE_LOWER_ROWS_NUMERIC_FRACTION = 0.7;
+
+// Pass-through gate: overall text-heavy fallback.
+const GATE_OVERALL_TEXT_FRACTION    = 0.25;
+const GATE_OVERALL_NUMERIC_FRACTION = 0.5;
+const GATE_OVERALL_MIN_CELLS        = 12;
+
+// Title row: sparse, no numeric cells, at least one text cell.
+const MAX_TITLE_ROW_NON_EMPTY_CELLS = 3;
+
+// Banner row: wide (spans ≥50% of columns) and text-heavy.
+const BANNER_MIN_FILL_FRACTION     = 0.5;
+const BANNER_TEXT_FRACTION         = 0.6;
+
+// Label column: text fraction threshold for "clearly a label column."
+const LABEL_TEXT_FRACTION_THRESHOLD = 0.6;
+// Text fraction below this → first column is clearly not a label column.
+const LABEL_NUMERIC_THRESHOLD       = 0.5;
+
+// Blocking: label split is uncertain AND body is still text-heavy → unsafe.
+const LABEL_BLOCKING_BODY_TEXT_FRACTION = 0.4;
+
+// Confidence thresholds on body numeric fraction.
+const CONFIDENCE_HIGH_NUMERIC   = 0.7;
+const CONFIDENCE_MEDIUM_NUMERIC = 0.5;
+
+// ─── Cell helpers ─────────────────────────────────────────────────────────────
+
+function isCellEmpty(cell) {
+  return cell === "" || cell === null || cell === undefined;
+}
+
+function isNumericCell(cell) {
+  if (typeof cell === "number") return !isNaN(cell);
+  if (typeof cell !== "string") return false;
+  const trimmed = cell.trim();
+  if (!trimmed) return false;
+  return !isNaN(parseFloat(trimmed.replace(/,/g, ".")));
+}
+
+function isTextOnlyCell(cell) {
+  if (typeof cell !== "string" || !cell.trim()) return false;
+  return isNaN(parseFloat(cell.trim().replace(/,/g, ".")));
+}
+
+// ─── Grid analysis helpers ────────────────────────────────────────────────────
+
+function computeTextFraction(values, startRow, endRow, startCol, endCol) {
+  let textCount = 0;
+  let totalNonEmpty = 0;
+  for (let r = startRow; r <= endRow; r++) {
+    const row = values[r];
+    if (!row) continue;
+    for (let c = startCol; c <= endCol; c++) {
+      const cell = row[c];
+      if (isCellEmpty(cell)) continue;
+      totalNonEmpty++;
+      if (isTextOnlyCell(cell)) textCount++;
+    }
+  }
+  return totalNonEmpty === 0 ? 0 : textCount / totalNonEmpty;
+}
+
+function computeNumericFraction(values, startRow, endRow, startCol, endCol) {
+  let numericCount = 0;
+  let totalNonEmpty = 0;
+  for (let r = startRow; r <= endRow; r++) {
+    const row = values[r];
+    if (!row) continue;
+    for (let c = startCol; c <= endCol; c++) {
+      const cell = row[c];
+      if (isCellEmpty(cell)) continue;
+      totalNonEmpty++;
+      if (isNumericCell(cell)) numericCount++;
+    }
+  }
+  return totalNonEmpty === 0 ? 0 : numericCount / totalNonEmpty;
+}
+
+function countNonEmpty(values, startRow, endRow, startCol, endCol) {
+  let count = 0;
+  for (let r = startRow; r <= endRow; r++) {
+    const row = values[r];
+    if (!row) continue;
+    for (let c = startCol; c <= endCol; c++) {
+      if (!isCellEmpty(row[c])) count++;
+    }
+  }
+  return count;
+}
+
+// ─── Pass-through gate ────────────────────────────────────────────────────────
+
+/**
+ * Returns true when the selection appears to contain non-numeric structure
+ * (label columns, header rows, title rows) that warrants normalization.
+ *
+ * Returns false when the selection looks like numeric-only data —
+ * no normalization attempt should be made in that case.
+ */
+function isNormalizationNeeded(values, rowCount, colCount) {
+  if (rowCount < GATE_MIN_ROWS || colCount < GATE_MIN_COLS) return false;
+
+  // Left-column pattern: col[0] is text-heavy, cols[1..N] are numeric-heavy.
+  const leftColNonEmpty = countNonEmpty(values, 0, rowCount - 1, 0, 0);
+  if (leftColNonEmpty >= Math.max(2, Math.ceil(rowCount * 0.5))) {
+    const leftColTextFrac = computeTextFraction(values, 0, rowCount - 1, 0, 0);
+    const restNumericFrac = computeNumericFraction(values, 0, rowCount - 1, 1, colCount - 1);
+    if (
+      leftColTextFrac    >= GATE_LEFT_COL_TEXT_FRACTION &&
+      restNumericFrac    >= GATE_REST_COLS_NUMERIC_FRACTION
+    ) {
+      return true;
+    }
+  }
+
+  // Top-row pattern: row[0] is text-heavy, rows[1..N] are numeric-heavy.
+  // Requires row[0] to fill at least half the columns (wide banner/header row).
+  const topRowNonEmpty = countNonEmpty(values, 0, 0, 0, colCount - 1);
+  if (topRowNonEmpty >= Math.max(2, Math.ceil(colCount * 0.5))) {
+    const topRowTextFrac     = computeTextFraction(values, 0, 0, 0, colCount - 1);
+    const lowerNumericFrac   = computeNumericFraction(values, 1, rowCount - 1, 0, colCount - 1);
+    if (
+      topRowTextFrac   >= GATE_TOP_ROW_TEXT_FRACTION &&
+      lowerNumericFrac >= GATE_LOWER_ROWS_NUMERIC_FRACTION
+    ) {
+      return true;
+    }
+  }
+
+  // Sparse title-row pattern: row[0] is a sparse text-only heading (≤3 cells),
+  // rows[1..N] are numeric-heavy.  The wide top-row gate above misses this case
+  // because a merged-like title cell fills only 1 column regardless of table width.
+  if (isTitleLikeRow(values, 0, colCount)) {
+    const lowerNumericFrac = computeNumericFraction(values, 1, rowCount - 1, 0, colCount - 1);
+    if (lowerNumericFrac >= GATE_LOWER_ROWS_NUMERIC_FRACTION) {
+      return true;
+    }
+  }
+
+  // Fallback: overall text-heavy with substantial numeric content.
+  const totalCells = rowCount * colCount;
+  if (totalCells >= GATE_OVERALL_MIN_CELLS) {
+    const allTextFrac    = computeTextFraction(values, 0, rowCount - 1, 0, colCount - 1);
+    const allNumericFrac = computeNumericFraction(values, 0, rowCount - 1, 0, colCount - 1);
+    if (allTextFrac >= GATE_OVERALL_TEXT_FRACTION && allNumericFrac >= GATE_OVERALL_NUMERIC_FRACTION) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+// ─── Title / subtitle detection ───────────────────────────────────────────────
+
+/**
+ * A row is title-like when:
+ *   - it has at least one non-empty non-numeric text cell
+ *   - it has no numeric cells
+ *   - it is sparse: at most MAX_TITLE_ROW_NON_EMPTY_CELLS non-empty cells
+ *
+ * The sparseness constraint distinguishes title rows (single merged-cell heading)
+ * from banner rows (which span most or all columns).
+ */
+function isTitleLikeRow(values, rowIndex, colCount) {
+  const row = values[rowIndex];
+  if (!row) return false;
+
+  let nonEmptyCount = 0;
+  let hasText = false;
+
+  for (let c = 0; c < colCount; c++) {
+    const cell = row[c];
+    if (isCellEmpty(cell)) continue;
+    nonEmptyCount++;
+    if (isNumericCell(cell)) return false;
+    if (isTextOnlyCell(cell)) hasText = true;
+  }
+
+  return hasText && nonEmptyCount > 0 && nonEmptyCount <= MAX_TITLE_ROW_NON_EMPTY_CELLS;
+}
+
+/**
+ * Detects up to one title row and one subtitle row at the top of the selection.
+ * Both rows must be at the very beginning; any non-title-like row stops detection.
+ */
+function detectTitleSubtitleRows(values, rowCount, colCount) {
+  const titleRows    = [];
+  const subtitleRows = [];
+
+  if (rowCount === 0) return { titleRows, subtitleRows };
+
+  let idx = 0;
+
+  if (isTitleLikeRow(values, idx, colCount)) {
+    titleRows.push(idx);
+    idx++;
+
+    if (idx < rowCount && isTitleLikeRow(values, idx, colCount)) {
+      subtitleRows.push(idx);
+    }
+  }
+
+  return { titleRows, subtitleRows };
+}
+
+// ─── Banner / header row detection ───────────────────────────────────────────
+
+/**
+ * Detects consecutive banner/header rows starting from startRow.
+ *
+ * A banner row is:
+ *   - wide: fills ≥ BANNER_MIN_FILL_FRACTION of the total column count
+ *   - text-heavy: text fraction ≥ BANNER_TEXT_FRACTION
+ *
+ * The fill requirement distinguishes banner rows from title rows (which are sparse).
+ * Detection stops at the first row that fails either criterion.
+ */
+function detectBannerRows(values, startRow, rowCount, colCount) {
+  const bannerRows = [];
+
+  for (let r = startRow; r < rowCount; r++) {
+    const nonEmpty  = countNonEmpty(values, r, r, 0, colCount - 1);
+    const fillFrac  = colCount > 0 ? nonEmpty / colCount : 0;
+    const textFrac  = computeTextFraction(values, r, r, 0, colCount - 1);
+
+    if (fillFrac >= BANNER_MIN_FILL_FRACTION && textFrac >= BANNER_TEXT_FRACTION) {
+      bannerRows.push(r);
+    } else {
+      break;
+    }
+  }
+
+  return bannerRows;
+}
+
+// ─── Label column detection ───────────────────────────────────────────────────
+
+/**
+ * Detects up to 2 row-label columns at the left edge of the body rows.
+ *
+ * Rules (applied over body rows only):
+ *   col[0] text fraction < 0.5          → no label column, confident
+ *   col[0] text fraction in [0.5, 0.6)  → split uncertain
+ *   col[0] text fraction ≥ 0.6          → label column
+ *     col[1] text fraction ≥ 0.6        → second label column
+ *     col[1] text fraction < 0.6        → only one label column
+ *
+ * Never consumes a column with < 50% text as a label column.
+ */
+function detectLabelColumns(values, bodyStartRow, bodyEndRow, colCount) {
+  if (colCount < 2 || bodyEndRow < bodyStartRow) {
+    return { labelColCount: 0, labelSplitConfidence: "uncertain" };
+  }
+
+  const col0Frac = computeTextFraction(values, bodyStartRow, bodyEndRow, 0, 0);
+
+  if (col0Frac < LABEL_NUMERIC_THRESHOLD) {
+    return { labelColCount: 0, labelSplitConfidence: "confident" };
+  }
+
+  if (col0Frac < LABEL_TEXT_FRACTION_THRESHOLD) {
+    // Ambiguous: col[0] is neither clearly text nor clearly numeric.
+    return { labelColCount: 0, labelSplitConfidence: "uncertain" };
+  }
+
+  // col[0] is clearly text (≥ 0.6).
+  if (colCount < 3) {
+    return { labelColCount: 1, labelSplitConfidence: "confident" };
+  }
+
+  const col1Frac = computeTextFraction(values, bodyStartRow, bodyEndRow, 1, 1);
+  if (col1Frac >= LABEL_TEXT_FRACTION_THRESHOLD) {
+    return { labelColCount: 2, labelSplitConfidence: "confident" };
+  }
+
+  return { labelColCount: 1, labelSplitConfidence: "confident" };
+}
+
+// ─── Body validation ──────────────────────────────────────────────────────────
+
+/**
+ * Validates the candidate data body.
+ * Returns an array of blocking-reason objects (empty = valid).
+ */
+function validateBody(values, bodyStartRow, bodyEndRow, dataColStart, dataColEnd) {
+  const reasons = [];
+  const bodyRowCount  = bodyEndRow - bodyStartRow + 1;
+  const dataColCount  = dataColEnd - dataColStart + 1;
+
+  if (bodyRowCount < 2) {
+    reasons.push({
+      code: "BODY_TOO_SHORT",
+      message: "Недостаточно строк данных после удаления заголовков.",
+    });
+  }
+
+  if (dataColCount < 2) {
+    reasons.push({
+      code: "DATA_TOO_NARROW",
+      message: "Недостаточно столбцов данных после удаления столбцов меток.",
+    });
+  }
+
+  // Stop early — the following checks require a valid body rectangle.
+  if (reasons.length > 0) return reasons;
+
+  // All-empty row gap inside the body → likely multiple tables in one selection.
+  for (let r = bodyStartRow; r <= bodyEndRow; r++) {
+    const nonEmpty = countNonEmpty(values, r, r, dataColStart, dataColEnd);
+    if (nonEmpty === 0) {
+      reasons.push({
+        code: "BODY_APPEARS_MULTI_TABLE",
+        message:
+          "Выделенный диапазон содержит пустые строки внутри области данных. " +
+          "Возможно, выделено несколько таблиц. Выделите одну таблицу.",
+      });
+      break;
+    }
+  }
+
+  if (reasons.length > 0) return reasons;
+
+  // No numeric content at all → not a data table.
+  let hasNumeric = false;
+  outer: for (let r = bodyStartRow; r <= bodyEndRow; r++) {
+    const row = values[r] || [];
+    for (let c = dataColStart; c <= dataColEnd; c++) {
+      if (isNumericCell(row[c])) {
+        hasNumeric = true;
+        break outer;
+      }
+    }
+  }
+
+  if (!hasNumeric) {
+    reasons.push({
+      code: "NO_NUMERIC_BODY",
+      message: "В выделенном диапазоне не найдено числовых данных.",
+    });
+  }
+
+  return reasons;
+}
+
+// ─── Confidence scoring ───────────────────────────────────────────────────────
+
+/**
+ * Scores decomposition confidence based on body numeric density
+ * and label split reliability.
+ *
+ * Returns "high" | "medium" | "low".
+ * "low" is treated as a blocking condition by the caller.
+ */
+function scoreConfidence(bodyNumericFrac, labelSplitConfidence) {
+  if (bodyNumericFrac < CONFIDENCE_MEDIUM_NUMERIC) return "low";
+
+  if (labelSplitConfidence === "uncertain") {
+    // Uncertain split: cap at medium regardless of numeric fraction.
+    return bodyNumericFrac >= CONFIDENCE_HIGH_NUMERIC ? "medium" : "low";
+  }
+
+  if (bodyNumericFrac < CONFIDENCE_HIGH_NUMERIC) return "medium";
+  return "high";
+}
+
+// ─── Grid slicing ─────────────────────────────────────────────────────────────
+
+function sliceGrid(grid, startRow, endRow, startCol, endCol) {
+  const result = [];
+  for (let r = startRow; r <= endRow; r++) {
+    const row = grid[r] || [];
+    result.push(row.slice(startCol, endCol + 1));
+  }
+  return result;
+}
+
+function buildIndexRange(start, end) {
+  const arr = [];
+  for (let i = start; i <= end; i++) arr.push(i);
+  return arr;
+}
+
+// ─── Model builders ───────────────────────────────────────────────────────────
+
+function buildPassThroughModel(rowCount, colCount) {
+  return {
+    normalizationNeeded:  false,
+    normalizationApplied: false,
+    originalRowCount:     rowCount,
+    originalColumnCount:  colCount,
+
+    titleRows:    [],
+    subtitleRows: [],
+    bannerRows:   [],
+    labelColumns: [],
+    dataColumns:  buildIndexRange(0, colCount - 1),
+    bodyRows:     buildIndexRange(0, rowCount - 1),
+
+    valuesForCalculation:        null,
+    textForCalculation:          null,
+    leftLabelValues:             null,
+    bannerContext:               null,
+
+    dataRowOffset: 0,
+    dataColOffset: 0,
+
+    confidence:      "high",
+    warnings:        [],
+    blockingReasons: [],
+    blockingMessage: "",
+  };
+}
+
+function buildBlockedModel(
+  rowCount,
+  colCount,
+  titleRows,
+  subtitleRows,
+  bannerRows,
+  labelColCount,
+  confidence,
+  blockingReasons
+) {
+  const firstReason = blockingReasons[0];
+  const blockingMessage = firstReason
+    ? firstReason.message
+    : "Не удаётся нормализовать выделенный диапазон. Выделите только числовую область данных.";
+
+  return {
+    normalizationNeeded:  true,
+    normalizationApplied: false,
+    originalRowCount:     rowCount,
+    originalColumnCount:  colCount,
+
+    titleRows,
+    subtitleRows,
+    bannerRows,
+    labelColumns: labelColCount > 0 ? buildIndexRange(0, labelColCount - 1) : [],
+    dataColumns:  [],
+    bodyRows:     [],
+
+    valuesForCalculation:        null,
+    textForCalculation:          null,
+    leftLabelValues:             null,
+    bannerContext:               null,
+
+    dataRowOffset: 0,
+    dataColOffset: 0,
+
+    confidence,
+    warnings:        [],
+    blockingReasons: blockingReasons.map((r) => r.code),
+    blockingMessage,
+  };
+}
+
+function buildNormalizedModel(
+  values,
+  text,
+  rowCount,
+  colCount,
+  titleRows,
+  subtitleRows,
+  bannerRows,
+  labelColCount,
+  dataColStart,
+  dataColEnd,
+  bodyStartRow,
+  bodyEndRow,
+  confidence,
+  warnings
+) {
+  const labelColumns = labelColCount > 0 ? buildIndexRange(0, labelColCount - 1) : [];
+  const dataColumns  = buildIndexRange(dataColStart, dataColEnd);
+  const bodyRows     = buildIndexRange(bodyStartRow, bodyEndRow);
+
+  const valuesForCalculation = sliceGrid(values, bodyStartRow, bodyEndRow, dataColStart, dataColEnd);
+
+  const textForCalculation = text.length > 0
+    ? sliceGrid(text, bodyStartRow, bodyEndRow, dataColStart, dataColEnd)
+    : [];
+
+  const leftLabelValues = labelColCount > 0
+    ? sliceGrid(values, bodyStartRow, bodyEndRow, 0, labelColCount - 1)
+    : [];
+
+  // Banner scan rows are sliced to data columns only so they align with
+  // valuesForCalculation. detectBannerStructure expects column indices to
+  // match the data grid, not the full raw selection width.
+  const bannerScanRows = bannerRows.length > 0
+    ? sliceGrid(values, bannerRows[0], bannerRows[bannerRows.length - 1], dataColStart, dataColEnd)
+    : [];
+
+  const bannerContext = {
+    scanRows:    bannerScanRows,
+    columnCount: dataColEnd - dataColStart + 1,
+  };
+
+  return {
+    normalizationNeeded:  true,
+    normalizationApplied: true,
+    originalRowCount:     rowCount,
+    originalColumnCount:  colCount,
+
+    titleRows,
+    subtitleRows,
+    bannerRows,
+    labelColumns,
+    dataColumns,
+    bodyRows,
+
+    valuesForCalculation,
+    textForCalculation,
+    leftLabelValues,
+    bannerContext,
+
+    dataRowOffset: bodyStartRow,
+    dataColOffset: dataColStart,
+
+    confidence,
+    warnings,
+    blockingReasons: [],
+    blockingMessage: "",
+  };
+}
+
+// ─── Main export ──────────────────────────────────────────────────────────────
+
+/**
+ * Analyzes a selected Excel range and returns a NormalizedSelectionModel.
+ *
+ * @param {Array}  rawValues - 2D array from selectedRange.values (markers already removed).
+ * @param {Array}  [rawText] - Optional 2D array from selectedRange.text.
+ * @param {object} [options] - Reserved for future configuration options.
+ * @returns {object} NormalizedSelectionModel
+ *
+ * Callers must check normalizationNeeded and normalizationApplied before using
+ * any sliced output grids. See module-level JSDoc for the three valid states.
+ */
+export function normalizeSelectedRange(rawValues, rawText, options = {}) {
+  const values   = Array.isArray(rawValues) ? rawValues : [];
+  const text     = Array.isArray(rawText)   ? rawText   : [];
+  const rowCount = values.length;
+  const colCount = rowCount > 0 && Array.isArray(values[0]) ? values[0].length : 0;
+
+  // ── Step 0: Pass-through gate ──────────────────────────────────────────────
+  // If the selection looks like numeric-only data, return immediately.
+  // The existing strict workflow must run unchanged for this state.
+  if (!isNormalizationNeeded(values, rowCount, colCount)) {
+    return buildPassThroughModel(rowCount, colCount);
+  }
+
+  // Normalization is needed. Attempt structural decomposition.
+
+  // ── Step 1: Title / subtitle rows ─────────────────────────────────────────
+  const { titleRows, subtitleRows } = detectTitleSubtitleRows(values, rowCount, colCount);
+
+  // ── Step 2: Banner rows ────────────────────────────────────────────────────
+  // Banner detection starts immediately after title/subtitle rows.
+  const firstBodyCandidate = titleRows.length + subtitleRows.length;
+  const bannerRows = detectBannerRows(values, firstBodyCandidate, rowCount, colCount);
+
+  const bodyStartRow = firstBodyCandidate + bannerRows.length;
+  const bodyEndRow   = rowCount - 1;
+
+  // ── Step 3: Label columns ──────────────────────────────────────────────────
+  // Applied over body rows only (title/subtitle/banner already excluded).
+  const { labelColCount, labelSplitConfidence } = detectLabelColumns(
+    values,
+    bodyStartRow,
+    bodyEndRow,
+    colCount
+  );
+
+  const dataColStart = labelColCount;
+  const dataColEnd   = colCount - 1;
+
+  // ── Step 4: Body validation ────────────────────────────────────────────────
+  const blockingReasons = validateBody(values, bodyStartRow, bodyEndRow, dataColStart, dataColEnd);
+
+  // Label split safety: uncertain split + body still text-heavy → unsafe to proceed.
+  if (
+    blockingReasons.length === 0 &&
+    labelSplitConfidence === "uncertain"
+  ) {
+    const bodyTextFrac = computeTextFraction(
+      values,
+      bodyStartRow,
+      bodyEndRow,
+      dataColStart,
+      dataColEnd
+    );
+    if (bodyTextFrac >= LABEL_BLOCKING_BODY_TEXT_FRACTION) {
+      blockingReasons.push({
+        code: "LABEL_SPLIT_BLOCKING",
+        message:
+          "Не удаётся надёжно определить границу между метками строк и данными. " +
+          "Выделите только числовую область данных.",
+      });
+    }
+  }
+
+  // ── Step 5: Confidence scoring ─────────────────────────────────────────────
+  // Only computed when the body passed structural validation.
+  let confidence = "high";
+
+  if (blockingReasons.length === 0) {
+    const bodyNumericFrac = computeNumericFraction(
+      values,
+      bodyStartRow,
+      bodyEndRow,
+      dataColStart,
+      dataColEnd
+    );
+    confidence = scoreConfidence(bodyNumericFrac, labelSplitConfidence);
+
+    if (confidence === "low") {
+      blockingReasons.push({
+        code: "LOW_CONFIDENCE",
+        message:
+          "Не удаётся надёжно определить структуру таблицы в выделенном диапазоне. " +
+          "Выделите только числовую область данных.",
+      });
+    }
+  }
+
+  // ── Return blocked model if any reason prevents safe normalization ─────────
+  if (blockingReasons.length > 0) {
+    return buildBlockedModel(
+      rowCount,
+      colCount,
+      titleRows,
+      subtitleRows,
+      bannerRows,
+      labelColCount,
+      confidence === "low" ? "low" : "medium",
+      blockingReasons
+    );
+  }
+
+  // ── Return normalized model ────────────────────────────────────────────────
+  const warnings = [];
+
+  if (titleRows.length > 0) {
+    warnings.push({ code: "TITLE_ROWS_DETECTED",   severity: "info",    rowIndexes: titleRows });
+  }
+  if (subtitleRows.length > 0) {
+    warnings.push({ code: "SUBTITLE_ROWS_DETECTED", severity: "info",   rowIndexes: subtitleRows });
+  }
+  if (bannerRows.length > 0) {
+    warnings.push({ code: "BANNER_ROWS_DETECTED",  severity: "info",    rowIndexes: bannerRows });
+  }
+  if (labelColCount > 0) {
+    warnings.push({
+      code: "LABEL_COLUMNS_DETECTED",
+      severity: "info",
+      columnIndexes: buildIndexRange(0, labelColCount - 1),
+    });
+  }
+  if (confidence === "medium") {
+    warnings.push({ code: "NORMALIZATION_CONFIDENCE_MEDIUM", severity: "warning" });
+  }
+
+  return buildNormalizedModel(
+    values,
+    text,
+    rowCount,
+    colCount,
+    titleRows,
+    subtitleRows,
+    bannerRows,
+    labelColCount,
+    dataColStart,
+    dataColEnd,
+    bodyStartRow,
+    bodyEndRow,
+    confidence,
+    warnings
+  );
+}


### PR DESCRIPTION
﻿## Summary

Adds Phase 1 of selected range normalization: a pure Office.js-free normalizer module.

The new module:
- exports normalizeSelectedRange(rawValues, rawText, options)
- distinguishes pass-through, normalized, and blocked states
- detects sparse title/subtitle rows
- detects banner/header rows
- detects left-side label columns
- slices valuesForCalculation, textForCalculation, leftLabelValues, and bannerContext
- returns coordinate offsets for future runtime integration
- blocks unsafe broad selections instead of falling back to strict Run behavior

No runtime wiring is added in this PR.

## Scope

Allowed:
- src/core/range-normalizer.js
- docs/SELECTED_RANGE_NORMALIZATION.md
- docs/TABLE_STRUCTURE_MATRIX.md

No:
- taskpane integration
- Run significance integration
- Check table integration
- Excel writes
- Office.js dependencies
- test framework
- scanner refactor

## Validation

- npm run build passed with existing webpack asset-size warnings only
- Manual Node smoke confirmed:
  - numeric-only selection stays pass-through
  - sparse title + numeric body normalizes
  - label column + data normalizes
  - broad multi-block selection is blocked with BODY_APPEARS_MULTI_TABLE

Closes #81
