### PR TITLE
feat: normalize Check table selections

### DIFF
--- a/src/core/range-normalizer.js
+++ b/src/core/range-normalizer.js
@@ -44,17 +44,30 @@ const GATE_MIN_COLS = 3;
 // Pass-through gate: left-column pattern.
 // First column is text-heavy AND the remaining columns are numeric-heavy.
 const GATE_LEFT_COL_TEXT_FRACTION    = 0.7;
-const GATE_REST_COLS_NUMERIC_FRACTION = 0.7;
+// Lowered from 0.7: banner rows that contain "2025Q4"-style text labels dilute
+// the numeric fraction of the rest of the grid even when the data body is purely
+// numeric.  0.35 allows detection when ~4 banner rows precede ~3 data rows.
+const GATE_REST_COLS_NUMERIC_FRACTION = 0.35;
 
 // Pass-through gate: top-row pattern.
 // First row is text-heavy AND the lower rows are numeric-heavy.
 const GATE_TOP_ROW_TEXT_FRACTION      = 0.6;
-const GATE_LOWER_ROWS_NUMERIC_FRACTION = 0.7;
+// Lowered from 0.7 for the same banner-dilution reason as above.
+const GATE_LOWER_ROWS_NUMERIC_FRACTION = 0.3;
 
 // Pass-through gate: overall text-heavy fallback.
 const GATE_OVERALL_TEXT_FRACTION    = 0.25;
-const GATE_OVERALL_NUMERIC_FRACTION = 0.5;
+// Lowered from 0.5: when both label columns and banner rows are present, the
+// overall numeric fraction of the whole grid can fall below 0.5 even for a
+// structurally valid research table.
+const GATE_OVERALL_NUMERIC_FRACTION = 0.3;
 const GATE_OVERALL_MIN_CELLS        = 12;
+
+// Banner row count safety cap.  More than this many rows classified as banner
+// before the first body row almost certainly means the selection spans multiple
+// tables (or includes unrelated content), not a single wide banner header.
+// Real survey tables have at most 4–5 banner rows; the threshold is set to 6.
+const MAX_BANNER_ROW_COUNT = 6;
 
 // Title row: sparse, no numeric cells, at least one text cell.
 const MAX_TITLE_ROW_NON_EMPTY_CELLS = 3;
@@ -81,17 +94,27 @@ function isCellEmpty(cell) {
   return cell === "" || cell === null || cell === undefined;
 }
 
+// Strict numeric pattern: the entire cell value (after trimming) must consist of
+// an optional sign, digits with an optional decimal separator (dot or comma), and
+// an optional trailing percent.  Mixed strings like "2025Q4", "(a)", or
+// "Волна (квартал)" do NOT match — parseFloat() would accept them because it
+// stops at the first non-numeric character, but these are header labels, not data.
+const STRICT_NUMERIC_RE = /^[+-]?(\d+([.,]\d*)?|\d*[.,]\d+)%?$/;
+
 function isNumericCell(cell) {
   if (typeof cell === "number") return !isNaN(cell);
   if (typeof cell !== "string") return false;
   const trimmed = cell.trim();
   if (!trimmed) return false;
-  return !isNaN(parseFloat(trimmed.replace(/,/g, ".")));
+  return STRICT_NUMERIC_RE.test(trimmed);
 }
 
 function isTextOnlyCell(cell) {
   if (typeof cell !== "string" || !cell.trim()) return false;
-  return isNaN(parseFloat(cell.trim().replace(/,/g, ".")));
+  // A non-empty string is "text-only" when it is NOT a strict numeric value.
+  // Using isNumericCell here keeps both functions consistent: anything that
+  // isNumericCell rejects (e.g. "2025Q4", "(a)") is correctly treated as text.
+  return !isNumericCell(cell);
 }
 
 // ─── Grid analysis helpers ────────────────────────────────────────────────────
@@ -228,7 +251,15 @@ function isTitleLikeRow(values, rowIndex, colCount) {
     if (isTextOnlyCell(cell)) hasText = true;
   }
 
-  return hasText && nonEmptyCount > 0 && nonEmptyCount <= MAX_TITLE_ROW_NON_EMPTY_CELLS;
+  if (!hasText || nonEmptyCount === 0 || nonEmptyCount > MAX_TITLE_ROW_NON_EMPTY_CELLS) {
+    return false;
+  }
+
+  // Title and subtitle rows originate from col[0] — the leftmost cell must be
+  // non-empty. A sparse row whose content is entirely in col[1]+ (common for
+  // Excel merged banner headers, where the merge value appears only in the
+  // top-left data cell) is a banner row, not a title or subtitle row.
+  return !isCellEmpty(row[0]);
 }
 
 /**
@@ -283,6 +314,61 @@ function detectBannerRows(values, startRow, rowCount, colCount) {
   }
 
   return bannerRows;
+}
+
+// ─── Body-start detection ─────────────────────────────────────────────────────
+
+/**
+ * Finds the first row that looks like a real data body row, scanning forward
+ * from startRow.
+ *
+ * A row qualifies when:
+ *   - col[0] is non-empty, AND
+ *   - at least one cell in cols[1..N-1] is numeric.
+ *
+ * This handles merged-like / sparse banner rows that detectBannerRows misses:
+ * Excel merged areas store text only in the top-left cell of the merge, so a
+ * banner row spanning many columns often looks like ["", "Всего", ""] with an
+ * empty col[0]. The first real data row, by contrast, always has a label in
+ * col[0] alongside numeric values to its right.
+ *
+ * Returns startRow as a safe fallback when no qualifying row is found before
+ * endRow (validation will then produce an appropriate blocking reason).
+ */
+function findFirstDataBodyRow(values, startRow, rowCount, colCount) {
+  if (colCount < 2) return startRow;
+  for (let r = startRow; r < rowCount; r++) {
+    const row = values[r] || [];
+    if (isCellEmpty(row[0])) continue;
+    for (let c = 1; c < colCount; c++) {
+      if (isNumericCell(row[c])) return r;
+    }
+  }
+  return startRow;
+}
+
+// ─── Body-end detection ───────────────────────────────────────────────────────
+
+/**
+ * Finds the last row at or before endRow that contains at least one numeric cell
+ * in the data columns [dataColStart, dataColEnd].
+ *
+ * Trailing rows that have only label content (col[0] text, empty data columns)
+ * are treated as footer rows and excluded from the validated body range.  This
+ * prevents a single-table selection with a trailing summary row (e.g. "Все
+ * респонденты" with empty data columns) from falsely triggering the
+ * BODY_APPEARS_MULTI_TABLE empty-gap check.
+ *
+ * Returns startRow as a safe fallback when no numeric row is found.
+ */
+function findLastDataBodyRow(values, startRow, endRow, dataColStart, dataColEnd) {
+  for (let r = endRow; r >= startRow; r--) {
+    const row = values[r] || [];
+    for (let c = dataColStart; c <= dataColEnd; c++) {
+      if (isNumericCell(row[c])) return r;
+    }
+  }
+  return startRow;
 }
 
 // ─── Label column detection ───────────────────────────────────────────────────
@@ -532,8 +618,12 @@ function buildNormalizedModel(
     ? sliceGrid(text, bodyStartRow, bodyEndRow, dataColStart, dataColEnd)
     : [];
 
+  // Significance marker removal (applied to values before normalization) can erase
+  // pure-letter label cells like "mean" or "BASE". Use text (Office.js selectedRange.text,
+  // never marker-stripped) when it covers the body rows.
+  const leftLabelSource = text.length > bodyEndRow ? text : values;
   const leftLabelValues = labelColCount > 0
-    ? sliceGrid(values, bodyStartRow, bodyEndRow, 0, labelColCount - 1)
+    ? sliceGrid(leftLabelSource, bodyStartRow, bodyEndRow, 0, labelColCount - 1)
     : [];
 
   // Banner scan rows are sliced to data columns only so they align with
@@ -610,9 +700,47 @@ export function normalizeSelectedRange(rawValues, rawText, options = {}) {
   // ── Step 2: Banner rows ────────────────────────────────────────────────────
   // Banner detection starts immediately after title/subtitle rows.
   const firstBodyCandidate = titleRows.length + subtitleRows.length;
-  const bannerRows = detectBannerRows(values, firstBodyCandidate, rowCount, colCount);
 
-  const bodyStartRow = firstBodyCandidate + bannerRows.length;
+  // Approach A: consecutive wide text-heavy rows (existing logic).
+  const wideBannerRowCount = detectBannerRows(values, firstBodyCandidate, rowCount, colCount).length;
+
+  // Approach B: scan for the first row where col[0] is non-empty AND at least
+  // one cell to its right is numeric. All rows before that point are treated as
+  // banner/header rows. This covers merged-like sparse header rows (Excel stores
+  // merged text only in the top-left cell, leaving col[0] empty in continuation
+  // rows) that approach A misses because their fill fraction is too low.
+  const firstDataBodyRow = findFirstDataBodyRow(values, firstBodyCandidate, rowCount, colCount);
+
+  // Use whichever approach identifies a later body start (more header rows).
+  const bodyStartRow = Math.max(firstBodyCandidate + wideBannerRowCount, firstDataBodyRow);
+  const bannerRows   = bodyStartRow > firstBodyCandidate
+    ? buildIndexRange(firstBodyCandidate, bodyStartRow - 1)
+    : [];
+
+  // Safety check: a legitimate single-table banner rarely exceeds MAX_BANNER_ROW_COUNT
+  // rows.  If more rows were classified as banner it almost certainly means the
+  // selection spans multiple tables (the first table's data rows were consumed into
+  // the header area because they looked text-heavy / non-numeric).
+  if (bannerRows.length > MAX_BANNER_ROW_COUNT) {
+    return buildBlockedModel(
+      rowCount,
+      colCount,
+      titleRows,
+      subtitleRows,
+      bannerRows,
+      0,
+      "medium",
+      [
+        {
+          code: "HEADER_AREA_TOO_LARGE",
+          message:
+            "Область заголовков слишком велика — возможно, выделено несколько таблиц. " +
+            "Выделите одну таблицу.",
+        },
+      ]
+    );
+  }
+
   const bodyEndRow   = rowCount - 1;
 
   // ── Step 3: Label columns ──────────────────────────────────────────────────
@@ -627,8 +755,13 @@ export function normalizeSelectedRange(rawValues, rawText, options = {}) {
   const dataColStart = labelColCount;
   const dataColEnd   = colCount - 1;
 
+  // ── Step 3b: Trim trailing footer rows ────────────────────────────────────
+  // Rows after the last numeric data row (e.g. a summary label with empty data
+  // columns) must not participate in the empty-gap check or in slicing outputs.
+  const bodyDataEndRow = findLastDataBodyRow(values, bodyStartRow, bodyEndRow, dataColStart, dataColEnd);
+
   // ── Step 4: Body validation ────────────────────────────────────────────────
-  const blockingReasons = validateBody(values, bodyStartRow, bodyEndRow, dataColStart, dataColEnd);
+  const blockingReasons = validateBody(values, bodyStartRow, bodyDataEndRow, dataColStart, dataColEnd);
 
   // Label split safety: uncertain split + body still text-heavy → unsafe to proceed.
   if (
@@ -638,7 +771,7 @@ export function normalizeSelectedRange(rawValues, rawText, options = {}) {
     const bodyTextFrac = computeTextFraction(
       values,
       bodyStartRow,
-      bodyEndRow,
+      bodyDataEndRow,
       dataColStart,
       dataColEnd
     );
@@ -660,7 +793,7 @@ export function normalizeSelectedRange(rawValues, rawText, options = {}) {
     const bodyNumericFrac = computeNumericFraction(
       values,
       bodyStartRow,
-      bodyEndRow,
+      bodyDataEndRow,
       dataColStart,
       dataColEnd
     );
@@ -725,7 +858,7 @@ export function normalizeSelectedRange(rawValues, rawText, options = {}) {
     dataColStart,
     dataColEnd,
     bodyStartRow,
-    bodyEndRow,
+    bodyDataEndRow,
     confidence,
     warnings
   );

--- a/src/taskpane/taskpane.js
+++ b/src/taskpane/taskpane.js
@@ -35,6 +35,8 @@ import { scanWorksheetForTables } from "../core/table-inventory-scanner";
 
 import { detectBannerStructure, formatBannerDetectionDiagnostics } from "../core/banner-detector";
 
+import { normalizeSelectedRange } from "../core/range-normalizer";
+
 const USER_VISIBLE_BANNER_MESSAGE_CODES = new Set([
   "GLOBAL_TOTAL_USED",
   "BANNER_AUTO_PREVIOUS_COLUMN_APPLIED",
@@ -951,17 +953,23 @@ async function runMetricDetectionDiagnostics() {
  * Reads selected range and calls buildTablePreviewModel to display a short summary.
  *
  * Read-only: does not write to Excel, does not calculate significance.
+ *
+ * Three normalizer states:
+ *   1. pass-through  — selection is numeric-only; existing flow runs unchanged.
+ *   2. normalized    — broad/full-table selection decomposed; normalized values used.
+ *   3. blocked       — broad selection but decomposition failed; early return with message.
  */
 async function runCheckTable() {
   await Excel.run(async (context) => {
     const calculationSettings = readCalculationSettingsFromPanel();
     const selectedRange = context.workbook.getSelectedRange();
 
-    selectedRange.load(["values", "rowIndex", "columnIndex", "rowCount", "columnCount"]);
+    selectedRange.load(["values", "text", "rowIndex", "columnIndex", "rowCount", "columnCount"]);
 
     await context.sync();
 
     const selectedValues = selectedRange.values;
+    const selectedText = selectedRange.text;
 
     if (!selectedValues || selectedValues.length < 1 || !selectedValues[0] || selectedValues[0].length < 1) {
       setCheckMessage("Нет данных в выделенном диапазоне.");
@@ -970,13 +978,48 @@ async function runCheckTable() {
 
     const cleanedValues = removeSignificanceMarkersFromMatrix(selectedValues);
 
-    const leftLabelValues = await loadLabelValuesForSelectedRange(
-      context,
-      selectedRange,
-      calculationSettings
-    );
+    const normalized = normalizeSelectedRange(cleanedValues, selectedText);
 
-    const model = buildTablePreviewModel({ values: cleanedValues, leftLabelValues });
+    // State 3: normalization needed but blocked — stop and show reason.
+    if (normalized.normalizationNeeded && !normalized.normalizationApplied) {
+      const codes = normalized.blockingReasons.length > 0
+        ? ` [${normalized.blockingReasons.join(", ")}]`
+        : "";
+      setCheckMessage(`${normalized.blockingMessage}${codes}`);
+      return;
+    }
+
+    let modelInput;
+    const normalizationLines = [];
+
+    if (normalized.normalizationNeeded && normalized.normalizationApplied) {
+      // State 2: broad selection successfully decomposed — use normalized partitions.
+      modelInput = {
+        values: normalized.valuesForCalculation,
+        leftLabelValues: normalized.leftLabelValues,
+        bannerContext: normalized.bannerContext,
+        settings: calculationSettings,
+      };
+
+      normalizationLines.push("Диапазон нормализован: заголовки/лейблы/баннер отделены от данных.");
+
+      const parts = [];
+      if (normalized.titleRows.length > 0) parts.push(`заголовков: ${normalized.titleRows.length}`);
+      if (normalized.subtitleRows.length > 0) parts.push(`подзаголовков: ${normalized.subtitleRows.length}`);
+      if (normalized.bannerRows.length > 0) parts.push(`строк баннера: ${normalized.bannerRows.length}`);
+      if (normalized.labelColumns.length > 0) parts.push(`колонок меток: ${normalized.labelColumns.length}`);
+      if (parts.length > 0) normalizationLines.push(`Отделено: ${parts.join(", ")}.`);
+    } else {
+      // State 1: numeric-only selection — existing flow unchanged.
+      const leftLabelValues = await loadLabelValuesForSelectedRange(
+        context,
+        selectedRange,
+        calculationSettings
+      );
+      modelInput = { values: cleanedValues, leftLabelValues };
+    }
+
+    const model = buildTablePreviewModel(modelInput);
     const { summary, qualitySummary, warnings } = model;
 
     if (summary.rowCount === 0) {
@@ -987,6 +1030,11 @@ async function runCheckTable() {
     const lines = [
       `Проверка завершена. Строк: ${summary.rowCount}. Блоков: ${summary.detectedBlocks}. Баз: ${summary.baseRows}. Предупреждений: ${qualitySummary.warningCount}. Критических: ${qualitySummary.criticalCount}.`,
     ];
+
+    if (normalizationLines.length > 0) {
+      lines.push("");
+      lines.push(...normalizationLines);
+    }
 
     if (warnings && warnings.length > 0) {
       lines.push("");

--- a/tests/core/range-normalizer.test.mjs
+++ b/tests/core/range-normalizer.test.mjs
@@ -48,6 +48,239 @@ describe("normalizeSelectedRange", () => {
     assert.deepStrictEqual(result.blockingReasons, []);
   });
 
+  it("sparse merged-like banner rows with title are normalized correctly", () => {
+    // Simulates a full-table selection where Excel merged cells produce sparse
+    // banner rows: text appears only in one column per row because Office.js
+    // returns the merge value only in the top-left cell.
+    //
+    // Row 0:   sparse title ("Ваш возраст" in col 0, rest empty)
+    // Rows 1-3: sparse banner (col 0 is empty; text only in col 1 or cols 1-2)
+    // Rows 4-11: body with label column (col 0) + numeric data (cols 1-2)
+    const values = [
+      ["Ваш возраст",     "",       ""      ],
+      ["",                "Всего",  ""      ],
+      ["",                "Волна",  ""      ],
+      ["",                "2025Q4", "2026Q1"],
+      ["19 и младше",     0.19,     0.15    ],
+      ["20-29",           0.37,     0.32    ],
+      ["от 30 до 40",     0.28,     0.28    ],
+      ["40 и старше",     0.17,     0.24    ],
+      ["mean",            29.4,     31.5    ],
+      ["variance",        103.6,    132.6   ],
+      ["BASE",            5605,     1320    ],
+      ["Все респонденты", 6925,     2640    ],
+    ];
+    const result = normalizeSelectedRange(values);
+
+    assert.strictEqual(result.normalizationNeeded, true);
+    assert.strictEqual(result.normalizationApplied, true);
+    assert.deepStrictEqual(result.titleRows, [0], "title row should be row 0");
+    assert.deepStrictEqual(result.bannerRows, [1, 2, 3], "sparse banner rows 1-3 should be detected");
+    assert.deepStrictEqual(result.labelColumns, [0], "col 0 should be identified as label column");
+    assert.strictEqual(result.dataRowOffset, 4, "body should start at row 4");
+    assert.strictEqual(result.dataColOffset, 1, "data columns should start at col 1");
+    assert.deepStrictEqual(
+      result.valuesForCalculation[0],
+      [0.19, 0.15],
+      "first valuesForCalculation row should be the first body data row"
+    );
+    assert.deepStrictEqual(result.blockingReasons, []);
+  });
+
+  it("full table with 2025Q4-style banner labels and percent strings normalizes correctly", () => {
+    // Simulates the full "Ваш пол" shape as it actually arrives from Excel:
+    //   - row 0: sparse title
+    //   - rows 1-4: sparse banner rows whose labels include "2025Q4", "(a)" etc.
+    //     These must be classified as TEXT (not numeric) so they are treated as
+    //     banner rows, not body rows.
+    //   - rows 5-7: data rows where values are percentage strings ("44%") or
+    //     numbers (5605).  "44%" must be classified as NUMERIC.
+    //   - row 8: trailing footer with empty data columns → trimmed away.
+    const values = [
+      ["Ваш пол:",          "",                    "",                   ""             ],
+      ["",                  "Всего",               "",                   "Пользование категорией"],
+      ["",                  "Волна (квартал)",     "Всё покупаю сам(а)", "Большую часть"],
+      ["",                  "2025Q4",              "2026Q1",             "2025Q4"       ],
+      ["",                  "(a)",                 "(a)",                "(a)"          ],
+      ["Мужской",           "44%",                 "41%",                "39%"          ],
+      ["Женский",           "56%",                 "59%",                "61%"          ],
+      ["BASE",              5605,                  1320,                 3083           ],
+      ["Все респонденты",   "",                    "",                   ""             ],
+    ];
+    const result = normalizeSelectedRange(values);
+
+    assert.strictEqual(result.normalizationNeeded, true);
+    assert.strictEqual(result.normalizationApplied, true, "must normalize, not block");
+    assert.deepStrictEqual(result.titleRows, [0], "row 0 is the sparse title");
+    assert.deepStrictEqual(result.bannerRows, [1, 2, 3, 4], "rows 1-4 are banner rows");
+    assert.deepStrictEqual(result.labelColumns, [0], "col 0 is the label column");
+    assert.strictEqual(result.dataRowOffset, 5, "body starts at row 5");
+    assert.strictEqual(result.valuesForCalculation.length, 3, "footer row excluded");
+    assert.deepStrictEqual(
+      result.valuesForCalculation[0],
+      ["44%", "41%", "39%"],
+      "first data row is Мужской with percent strings"
+    );
+    assert.deepStrictEqual(result.blockingReasons, []);
+  });
+
+  it("two-table broad selection blocks with BODY_APPEARS_MULTI_TABLE", () => {
+    // Two complete research tables stacked vertically.  The second table's sparse
+    // title row (content only in col 0, data cols empty) falls inside what the
+    // normalizer computes as the body, creating an all-empty-data-col gap that
+    // must trigger BODY_APPEARS_MULTI_TABLE.
+    const values = [
+      // Table 1
+      ["Таблица 1",  "",       "",       ""],
+      ["",           "Всего",  "Кат A",  ""],
+      ["",           "2025Q4", "2025Q4", ""],
+      ["Вариант A",  0.4,      0.3,      ""],
+      ["Вариант B",  0.6,      0.7,      ""],
+      ["BASE",       1000,     500,      ""],
+      // Table 2 — sparse title provides all-empty data cols → gap
+      ["Таблица 2",  "",       "",       ""],
+      ["",           "Всего",  "Кат B",  ""],
+      ["",           "2026Q1", "2026Q1", ""],
+      ["Вариант X",  0.5,      0.4,      ""],
+      ["Вариант Y",  0.5,      0.6,      ""],
+      ["BASE",       800,      400,      ""],
+    ];
+    const result = normalizeSelectedRange(values);
+
+    assert.strictEqual(result.normalizationNeeded, true);
+    assert.strictEqual(result.normalizationApplied, false);
+    assert.ok(
+      result.blockingReasons.includes("BODY_APPEARS_MULTI_TABLE") ||
+      result.blockingReasons.includes("HEADER_AREA_TOO_LARGE"),
+      `expected BODY_APPEARS_MULTI_TABLE or HEADER_AREA_TOO_LARGE, got: ${JSON.stringify(result.blockingReasons)}`
+    );
+  });
+
+  it("leftLabelValues uses rawText when values have significance markers stripped", () => {
+    // Root-cause regression test.
+    //
+    // taskpane.js calls removeSignificanceMarkersFromMatrix(selectedRange.values)
+    // before passing to normalizeSelectedRange. The marker-strip regex is
+    // /\s*[allLetters]+$/ — for cells whose entire content is letters, the whole
+    // value is erased: "mean" → "", "variance" → "", "BASE" → "".
+    //
+    // The fix: buildNormalizedModel slices leftLabelValues from rawText
+    // (Office.js selectedRange.text, never marker-stripped) rather than from the
+    // stripped values grid.
+    //
+    // This test simulates the stripping by passing "" in the label column for the
+    // three service rows while passing the original values as rawText.
+    const rawText = [
+      ["Ваш возраст",     "",       ""      ],
+      ["",                "Всего",  ""      ],
+      ["",                "Волна",  ""      ],
+      ["",                "2025Q4", "2026Q1"],
+      ["",                "(a)",    "(a)"   ],
+      ["19 и младше",     "19%",    "15%"   ],
+      ["20-29",           "37%",    "32%"   ],
+      ["от 30 до 40",     "28%",    "28%"   ],
+      ["40 и старше",     "17%",    "24%"   ],
+      ["mean",            "29,4",   "31,5"  ],
+      ["variance",        "103,6",  "132,6" ],
+      ["BASE",            "5605",   "1320"  ],
+      ["Все респонденты", "",       ""      ],
+    ];
+    // Simulate significance marker removal: pure-letter label cells → "".
+    const strippedValues = rawText.map((row, r) =>
+      [9, 10, 11].includes(r)
+        ? ["", row[1], row[2]]   // "mean"/"variance"/"BASE" erased
+        : row
+    );
+
+    const result = normalizeSelectedRange(strippedValues, rawText);
+
+    assert.strictEqual(result.normalizationApplied, true);
+    // Labels must come from rawText, not from strippedValues.
+    assert.deepStrictEqual(result.leftLabelValues[4], ["mean"],     "mean label preserved from text");
+    assert.deepStrictEqual(result.leftLabelValues[5], ["variance"], "variance label preserved from text");
+    assert.deepStrictEqual(result.leftLabelValues[6], ["BASE"],     "BASE label preserved from text");
+  });
+
+  it("Возраст full-table shape with service rows normalizes correctly", () => {
+    // Exact shape from Excel smoke test, values as strings (Russian comma-decimal,
+    // percent strings, quarter labels). Verifies leftLabelValues contains the
+    // service-row labels ("mean", "variance", "BASE") so buildTablePreviewModel
+    // can classify them correctly.
+    const values = [
+      ["Ваш возраст",     "",                   ""      ],
+      ["",                "Всего",              ""      ],
+      ["",                "Волна (квартал)",    ""      ],
+      ["",                "2025Q4",             "2026Q1"],
+      ["",                "(a)",                "(a)"   ],
+      ["19 и младше",     "19%",                "15%"   ],
+      ["20-29",           "37%",                "32%"   ],
+      ["от 30 до 40",     "28%",                "28%"   ],
+      ["40 и старше",     "17%",                "24%"   ],
+      ["mean",            "29,4",               "31,5"  ],
+      ["variance",        "103,6",              "132,6" ],
+      ["BASE",            "5605",               "1320"  ],
+      ["Все респонденты", "",                   ""      ],
+    ];
+    const result = normalizeSelectedRange(values);
+
+    assert.strictEqual(result.normalizationNeeded, true);
+    assert.strictEqual(result.normalizationApplied, true, "must normalize successfully");
+    assert.deepStrictEqual(result.titleRows, [0]);
+    assert.deepStrictEqual(result.bannerRows, [1, 2, 3, 4]);
+    assert.deepStrictEqual(result.labelColumns, [0]);
+    assert.strictEqual(result.dataRowOffset, 5);
+    assert.strictEqual(result.valuesForCalculation.length, 7, "trailing footer excluded");
+    assert.strictEqual(result.leftLabelValues.length, 7, "leftLabelValues must have 7 rows");
+    assert.deepStrictEqual(result.leftLabelValues[0], ["19 и младше"], "first body label");
+    assert.deepStrictEqual(result.leftLabelValues[4], ["mean"],     "mean row label");
+    assert.deepStrictEqual(result.leftLabelValues[5], ["variance"], "variance row label");
+    assert.deepStrictEqual(result.leftLabelValues[6], ["BASE"],     "BASE row label");
+    assert.deepStrictEqual(result.blockingReasons, []);
+  });
+
+  it("trailing label-only footer row is excluded from body, normalization succeeds", () => {
+    // Simulates "Ваш пол" shape: sparse banner rows at top, two data rows,
+    // then "Все респонденты" which has a label in col[0] but empty data columns.
+    // The footer row must be trimmed so it does not trigger BODY_APPEARS_MULTI_TABLE.
+    const values = [
+      ["Ваш пол:",         "",       ""      ],
+      ["",                 "Всего",  ""      ],
+      ["",                 "2025Q4", "2026Q1"],
+      ["Мужской",          0.44,     0.41    ],
+      ["Женский",          0.56,     0.59    ],
+      ["BASE",             5605,     1320    ],
+      ["Все респонденты",  "",       ""      ],
+    ];
+    const result = normalizeSelectedRange(values);
+    assert.strictEqual(result.normalizationNeeded, true);
+    assert.strictEqual(result.normalizationApplied, true);
+    assert.deepStrictEqual(result.blockingReasons, [], "footer row must not trigger BODY_APPEARS_MULTI_TABLE");
+    assert.strictEqual(result.valuesForCalculation.length, 3, "footer row must be excluded from valuesForCalculation");
+    assert.deepStrictEqual(result.valuesForCalculation[0], [0.44, 0.41], "first data row");
+    assert.deepStrictEqual(result.valuesForCalculation[2], [5605, 1320], "BASE row included");
+  });
+
+  it("multi-table selection with mid-body empty row blocks normalization with BODY_APPEARS_MULTI_TABLE", () => {
+    // Two groups of data rows separated by a fully empty row.
+    // The empty row lies between actual numeric rows so bodyDataEndRow does NOT
+    // trim it away — the gap check must fire and block normalization.
+    const values = [
+      ["Группа",  "A",  "B",  "C" ],
+      ["Label1",  10,   20,   30  ],
+      ["Label2",  40,   50,   60  ],
+      [null,      null, null, null],
+      ["Label3",  70,   80,   90  ],
+      ["Label4",  10,   20,   30  ],
+    ];
+    const result = normalizeSelectedRange(values);
+    assert.strictEqual(result.normalizationNeeded, true);
+    assert.strictEqual(result.normalizationApplied, false);
+    assert.ok(
+      result.blockingReasons.includes("BODY_APPEARS_MULTI_TABLE"),
+      `expected BODY_APPEARS_MULTI_TABLE in blockingReasons, got: ${JSON.stringify(result.blockingReasons)}`
+    );
+  });
+
   it("empty row inside body blocks normalization with BODY_APPEARS_MULTI_TABLE", () => {
     // Row 0: wide banner header. Rows 1-2 and 4-5: data. Row 3: empty gap.
     // The gap triggers the multi-table blocking reason.

--- a/tests/core/table-preview-model.test.mjs
+++ b/tests/core/table-preview-model.test.mjs
@@ -1,6 +1,7 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import { buildTablePreviewModel } from "../../src/core/table-preview-model.js";
+import { normalizeSelectedRange } from "../../src/core/range-normalizer.js";
 
 // Minimal 3-row data grid with one base row and two proportion rows.
 // Labels are supplied via leftLabelValues; values are plain proportions.
@@ -17,6 +18,58 @@ function makeModel(labels) {
 function warnCodes(model) {
   return model.warnings.map((w) => w.code);
 }
+
+describe("buildTablePreviewModel – Возраст normalized integration", () => {
+  // Full "Возраст" shape as it arrives from Excel: percentage strings,
+  // Russian comma-decimal service rows, trailing "Все респонденты" footer.
+  const vozrastValues = [
+    ["Ваш возраст",     "",                ""],
+    ["",                "Всего",           ""],
+    ["",                "Волна (квартал)", ""],
+    ["",                "2025Q4",          "2026Q1"],
+    ["",                "(a)",             "(a)"],
+    ["19 и младше",     "19%",             "15%"],
+    ["20-29",           "37%",             "32%"],
+    ["от 30 до 40",     "28%",             "28%"],
+    ["40 и старше",     "17%",             "24%"],
+    ["mean",            "29,4",            "31,5"],
+    ["variance",        "103,6",           "132,6"],
+    ["BASE",            "5605",            "1320"],
+    ["Все респонденты", "",                ""],
+  ];
+
+  it("normalizer produces leftLabelValues with mean/variance/BASE", () => {
+    const norm = normalizeSelectedRange(vozrastValues);
+    assert.strictEqual(norm.normalizationApplied, true);
+    assert.deepStrictEqual(norm.leftLabelValues[4], ["mean"]);
+    assert.deepStrictEqual(norm.leftLabelValues[5], ["variance"]);
+    assert.deepStrictEqual(norm.leftLabelValues[6], ["BASE"]);
+  });
+
+  it("buildTablePreviewModel receives mean/variance/BASE as service rows, no MISSING_ROW_LABEL_WITH_DATA for them", () => {
+    const norm = normalizeSelectedRange(vozrastValues);
+    assert.strictEqual(norm.normalizationApplied, true, "normalization must succeed first");
+
+    const model = buildTablePreviewModel({
+      values: norm.valuesForCalculation,
+      leftLabelValues: norm.leftLabelValues,
+      bannerContext: norm.bannerContext,
+    });
+
+    // mean/variance/BASE are service rows — no MISSING_ROW_LABEL_WITH_DATA for them.
+    const missingLabelWarnings = model.warnings.filter(
+      (w) => w.code === "MISSING_ROW_LABEL_WITH_DATA"
+    );
+    assert.strictEqual(
+      missingLabelWarnings.length,
+      0,
+      `expected 0 MISSING_ROW_LABEL_WITH_DATA warnings but got: ${JSON.stringify(missingLabelWarnings)}`
+    );
+
+    // BASE must be detected.
+    assert.ok(model.summary.baseRows > 0, `expected at least 1 base row; summary: ${JSON.stringify(model.summary)}`);
+  });
+});
 
 describe("buildTablePreviewModel – label warnings", () => {
   it('"q12" emits SUSPICIOUS_CODE_LIKE_LABEL', () => {


### PR DESCRIPTION
﻿## Summary

Wires selected range normalization into the read-only Check table flow.

Behavior:
- Numeric-only selections keep the existing Check table path.
- Broad/full-table selections that normalize successfully are passed to buildTablePreviewModel using normalized values, labels, and banner context.
- Blocked broad selections show the normalizer blocking message and stop instead of interpreting the raw broad selection.
- Full-table selections with merged-like sparse banner/header rows are handled by detecting the first real data body row.
- Trailing label-only footer rows are excluded from the normalized body.
- Service-row labels such as mean / variance / BASE are preserved by slicing leftLabelValues from selectedRange.text rather than marker-stripped values.

No Excel writes are added.

## Scope

Changed:
- src/taskpane/taskpane.js
- src/core/range-normalizer.js
- tests/core/range-normalizer.test.mjs
- tests/core/table-preview-model.test.mjs

No changes to:
- Run significance
- Clear significance
- Excel writer
- Core statistics logic
- Table Inventory
- Test runner/package setup

## Validation

- npm test passes
- npm run build passes with existing webpack asset-size warnings only
- Manual smoke passed:
  - numeric-only Check table behaves as before
  - full-table Check table normalizes title/banner/labels and uses data body
  - service rows mean / variance / BASE keep labels and are not treated as missing-label rows
  - multi-table broad selection blocks instead of interpreting raw broad selection

Closes #86
