### PR TITLE
Normalize Run selections to data body

### DIFF
--- a/src/core/range-normalizer.js
+++ b/src/core/range-normalizer.js
@@ -518,6 +518,16 @@ function buildIndexRange(start, end) {
   return arr;
 }
 
+function hasUsableTextGrid(text, rowCount, colCount) {
+  return (
+    Array.isArray(text) &&
+    text.length >= rowCount &&
+    rowCount > 0 &&
+    Array.isArray(text[0]) &&
+    text[0].length >= colCount
+  );
+}
+
 // ─── Model builders ───────────────────────────────────────────────────────────
 
 function buildPassThroughModel(rowCount, colCount) {
@@ -629,8 +639,10 @@ function buildNormalizedModel(
   // Banner scan rows are sliced to data columns only so they align with
   // valuesForCalculation. detectBannerStructure expects column indices to
   // match the data grid, not the full raw selection width.
+  const lastBannerRow = bannerRows.length > 0 ? bannerRows[bannerRows.length - 1] : -1;
+  const bannerSource = text.length > lastBannerRow ? text : values;
   const bannerScanRows = bannerRows.length > 0
-    ? sliceGrid(values, bannerRows[0], bannerRows[bannerRows.length - 1], dataColStart, dataColEnd)
+    ? sliceGrid(bannerSource, bannerRows[0], bannerRows[bannerRows.length - 1], dataColStart, dataColEnd)
     : [];
 
   const bannerContext = {
@@ -684,32 +696,47 @@ export function normalizeSelectedRange(rawValues, rawText, options = {}) {
   const text     = Array.isArray(rawText)   ? rawText   : [];
   const rowCount = values.length;
   const colCount = rowCount > 0 && Array.isArray(values[0]) ? values[0].length : 0;
+  const structureValues = hasUsableTextGrid(text, rowCount, colCount) ? text : values;
 
   // ── Step 0: Pass-through gate ──────────────────────────────────────────────
   // If the selection looks like numeric-only data, return immediately.
   // The existing strict workflow must run unchanged for this state.
-  if (!isNormalizationNeeded(values, rowCount, colCount)) {
+  if (!isNormalizationNeeded(structureValues, rowCount, colCount)) {
     return buildPassThroughModel(rowCount, colCount);
   }
 
   // Normalization is needed. Attempt structural decomposition.
 
   // ── Step 1: Title / subtitle rows ─────────────────────────────────────────
-  const { titleRows, subtitleRows } = detectTitleSubtitleRows(values, rowCount, colCount);
+  const { titleRows, subtitleRows } = detectTitleSubtitleRows(
+    structureValues,
+    rowCount,
+    colCount
+  );
 
   // ── Step 2: Banner rows ────────────────────────────────────────────────────
   // Banner detection starts immediately after title/subtitle rows.
   const firstBodyCandidate = titleRows.length + subtitleRows.length;
 
   // Approach A: consecutive wide text-heavy rows (existing logic).
-  const wideBannerRowCount = detectBannerRows(values, firstBodyCandidate, rowCount, colCount).length;
+  const wideBannerRowCount = detectBannerRows(
+    structureValues,
+    firstBodyCandidate,
+    rowCount,
+    colCount
+  ).length;
 
   // Approach B: scan for the first row where col[0] is non-empty AND at least
   // one cell to its right is numeric. All rows before that point are treated as
   // banner/header rows. This covers merged-like sparse header rows (Excel stores
   // merged text only in the top-left cell, leaving col[0] empty in continuation
   // rows) that approach A misses because their fill fraction is too low.
-  const firstDataBodyRow = findFirstDataBodyRow(values, firstBodyCandidate, rowCount, colCount);
+  const firstDataBodyRow = findFirstDataBodyRow(
+    structureValues,
+    firstBodyCandidate,
+    rowCount,
+    colCount
+  );
 
   // Use whichever approach identifies a later body start (more header rows).
   const bodyStartRow = Math.max(firstBodyCandidate + wideBannerRowCount, firstDataBodyRow);
@@ -746,7 +773,7 @@ export function normalizeSelectedRange(rawValues, rawText, options = {}) {
   // ── Step 3: Label columns ──────────────────────────────────────────────────
   // Applied over body rows only (title/subtitle/banner already excluded).
   const { labelColCount, labelSplitConfidence } = detectLabelColumns(
-    values,
+    structureValues,
     bodyStartRow,
     bodyEndRow,
     colCount

--- a/src/taskpane/taskpane.js
+++ b/src/taskpane/taskpane.js
@@ -591,16 +591,9 @@ async function runSignificanceFromSelection() {
       return;
     }
 
-    selectedRange.load(["rowIndex", "columnIndex", "rowCount", "columnCount"]);
+    selectedRange.load(["address", "rowIndex", "columnIndex", "rowCount", "columnCount"]);
 
     await context.sync();
-
-    if (calculationSettings.writeBannerLetters && selectedRange.rowIndex === 0) {
-      outputElement.textContent =
-        "Данные расположены в первой строке. Добавьте строку над выделенным массивом и запустите расчёт повторно.";
-
-      return;
-    }
 
     if (
       calculationSettings.compareWithPreviousColumn &&
@@ -612,10 +605,14 @@ async function runSignificanceFromSelection() {
       return;
     }
 
-    selectedRange.load(["values", "text", "rowIndex", "columnIndex", "rowCount", "columnCount"]);
-
-    selectedRange.format.horizontalAlignment = "Center";
-    selectedRange.format.verticalAlignment = "Center";
+    selectedRange.load([
+      "values",
+      "text",
+      "rowIndex",
+      "columnIndex",
+      "rowCount",
+      "columnCount",
+    ]);
 
     await context.sync();
 
@@ -628,24 +625,103 @@ async function runSignificanceFromSelection() {
     }
 
     const cleanedValues = removeSignificanceMarkersFromMatrix(selectedValues);
-    const selectedRangeGuardrailWarnings = detectSelectedRangeGuardrails(selectedText, cleanedValues);
+    const normalized = normalizeSelectedRange(cleanedValues, selectedText);
 
-    selectedRange.values = cleanedValues;
+    if (normalized.normalizationNeeded && !normalized.normalizationApplied) {
+      const codes =
+        normalized.blockingReasons && normalized.blockingReasons.length > 0
+          ? ` [${normalized.blockingReasons.join(", ")}]`
+          : "";
 
-    selectedRange.format.font.bold = false;
-    selectedRange.format.fill.clear();
-    selectedRange.format.horizontalAlignment = "Center";
-    selectedRange.format.verticalAlignment = "Center";
+      setStatusMessage(`${normalized.blockingMessage}${codes}`);
+      return;
+    }
+
+    const rawSelectedRangeGuardrailWarnings = detectSelectedRangeGuardrails(
+      selectedText,
+      cleanedValues
+    );
+
+    const runModel = {
+      values: cleanedValues,
+      text: selectedText,
+      leftLabelValues: null,
+      bannerContext: null,
+      writeTargetRange: selectedRange,
+      targetStartRowIndex: selectedRange.rowIndex,
+      normalizationApplied: false,
+      normalizationStatusLines: [],
+      selectedRangeGuardrailWarnings: rawSelectedRangeGuardrailWarnings,
+    };
+
+    if (normalized.normalizationNeeded && normalized.normalizationApplied) {
+      if (
+        !normalized.valuesForCalculation ||
+        normalized.valuesForCalculation.length < 2 ||
+        !normalized.valuesForCalculation[0] ||
+        normalized.valuesForCalculation[0].length < 2
+      ) {
+        setStatusMessage("Please select at least 2 columns and 2 rows.");
+        return;
+      }
+
+      runModel.values = normalized.valuesForCalculation;
+      runModel.text = normalized.textForCalculation;
+      runModel.leftLabelValues = normalized.leftLabelValues;
+      runModel.bannerContext = normalized.bannerContext;
+      runModel.writeTargetRange = selectedRange
+        .getCell(normalized.dataRowOffset, normalized.dataColOffset)
+        .getResizedRange(
+          normalized.valuesForCalculation.length - 1,
+          normalized.valuesForCalculation[0].length - 1
+        );
+      runModel.targetStartRowIndex = selectedRange.rowIndex + normalized.dataRowOffset;
+      runModel.normalizationApplied = true;
+      runModel.normalizationStatusLines.push(
+        "Диапазон нормализован: расчёт выполнен только по области данных."
+      );
+      runModel.selectedRangeGuardrailWarnings = [];
+    } else {
+      runModel.leftLabelValues = await loadLabelValuesForSelectedRange(
+        context,
+        selectedRange,
+        calculationSettings
+      ); // Labels located 1-2 columns to the left of the selected data.
+    }
+
+    if (!runModel.values || runModel.values.length < 2 || runModel.values[0].length < 2) {
+      setStatusMessage("Please select at least 2 columns and 2 rows.");
+      return;
+    }
+
+    runModel.writeTargetRange.load(["rowIndex", "columnIndex", "rowCount", "columnCount"]);
 
     await context.sync();
 
-    const leftLabelValues = await loadLabelValuesForSelectedRange(
-      context,
-      selectedRange,
-      calculationSettings
-    ); // Labels located 1-2 columns to the left of the selected data.
+    runModel.targetStartRowIndex = runModel.writeTargetRange.rowIndex;
 
-    const detectionResult = detectMetricRowsFromLeftLabels(cleanedValues, leftLabelValues); // Row type diagnostics based on left-side labels.
+    if (calculationSettings.writeBannerLetters && runModel.targetStartRowIndex === 0) {
+      outputElement.textContent =
+        "Данные расположены в первой строке. Добавьте строку над выделенным массивом и запустите расчёт повторно.";
+
+      return;
+    }
+
+    runModel.writeTargetRange.values = runModel.values;
+
+    runModel.writeTargetRange.format.font.bold = false;
+    runModel.writeTargetRange.format.fill.clear();
+    runModel.writeTargetRange.format.horizontalAlignment = "Center";
+    runModel.writeTargetRange.format.verticalAlignment = "Center";
+
+    await context.sync();
+
+    const selectedRangeGuardrailWarnings = runModel.selectedRangeGuardrailWarnings;
+
+    const detectionResult = detectMetricRowsFromLeftLabels(
+      runModel.values,
+      runModel.leftLabelValues
+    ); // Row type diagnostics based on left-side labels.
 
     const calculationBlocks = buildCalculationBlocks(detectionResult); // List of metric blocks to calculate.
 
@@ -662,11 +738,13 @@ async function runSignificanceFromSelection() {
     let bannerStructure = null;
 
     if (calculationSettings.respectBannerStructure) {
-      const bannerContext = await loadBannerContextForSelectedRange(
-        context,
-        selectedRange,
-        calculationSettings
-      );
+      const bannerContext =
+        buildRunBannerContext(runModel.bannerContext) ||
+        (await loadBannerContextForSelectedRange(
+          context,
+          runModel.writeTargetRange,
+          calculationSettings
+        ));
 
       bannerStructure = detectBannerStructure(bannerContext, calculationSettings);
 
@@ -683,13 +761,13 @@ async function runSignificanceFromSelection() {
     }
 
     const fullCellResultMatrix = createEmptyCellResultMatrix(
-      cleanedValues.length,
-      cleanedValues[0].length
-    ); // Full-size marker storage matching the selected range.
+      runModel.values.length,
+      runModel.values[0].length
+    ); // Full-size marker storage matching the data body being calculated.
 
     for (const calculationBlock of calculationBlocks) {
       const smallBaseResult = applySmallBaseRulesForCalculationBlock(
-        cleanedValues,
+        runModel.values,
         calculationBlock,
         fullCellResultMatrix,
         calculationSettings
@@ -712,7 +790,7 @@ async function runSignificanceFromSelection() {
       };
 
       const blockResults = calculateBlockResults(
-        cleanedValues,
+        runModel.values,
         calculationBlock,
         blockCalculationSettings
       );
@@ -732,9 +810,10 @@ async function runSignificanceFromSelection() {
         }
 
         setStatusMessage(
-          appendSelectedRangeGuardrailMessages(statusMessages, selectedRangeGuardrailWarnings).join(
-            "\n"
-          )
+          appendSelectedRangeGuardrailMessages(
+            statusMessages,
+            selectedRangeGuardrailWarnings
+          ).join("\n")
         );
         return;
       }
@@ -755,8 +834,8 @@ async function runSignificanceFromSelection() {
     keepMarkersOnlyInAllowedRows(fullCellResultMatrix, allowedMarkerRows);
 
     writeCellResultsToSelectedRange(
-      selectedRange,
-      selectedText,
+      runModel.writeTargetRange,
+      runModel.text,
       fullCellResultMatrix,
       detectionResult,
       calculationSettings
@@ -766,18 +845,27 @@ async function runSignificanceFromSelection() {
       if (calculationSettings.respectBannerStructure && bannerStructure) {
         await writeBannerMarkersAboveSelectedRangeUsingBannerStructure(
           context,
-          selectedRange,
+          runModel.writeTargetRange,
           bannerStructure,
           calculationSettings
         );
       } else {
-        await writeBannerMarkersAboveSelectedRange(context, selectedRange, calculationSettings);
+        await writeBannerMarkersAboveSelectedRange(
+          context,
+          runModel.writeTargetRange,
+          calculationSettings
+        );
       }
     }
 
     await context.sync();
 
     const statusMessages = [`Расчёт выполнен. Обработано блоков: ${calculationBlocks.length}.`];
+
+    if (runModel.normalizationStatusLines.length > 0) {
+      statusMessages.push("");
+      statusMessages.push(...runModel.normalizationStatusLines);
+    }
 
     const bannerUserMessages = formatBannerUserMessages(bannerStructure);
 
@@ -790,6 +878,33 @@ async function runSignificanceFromSelection() {
       appendSelectedRangeGuardrailMessages(statusMessages, selectedRangeGuardrailWarnings).join("\n")
     );
   });
+}
+
+/**
+ * Converts normalized banner context into the shape used by Run banner detection.
+ */
+function buildRunBannerContext(bannerContext) {
+  if (!bannerContext) {
+    return null;
+  }
+
+  if (bannerContext.selectedColumnCount !== undefined) {
+    return bannerContext;
+  }
+
+  const scanRows = Array.isArray(bannerContext.scanRows) ? bannerContext.scanRows : [];
+  const selectedColumnCount = bannerContext.columnCount || 0;
+
+  if (!selectedColumnCount || scanRows.length === 0) {
+    return null;
+  }
+
+  return {
+    selectedColumnCount,
+    lowerBannerRow: scanRows[scanRows.length - 1],
+    upperScanRows: scanRows.slice(0, -1).reverse(),
+    messages: bannerContext.messages || [],
+  };
 }
 
 /**

--- a/tests/core/range-normalizer.test.mjs
+++ b/tests/core/range-normalizer.test.mjs
@@ -2,6 +2,12 @@ import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import { normalizeSelectedRange } from "../../src/core/range-normalizer.js";
 
+function makeRunCleanedValues(rawText, bodyRowIndexes) {
+  return rawText.map((row, rowIndex) =>
+    bodyRowIndexes.includes(rowIndex) ? ["", ...row.slice(1)] : [...row]
+  );
+}
+
 describe("normalizeSelectedRange", () => {
   it("numeric-only selection passes through unchanged", () => {
     const values = [
@@ -122,6 +128,92 @@ describe("normalizeSelectedRange", () => {
       "first data row is Мужской with percent strings"
     );
     assert.deepStrictEqual(result.blockingReasons, []);
+  });
+
+  it("real sparse 4-row banner + proportion body normalizes from Run cleaned values", () => {
+    const rawText = [
+      ["Ваш пол:", "", "", "", "", "", "", "", "", "", "", "", ""],
+      ["", "", "", "Пользование кат", "", "", "", "", "", "", "", "", ""],
+      ["", "Волна (квартал)", "", "Всё покупаю сам(а)", "", "Большую часть", "", "", "", "", "", "", ""],
+      ["", "2025Q4", "2026Q1", "Волна (квартал)", "", "Волна (квартал)", "", "", "", "", "", "", ""],
+      ["", "", "", "2025Q4", "2026Q1", "2025Q4", "2026Q1", "2025Q4", "2026Q1", "2025Q4", "2026Q1", "2025Q4", "2026Q1"],
+      ["Мужской", "0.5", "0.4136", "0.39", "0.41", "0.44", "0.42", "0.48", "0.43", "0.51", "0.49", "0.46", "0.45"],
+      ["Женский", "0.5", "0.5863", "0.61", "0.59", "0.56", "0.58", "0.52", "0.57", "0.49", "0.51", "0.54", "0.55"],
+      ["BASE", "5605", "1320", "3083", "1045", "2200", "900", "1800", "760", "1500", "700", "1300", "620"],
+    ];
+    const cleanedValues = makeRunCleanedValues(rawText, [5, 6, 7]);
+
+    const result = normalizeSelectedRange(cleanedValues, rawText);
+
+    assert.strictEqual(result.normalizationNeeded, true);
+    assert.strictEqual(result.normalizationApplied, true);
+    assert.deepStrictEqual(result.titleRows, [0]);
+    assert.deepStrictEqual(result.bannerRows, [1, 2, 3, 4]);
+    assert.deepStrictEqual(result.labelColumns, [0]);
+    assert.strictEqual(result.dataRowOffset, 5);
+    assert.strictEqual(result.dataColOffset, 1);
+    assert.strictEqual(result.valuesForCalculation.length, 3);
+    assert.strictEqual(result.valuesForCalculation[0].length, 12);
+    assert.deepStrictEqual(result.valuesForCalculation[0].slice(0, 3), ["0.5", "0.4136", "0.39"]);
+    assert.deepStrictEqual(result.leftLabelValues, [["Мужской"], ["Женский"], ["BASE"]]);
+    assert.strictEqual(result.bannerContext.scanRows.length, 4);
+    assert.strictEqual(result.bannerContext.columnCount, 12);
+    assert.deepStrictEqual(result.bannerContext.scanRows[0].slice(0, 4), ["", "", "Пользование кат", ""]);
+  });
+
+  it("real sparse 4-row banner + means body preserves service labels from Run text", () => {
+    const rawText = [
+      ["Ваш возраст", "", "", "", "", "", "", "", "", "", "", "", ""],
+      ["", "", "", "Пользование кат", "", "", "", "", "", "", "", "", ""],
+      ["", "Волна (квартал)", "", "Всё покупаю сам(а)", "", "Большую часть", "", "", "", "", "", "", ""],
+      ["", "2025Q4", "2026Q1", "Волна (квартал)", "", "Волна (квартал)", "", "", "", "", "", "", ""],
+      ["", "", "", "2025Q4", "2026Q1", "2025Q4", "2026Q1", "2025Q4", "2026Q1", "2025Q4", "2026Q1", "2025Q4", "2026Q1"],
+      ["Среднее", "29.4", "31.5", "30.1", "32.2", "28.9", "30.7", "33.0", "34.1", "27.5", "28.0", "35.2", "36.4"],
+      ["variance", "103.6", "132.6", "120.1", "140.4", "99.2", "118.8", "150.0", "160.1", "90.5", "95.2", "170.4", "180.3"],
+      ["BASE", "5605", "1320", "3083", "1045", "2200", "900", "1800", "760", "1500", "700", "1300", "620"],
+    ];
+    const cleanedValues = makeRunCleanedValues(rawText, [5, 6, 7]);
+
+    const result = normalizeSelectedRange(cleanedValues, rawText);
+
+    assert.strictEqual(result.normalizationNeeded, true);
+    assert.strictEqual(result.normalizationApplied, true);
+    assert.deepStrictEqual(result.titleRows, [0]);
+    assert.deepStrictEqual(result.bannerRows, [1, 2, 3, 4]);
+    assert.deepStrictEqual(result.labelColumns, [0]);
+    assert.strictEqual(result.dataRowOffset, 5);
+    assert.strictEqual(result.dataColOffset, 1);
+    assert.strictEqual(result.valuesForCalculation.length, 3);
+    assert.deepStrictEqual(result.leftLabelValues, [["Среднее"], ["variance"], ["BASE"]]);
+    assert.strictEqual(result.bannerContext.scanRows.length, 4);
+  });
+
+  it("real-like multi-table broad selection with Run text still blocks", () => {
+    const rawText = [
+      ["Таблица 1", "", "", ""],
+      ["", "Всего", "Кат A", ""],
+      ["", "2025Q4", "2025Q4", ""],
+      ["Вариант A", "0.4", "0.3", ""],
+      ["Вариант B", "0.6", "0.7", ""],
+      ["BASE", "1000", "500", ""],
+      ["Таблица 2", "", "", ""],
+      ["", "Всего", "Кат B", ""],
+      ["", "2026Q1", "2026Q1", ""],
+      ["Вариант X", "0.5", "0.4", ""],
+      ["Вариант Y", "0.5", "0.6", ""],
+      ["BASE", "800", "400", ""],
+    ];
+    const cleanedValues = makeRunCleanedValues(rawText, [3, 4, 5, 9, 10, 11]);
+
+    const result = normalizeSelectedRange(cleanedValues, rawText);
+
+    assert.strictEqual(result.normalizationNeeded, true);
+    assert.strictEqual(result.normalizationApplied, false);
+    assert.ok(
+      result.blockingReasons.includes("BODY_APPEARS_MULTI_TABLE") ||
+      result.blockingReasons.includes("HEADER_AREA_TOO_LARGE"),
+      `expected multi-table blocking reason, got: ${JSON.stringify(result.blockingReasons)}`
+    );
   });
 
   it("two-table broad selection blocks with BODY_APPEARS_MULTI_TABLE", () => {


### PR DESCRIPTION
## Summary
- Integrates selected range normalization into Run significance.
- Automatically narrows safe full-table selections to the detected data body before cleanup, calculation, and writing.
- Blocks unsafe broad selections before any Excel mutation.
- Updates range normalization to use raw text for structural detection when cleaned values may have marker-stripped labels.
- Adds regression coverage for real sparse full-table banner shapes with proportions and means/service rows.

## Validation
- npm test
- npm run build
- Manual Excel smoke:
  - strict data-only selection works unchanged
  - full-table selection works with banner letters on/off
  - full-table selection works with respect banner structure on/off
  - multi-table broad selection blocks safely
