### PR TITLE
Fix full-table repeat-run normalization

### DIFF
--- a/src/core/range-normalizer.js
+++ b/src/core/range-normalizer.js
@@ -84,6 +84,12 @@ const LABEL_NUMERIC_THRESHOLD       = 0.5;
 // Blocking: label split is uncertain AND body is still text-heavy → unsafe.
 const LABEL_BLOCKING_BODY_TEXT_FRACTION = 0.4;
 
+// Extended NPS tables often use numeric-looking scale labels in the first
+// column ("1".."10"). Keep this high enough that ordinary numeric columns do
+// not become labels unless the NPS support rows are also present.
+const NPS_SCALE_LABEL_MIN_COUNT = 5;
+const NPS_SCALE_RIGHT_NUMERIC_FRACTION = 0.6;
+
 // Confidence thresholds on body numeric fraction.
 const CONFIDENCE_HIGH_NUMERIC   = 0.7;
 const CONFIDENCE_MEDIUM_NUMERIC = 0.5;
@@ -100,6 +106,8 @@ function isCellEmpty(cell) {
 // "Волна (квартал)" do NOT match — parseFloat() would accept them because it
 // stops at the first non-numeric character, but these are header labels, not data.
 const STRICT_NUMERIC_RE = /^[+-]?(\d+([.,]\d*)?|\d*[.,]\d+)%?$/;
+const NUMERIC_WITH_MARKER_SUFFIX_RE =
+  /^([+-]?(\d+([.,]\d*)?|\d*[.,]\d+)%?)(\s+[\p{L}↑↓]+)+$/u;
 
 function isNumericCell(cell) {
   if (typeof cell === "number") return !isNaN(cell);
@@ -115,6 +123,23 @@ function isTextOnlyCell(cell) {
   // Using isNumericCell here keeps both functions consistent: anything that
   // isNumericCell rejects (e.g. "2025Q4", "(a)") is correctly treated as text.
   return !isNumericCell(cell);
+}
+
+function cleanStructuralTextCell(cell) {
+  if (typeof cell !== "string") {
+    return cell;
+  }
+
+  const trimmed = cell.trim();
+  const match = trimmed.match(NUMERIC_WITH_MARKER_SUFFIX_RE);
+
+  return match ? match[1] : cell;
+}
+
+function cleanStructuralTextGrid(text) {
+  return text.map((row) =>
+    Array.isArray(row) ? row.map((cell) => cleanStructuralTextCell(cell)) : row
+  );
 }
 
 // ─── Grid analysis helpers ────────────────────────────────────────────────────
@@ -393,10 +418,16 @@ function detectLabelColumns(values, bodyStartRow, bodyEndRow, colCount) {
   const col0Frac = computeTextFraction(values, bodyStartRow, bodyEndRow, 0, 0);
 
   if (col0Frac < LABEL_NUMERIC_THRESHOLD) {
+    if (isExtendedNpsScaleLabelColumn(values, bodyStartRow, bodyEndRow, colCount)) {
+      return { labelColCount: 1, labelSplitConfidence: "confident" };
+    }
     return { labelColCount: 0, labelSplitConfidence: "confident" };
   }
 
   if (col0Frac < LABEL_TEXT_FRACTION_THRESHOLD) {
+    if (isExtendedNpsScaleLabelColumn(values, bodyStartRow, bodyEndRow, colCount)) {
+      return { labelColCount: 1, labelSplitConfidence: "confident" };
+    }
     // Ambiguous: col[0] is neither clearly text nor clearly numeric.
     return { labelColCount: 0, labelSplitConfidence: "uncertain" };
   }
@@ -412,6 +443,104 @@ function detectLabelColumns(values, bodyStartRow, bodyEndRow, colCount) {
   }
 
   return { labelColCount: 1, labelSplitConfidence: "confident" };
+}
+
+function normalizeLabelCandidate(rawValue) {
+  if (rawValue === null || rawValue === undefined) {
+    return "";
+  }
+
+  return String(rawValue)
+    .toLowerCase()
+    .replace(/[.,:;()_-]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function isNpsScaleLabel(rawValue) {
+  const label = normalizeLabelCandidate(rawValue);
+  if (!label || !/^\d+$/.test(label)) {
+    return false;
+  }
+
+  const value = Number(label);
+  return value >= 0 && value <= 10;
+}
+
+function isExtendedNpsScaleLabelColumn(values, bodyStartRow, bodyEndRow, colCount) {
+  if (colCount < 3 || bodyEndRow < bodyStartRow) {
+    return false;
+  }
+
+  const rightNumericFrac = computeNumericFraction(
+    values,
+    bodyStartRow,
+    bodyEndRow,
+    1,
+    colCount - 1
+  );
+
+  if (rightNumericFrac < NPS_SCALE_RIGHT_NUMERIC_FRACTION) {
+    return false;
+  }
+
+  let scaleLabelCount = 0;
+  let bucketOrNeutralCount = 0;
+  let hasDetractors = false;
+  let hasPromoters = false;
+  let hasNps = false;
+  let hasBase = false;
+
+  for (let rowIndex = bodyStartRow; rowIndex <= bodyEndRow; rowIndex++) {
+    const row = values[rowIndex] || [];
+    const rawLabel = row[0];
+    const label = normalizeLabelCandidate(rawLabel);
+
+    if (isNpsScaleLabel(rawLabel)) {
+      scaleLabelCount++;
+      continue;
+    }
+
+    if (label === "detractors" || label === "detractor") {
+      hasDetractors = true;
+      continue;
+    }
+
+    if (label === "promoters" || label === "promoter") {
+      hasPromoters = true;
+      continue;
+    }
+
+    if (label === "nps" || label === "net promoter score") {
+      hasNps = true;
+      continue;
+    }
+
+    if (label === "base") {
+      hasBase = true;
+      continue;
+    }
+
+    if (
+      label === "neutral" ||
+      label === "neutrals" ||
+      label.startsWith("bottom ") ||
+      label.startsWith("mid ") ||
+      label.startsWith("middle ") ||
+      label.startsWith("top ")
+    ) {
+      bucketOrNeutralCount++;
+    }
+  }
+
+  return (
+    scaleLabelCount >= NPS_SCALE_LABEL_MIN_COUNT &&
+    bucketOrNeutralCount > 0 &&
+    hasDetractors &&
+    hasPromoters &&
+    hasNps &&
+    hasBase
+  );
 }
 
 // ─── Body validation ──────────────────────────────────────────────────────────
@@ -696,7 +825,9 @@ export function normalizeSelectedRange(rawValues, rawText, options = {}) {
   const text     = Array.isArray(rawText)   ? rawText   : [];
   const rowCount = values.length;
   const colCount = rowCount > 0 && Array.isArray(values[0]) ? values[0].length : 0;
-  const structureValues = hasUsableTextGrid(text, rowCount, colCount) ? text : values;
+  const structureValues = hasUsableTextGrid(text, rowCount, colCount)
+    ? cleanStructuralTextGrid(text)
+    : values;
 
   // ── Step 0: Pass-through gate ──────────────────────────────────────────────
   // If the selection looks like numeric-only data, return immediately.

--- a/tests/core/range-normalizer.test.mjs
+++ b/tests/core/range-normalizer.test.mjs
@@ -63,25 +63,29 @@ describe("normalizeSelectedRange", () => {
     // Rows 1-3: sparse banner (col 0 is empty; text only in col 1 or cols 1-2)
     // Rows 4-11: body with label column (col 0) + numeric data (cols 1-2)
     const values = [
-      ["Ваш возраст",     "",       ""      ],
-      ["",                "Всего",  ""      ],
-      ["",                "Волна",  ""      ],
-      ["",                "2025Q4", "2026Q1"],
-      ["19 и младше",     0.19,     0.15    ],
-      ["20-29",           0.37,     0.32    ],
-      ["от 30 до 40",     0.28,     0.28    ],
-      ["40 и старше",     0.17,     0.24    ],
-      ["mean",            29.4,     31.5    ],
-      ["variance",        103.6,    132.6   ],
-      ["BASE",            5605,     1320    ],
-      ["Все респонденты", 6925,     2640    ],
+      ["Ваш возраст", "", ""],
+      ["", "Всего", ""],
+      ["", "Волна", ""],
+      ["", "2025Q4", "2026Q1"],
+      ["19 и младше", 0.19, 0.15],
+      ["20-29", 0.37, 0.32],
+      ["от 30 до 40", 0.28, 0.28],
+      ["40 и старше", 0.17, 0.24],
+      ["mean", 29.4, 31.5],
+      ["variance", 103.6, 132.6],
+      ["BASE", 5605, 1320],
+      ["Все респонденты", 6925, 2640],
     ];
     const result = normalizeSelectedRange(values);
 
     assert.strictEqual(result.normalizationNeeded, true);
     assert.strictEqual(result.normalizationApplied, true);
     assert.deepStrictEqual(result.titleRows, [0], "title row should be row 0");
-    assert.deepStrictEqual(result.bannerRows, [1, 2, 3], "sparse banner rows 1-3 should be detected");
+    assert.deepStrictEqual(
+      result.bannerRows,
+      [1, 2, 3],
+      "sparse banner rows 1-3 should be detected"
+    );
     assert.deepStrictEqual(result.labelColumns, [0], "col 0 should be identified as label column");
     assert.strictEqual(result.dataRowOffset, 4, "body should start at row 4");
     assert.strictEqual(result.dataColOffset, 1, "data columns should start at col 1");
@@ -103,15 +107,15 @@ describe("normalizeSelectedRange", () => {
     //     numbers (5605).  "44%" must be classified as NUMERIC.
     //   - row 8: trailing footer with empty data columns → trimmed away.
     const values = [
-      ["Ваш пол:",          "",                    "",                   ""             ],
-      ["",                  "Всего",               "",                   "Пользование категорией"],
-      ["",                  "Волна (квартал)",     "Всё покупаю сам(а)", "Большую часть"],
-      ["",                  "2025Q4",              "2026Q1",             "2025Q4"       ],
-      ["",                  "(a)",                 "(a)",                "(a)"          ],
-      ["Мужской",           "44%",                 "41%",                "39%"          ],
-      ["Женский",           "56%",                 "59%",                "61%"          ],
-      ["BASE",              5605,                  1320,                 3083           ],
-      ["Все респонденты",   "",                    "",                   ""             ],
+      ["Ваш пол:", "", "", ""],
+      ["", "Всего", "", "Пользование категорией"],
+      ["", "Волна (квартал)", "Всё покупаю сам(а)", "Большую часть"],
+      ["", "2025Q4", "2026Q1", "2025Q4"],
+      ["", "(a)", "(a)", "(a)"],
+      ["Мужской", "44%", "41%", "39%"],
+      ["Женский", "56%", "59%", "61%"],
+      ["BASE", 5605, 1320, 3083],
+      ["Все респонденты", "", "", ""],
     ];
     const result = normalizeSelectedRange(values);
 
@@ -134,12 +138,96 @@ describe("normalizeSelectedRange", () => {
     const rawText = [
       ["Ваш пол:", "", "", "", "", "", "", "", "", "", "", "", ""],
       ["", "", "", "Пользование кат", "", "", "", "", "", "", "", "", ""],
-      ["", "Волна (квартал)", "", "Всё покупаю сам(а)", "", "Большую часть", "", "", "", "", "", "", ""],
-      ["", "2025Q4", "2026Q1", "Волна (квартал)", "", "Волна (квартал)", "", "", "", "", "", "", ""],
-      ["", "", "", "2025Q4", "2026Q1", "2025Q4", "2026Q1", "2025Q4", "2026Q1", "2025Q4", "2026Q1", "2025Q4", "2026Q1"],
-      ["Мужской", "0.5", "0.4136", "0.39", "0.41", "0.44", "0.42", "0.48", "0.43", "0.51", "0.49", "0.46", "0.45"],
-      ["Женский", "0.5", "0.5863", "0.61", "0.59", "0.56", "0.58", "0.52", "0.57", "0.49", "0.51", "0.54", "0.55"],
-      ["BASE", "5605", "1320", "3083", "1045", "2200", "900", "1800", "760", "1500", "700", "1300", "620"],
+      [
+        "",
+        "Волна (квартал)",
+        "",
+        "Всё покупаю сам(а)",
+        "",
+        "Большую часть",
+        "",
+        "",
+        "",
+        "",
+        "",
+        "",
+        "",
+      ],
+      [
+        "",
+        "2025Q4",
+        "2026Q1",
+        "Волна (квартал)",
+        "",
+        "Волна (квартал)",
+        "",
+        "",
+        "",
+        "",
+        "",
+        "",
+        "",
+      ],
+      [
+        "",
+        "",
+        "",
+        "2025Q4",
+        "2026Q1",
+        "2025Q4",
+        "2026Q1",
+        "2025Q4",
+        "2026Q1",
+        "2025Q4",
+        "2026Q1",
+        "2025Q4",
+        "2026Q1",
+      ],
+      [
+        "Мужской",
+        "0.5",
+        "0.4136",
+        "0.39",
+        "0.41",
+        "0.44",
+        "0.42",
+        "0.48",
+        "0.43",
+        "0.51",
+        "0.49",
+        "0.46",
+        "0.45",
+      ],
+      [
+        "Женский",
+        "0.5",
+        "0.5863",
+        "0.61",
+        "0.59",
+        "0.56",
+        "0.58",
+        "0.52",
+        "0.57",
+        "0.49",
+        "0.51",
+        "0.54",
+        "0.55",
+      ],
+      [
+        "BASE",
+        "5605",
+        "1320",
+        "3083",
+        "1045",
+        "2200",
+        "900",
+        "1800",
+        "760",
+        "1500",
+        "700",
+        "1300",
+        "620",
+      ],
     ];
     const cleanedValues = makeRunCleanedValues(rawText, [5, 6, 7]);
 
@@ -158,19 +246,220 @@ describe("normalizeSelectedRange", () => {
     assert.deepStrictEqual(result.leftLabelValues, [["Мужской"], ["Женский"], ["BASE"]]);
     assert.strictEqual(result.bannerContext.scanRows.length, 4);
     assert.strictEqual(result.bannerContext.columnCount, 12);
-    assert.deepStrictEqual(result.bannerContext.scanRows[0].slice(0, 4), ["", "", "Пользование кат", ""]);
+    assert.deepStrictEqual(result.bannerContext.scanRows[0].slice(0, 4), [
+      "",
+      "",
+      "Пользование кат",
+      "",
+    ]);
+  });
+
+  it("real sparse 4-row banner + marked proportion body normalizes on repeat Run", () => {
+    const rawText = [
+      ["NPS-free proportion table", "", "", "", "", "", "", "", "", "", "", "", ""],
+      ["", "", "", "Category usage", "", "", "", "", "", "", "", "", ""],
+      ["", "Wave (quarter)", "", "Buys all myself", "", "Most of it", "", "", "", "", "", "", ""],
+      ["", "2025Q4", "2026Q1", "Wave (quarter)", "", "Wave (quarter)", "", "", "", "", "", "", ""],
+      [
+        "",
+        "",
+        "",
+        "2025Q4",
+        "2026Q1",
+        "2025Q4",
+        "2026Q1",
+        "2025Q4",
+        "2026Q1",
+        "2025Q4",
+        "2026Q1",
+        "2025Q4",
+        "2026Q1",
+      ],
+      [
+        "Male",
+        "50% b",
+        "41% a",
+        "39% a b",
+        "41%",
+        "44% b",
+        "42% a",
+        "48% b",
+        "43% a",
+        "51% b",
+        "49% a",
+        "46% b",
+        "45% a",
+      ],
+      [
+        "Female",
+        "50% a",
+        "59% b",
+        "61% b",
+        "59% b",
+        "56% a",
+        "58% b",
+        "52% a",
+        "57% b",
+        "49% a",
+        "51% b",
+        "54% a",
+        "55% b",
+      ],
+      [
+        "BASE",
+        "5605",
+        "1320",
+        "3083",
+        "1045",
+        "2200",
+        "900",
+        "1800",
+        "760",
+        "1500",
+        "700",
+        "1300",
+        "620",
+      ],
+    ];
+    const cleanedValues = [
+      ...rawText.slice(0, 5).map((row) => [...row]),
+      ["", "50%", "41%", "39%", "41%", "44%", "42%", "48%", "43%", "51%", "49%", "46%", "45%"],
+      ["", "50%", "59%", "61%", "59%", "56%", "58%", "52%", "57%", "49%", "51%", "54%", "55%"],
+      [
+        "",
+        "5605",
+        "1320",
+        "3083",
+        "1045",
+        "2200",
+        "900",
+        "1800",
+        "760",
+        "1500",
+        "700",
+        "1300",
+        "620",
+      ],
+    ];
+
+    const result = normalizeSelectedRange(cleanedValues, rawText);
+
+    assert.strictEqual(result.normalizationApplied, true);
+    assert.deepStrictEqual(result.labelColumns, [0]);
+    assert.strictEqual(result.dataRowOffset, 5);
+    assert.strictEqual(result.dataColOffset, 1);
+    assert.deepStrictEqual(result.valuesForCalculation[0].slice(0, 3), ["50%", "41%", "39%"]);
+    assert.notStrictEqual(result.valuesForCalculation[0][0], "Male");
+    assert.deepStrictEqual(result.leftLabelValues, [["Male"], ["Female"], ["BASE"]]);
+    assert.strictEqual(result.bannerContext.scanRows.length, 4);
+    assert.deepStrictEqual(result.bannerContext.scanRows[0].slice(0, 4), [
+      "",
+      "",
+      "Category usage",
+      "",
+    ]);
+    assert.deepStrictEqual(result.bannerContext.scanRows[3].slice(0, 4), [
+      "",
+      "",
+      "2025Q4",
+      "2026Q1",
+    ]);
   });
 
   it("real sparse 4-row banner + means body preserves service labels from Run text", () => {
     const rawText = [
       ["Ваш возраст", "", "", "", "", "", "", "", "", "", "", "", ""],
       ["", "", "", "Пользование кат", "", "", "", "", "", "", "", "", ""],
-      ["", "Волна (квартал)", "", "Всё покупаю сам(а)", "", "Большую часть", "", "", "", "", "", "", ""],
-      ["", "2025Q4", "2026Q1", "Волна (квартал)", "", "Волна (квартал)", "", "", "", "", "", "", ""],
-      ["", "", "", "2025Q4", "2026Q1", "2025Q4", "2026Q1", "2025Q4", "2026Q1", "2025Q4", "2026Q1", "2025Q4", "2026Q1"],
-      ["Среднее", "29.4", "31.5", "30.1", "32.2", "28.9", "30.7", "33.0", "34.1", "27.5", "28.0", "35.2", "36.4"],
-      ["variance", "103.6", "132.6", "120.1", "140.4", "99.2", "118.8", "150.0", "160.1", "90.5", "95.2", "170.4", "180.3"],
-      ["BASE", "5605", "1320", "3083", "1045", "2200", "900", "1800", "760", "1500", "700", "1300", "620"],
+      [
+        "",
+        "Волна (квартал)",
+        "",
+        "Всё покупаю сам(а)",
+        "",
+        "Большую часть",
+        "",
+        "",
+        "",
+        "",
+        "",
+        "",
+        "",
+      ],
+      [
+        "",
+        "2025Q4",
+        "2026Q1",
+        "Волна (квартал)",
+        "",
+        "Волна (квартал)",
+        "",
+        "",
+        "",
+        "",
+        "",
+        "",
+        "",
+      ],
+      [
+        "",
+        "",
+        "",
+        "2025Q4",
+        "2026Q1",
+        "2025Q4",
+        "2026Q1",
+        "2025Q4",
+        "2026Q1",
+        "2025Q4",
+        "2026Q1",
+        "2025Q4",
+        "2026Q1",
+      ],
+      [
+        "Среднее",
+        "29.4",
+        "31.5",
+        "30.1",
+        "32.2",
+        "28.9",
+        "30.7",
+        "33.0",
+        "34.1",
+        "27.5",
+        "28.0",
+        "35.2",
+        "36.4",
+      ],
+      [
+        "variance",
+        "103.6",
+        "132.6",
+        "120.1",
+        "140.4",
+        "99.2",
+        "118.8",
+        "150.0",
+        "160.1",
+        "90.5",
+        "95.2",
+        "170.4",
+        "180.3",
+      ],
+      [
+        "BASE",
+        "5605",
+        "1320",
+        "3083",
+        "1045",
+        "2200",
+        "900",
+        "1800",
+        "760",
+        "1500",
+        "700",
+        "1300",
+        "620",
+      ],
     ];
     const cleanedValues = makeRunCleanedValues(rawText, [5, 6, 7]);
 
@@ -211,7 +500,7 @@ describe("normalizeSelectedRange", () => {
     assert.strictEqual(result.normalizationApplied, false);
     assert.ok(
       result.blockingReasons.includes("BODY_APPEARS_MULTI_TABLE") ||
-      result.blockingReasons.includes("HEADER_AREA_TOO_LARGE"),
+        result.blockingReasons.includes("HEADER_AREA_TOO_LARGE"),
       `expected multi-table blocking reason, got: ${JSON.stringify(result.blockingReasons)}`
     );
   });
@@ -223,19 +512,19 @@ describe("normalizeSelectedRange", () => {
     // must trigger BODY_APPEARS_MULTI_TABLE.
     const values = [
       // Table 1
-      ["Таблица 1",  "",       "",       ""],
-      ["",           "Всего",  "Кат A",  ""],
-      ["",           "2025Q4", "2025Q4", ""],
-      ["Вариант A",  0.4,      0.3,      ""],
-      ["Вариант B",  0.6,      0.7,      ""],
-      ["BASE",       1000,     500,      ""],
+      ["Таблица 1", "", "", ""],
+      ["", "Всего", "Кат A", ""],
+      ["", "2025Q4", "2025Q4", ""],
+      ["Вариант A", 0.4, 0.3, ""],
+      ["Вариант B", 0.6, 0.7, ""],
+      ["BASE", 1000, 500, ""],
       // Table 2 — sparse title provides all-empty data cols → gap
-      ["Таблица 2",  "",       "",       ""],
-      ["",           "Всего",  "Кат B",  ""],
-      ["",           "2026Q1", "2026Q1", ""],
-      ["Вариант X",  0.5,      0.4,      ""],
-      ["Вариант Y",  0.5,      0.6,      ""],
-      ["BASE",       800,      400,      ""],
+      ["Таблица 2", "", "", ""],
+      ["", "Всего", "Кат B", ""],
+      ["", "2026Q1", "2026Q1", ""],
+      ["Вариант X", 0.5, 0.4, ""],
+      ["Вариант Y", 0.5, 0.6, ""],
+      ["BASE", 800, 400, ""],
     ];
     const result = normalizeSelectedRange(values);
 
@@ -243,7 +532,7 @@ describe("normalizeSelectedRange", () => {
     assert.strictEqual(result.normalizationApplied, false);
     assert.ok(
       result.blockingReasons.includes("BODY_APPEARS_MULTI_TABLE") ||
-      result.blockingReasons.includes("HEADER_AREA_TOO_LARGE"),
+        result.blockingReasons.includes("HEADER_AREA_TOO_LARGE"),
       `expected BODY_APPEARS_MULTI_TABLE or HEADER_AREA_TOO_LARGE, got: ${JSON.stringify(result.blockingReasons)}`
     );
   });
@@ -263,24 +552,24 @@ describe("normalizeSelectedRange", () => {
     // This test simulates the stripping by passing "" in the label column for the
     // three service rows while passing the original values as rawText.
     const rawText = [
-      ["Ваш возраст",     "",       ""      ],
-      ["",                "Всего",  ""      ],
-      ["",                "Волна",  ""      ],
-      ["",                "2025Q4", "2026Q1"],
-      ["",                "(a)",    "(a)"   ],
-      ["19 и младше",     "19%",    "15%"   ],
-      ["20-29",           "37%",    "32%"   ],
-      ["от 30 до 40",     "28%",    "28%"   ],
-      ["40 и старше",     "17%",    "24%"   ],
-      ["mean",            "29,4",   "31,5"  ],
-      ["variance",        "103,6",  "132,6" ],
-      ["BASE",            "5605",   "1320"  ],
-      ["Все респонденты", "",       ""      ],
+      ["Ваш возраст", "", ""],
+      ["", "Всего", ""],
+      ["", "Волна", ""],
+      ["", "2025Q4", "2026Q1"],
+      ["", "(a)", "(a)"],
+      ["19 и младше", "19%", "15%"],
+      ["20-29", "37%", "32%"],
+      ["от 30 до 40", "28%", "28%"],
+      ["40 и старше", "17%", "24%"],
+      ["mean", "29,4", "31,5"],
+      ["variance", "103,6", "132,6"],
+      ["BASE", "5605", "1320"],
+      ["Все респонденты", "", ""],
     ];
     // Simulate significance marker removal: pure-letter label cells → "".
     const strippedValues = rawText.map((row, r) =>
       [9, 10, 11].includes(r)
-        ? ["", row[1], row[2]]   // "mean"/"variance"/"BASE" erased
+        ? ["", row[1], row[2]] // "mean"/"variance"/"BASE" erased
         : row
     );
 
@@ -288,9 +577,13 @@ describe("normalizeSelectedRange", () => {
 
     assert.strictEqual(result.normalizationApplied, true);
     // Labels must come from rawText, not from strippedValues.
-    assert.deepStrictEqual(result.leftLabelValues[4], ["mean"],     "mean label preserved from text");
-    assert.deepStrictEqual(result.leftLabelValues[5], ["variance"], "variance label preserved from text");
-    assert.deepStrictEqual(result.leftLabelValues[6], ["BASE"],     "BASE label preserved from text");
+    assert.deepStrictEqual(result.leftLabelValues[4], ["mean"], "mean label preserved from text");
+    assert.deepStrictEqual(
+      result.leftLabelValues[5],
+      ["variance"],
+      "variance label preserved from text"
+    );
+    assert.deepStrictEqual(result.leftLabelValues[6], ["BASE"], "BASE label preserved from text");
   });
 
   it("Возраст full-table shape with service rows normalizes correctly", () => {
@@ -299,19 +592,19 @@ describe("normalizeSelectedRange", () => {
     // service-row labels ("mean", "variance", "BASE") so buildTablePreviewModel
     // can classify them correctly.
     const values = [
-      ["Ваш возраст",     "",                   ""      ],
-      ["",                "Всего",              ""      ],
-      ["",                "Волна (квартал)",    ""      ],
-      ["",                "2025Q4",             "2026Q1"],
-      ["",                "(a)",                "(a)"   ],
-      ["19 и младше",     "19%",                "15%"   ],
-      ["20-29",           "37%",                "32%"   ],
-      ["от 30 до 40",     "28%",                "28%"   ],
-      ["40 и старше",     "17%",                "24%"   ],
-      ["mean",            "29,4",               "31,5"  ],
-      ["variance",        "103,6",              "132,6" ],
-      ["BASE",            "5605",               "1320"  ],
-      ["Все респонденты", "",                   ""      ],
+      ["Ваш возраст", "", ""],
+      ["", "Всего", ""],
+      ["", "Волна (квартал)", ""],
+      ["", "2025Q4", "2026Q1"],
+      ["", "(a)", "(a)"],
+      ["19 и младше", "19%", "15%"],
+      ["20-29", "37%", "32%"],
+      ["от 30 до 40", "28%", "28%"],
+      ["40 и старше", "17%", "24%"],
+      ["mean", "29,4", "31,5"],
+      ["variance", "103,6", "132,6"],
+      ["BASE", "5605", "1320"],
+      ["Все респонденты", "", ""],
     ];
     const result = normalizeSelectedRange(values);
 
@@ -324,10 +617,54 @@ describe("normalizeSelectedRange", () => {
     assert.strictEqual(result.valuesForCalculation.length, 7, "trailing footer excluded");
     assert.strictEqual(result.leftLabelValues.length, 7, "leftLabelValues must have 7 rows");
     assert.deepStrictEqual(result.leftLabelValues[0], ["19 и младше"], "first body label");
-    assert.deepStrictEqual(result.leftLabelValues[4], ["mean"],     "mean row label");
+    assert.deepStrictEqual(result.leftLabelValues[4], ["mean"], "mean row label");
     assert.deepStrictEqual(result.leftLabelValues[5], ["variance"], "variance row label");
-    assert.deepStrictEqual(result.leftLabelValues[6], ["BASE"],     "BASE row label");
+    assert.deepStrictEqual(result.leftLabelValues[6], ["BASE"], "BASE row label");
     assert.deepStrictEqual(result.blockingReasons, []);
+  });
+
+  it("extended NPS full-table shape treats numeric scale rows as left labels", () => {
+    const rawText = [
+      ["NPS full table", "", ""],
+      ["", "Total", "Segment A"],
+      ["", "2025Q4", "2026Q1"],
+      ["1", "1%", "2%"],
+      ["2", "2%", "3%"],
+      ["3", "3%", "4%"],
+      ["4", "4%", "5%"],
+      ["5", "5%", "6%"],
+      ["6", "6%", "7%"],
+      ["7", "7%", "8%"],
+      ["8", "8%", "9%"],
+      ["9", "9%", "10%"],
+      ["10", "10%", "11%"],
+      ["Bottom-3", "6%", "9%"],
+      ["Mid-4", "22%", "26%"],
+      ["Top-3", "72%", "65%"],
+      ["Detractors", "6%", "9%"],
+      ["Neutral", "22%", "26%"],
+      ["Promoters", "72%", "65%"],
+      ["NPS", "66%", "56%"],
+      ["BASE", "1000", "800"],
+    ];
+
+    const cleanedValues = rawText.map((row, rowIndex) =>
+      rowIndex >= 3 ? ["", ...row.slice(1)] : [...row]
+    );
+
+    const result = normalizeSelectedRange(cleanedValues, rawText);
+
+    assert.strictEqual(result.normalizationApplied, true);
+    assert.deepStrictEqual(result.labelColumns, [0]);
+    assert.strictEqual(result.dataRowOffset, 3);
+    assert.strictEqual(result.dataColOffset, 1);
+    assert.strictEqual(result.valuesForCalculation[0][0], "1%");
+    assert.notStrictEqual(result.valuesForCalculation[0][0], "1");
+    assert.deepStrictEqual(result.leftLabelValues[13], ["Detractors"]);
+    assert.deepStrictEqual(result.leftLabelValues[14], ["Neutral"]);
+    assert.deepStrictEqual(result.leftLabelValues[15], ["Promoters"]);
+    assert.deepStrictEqual(result.leftLabelValues[16], ["NPS"]);
+    assert.deepStrictEqual(result.leftLabelValues[17], ["BASE"]);
   });
 
   it("trailing label-only footer row is excluded from body, normalization succeeds", () => {
@@ -335,19 +672,27 @@ describe("normalizeSelectedRange", () => {
     // then "Все респонденты" which has a label in col[0] but empty data columns.
     // The footer row must be trimmed so it does not trigger BODY_APPEARS_MULTI_TABLE.
     const values = [
-      ["Ваш пол:",         "",       ""      ],
-      ["",                 "Всего",  ""      ],
-      ["",                 "2025Q4", "2026Q1"],
-      ["Мужской",          0.44,     0.41    ],
-      ["Женский",          0.56,     0.59    ],
-      ["BASE",             5605,     1320    ],
-      ["Все респонденты",  "",       ""      ],
+      ["Ваш пол:", "", ""],
+      ["", "Всего", ""],
+      ["", "2025Q4", "2026Q1"],
+      ["Мужской", 0.44, 0.41],
+      ["Женский", 0.56, 0.59],
+      ["BASE", 5605, 1320],
+      ["Все респонденты", "", ""],
     ];
     const result = normalizeSelectedRange(values);
     assert.strictEqual(result.normalizationNeeded, true);
     assert.strictEqual(result.normalizationApplied, true);
-    assert.deepStrictEqual(result.blockingReasons, [], "footer row must not trigger BODY_APPEARS_MULTI_TABLE");
-    assert.strictEqual(result.valuesForCalculation.length, 3, "footer row must be excluded from valuesForCalculation");
+    assert.deepStrictEqual(
+      result.blockingReasons,
+      [],
+      "footer row must not trigger BODY_APPEARS_MULTI_TABLE"
+    );
+    assert.strictEqual(
+      result.valuesForCalculation.length,
+      3,
+      "footer row must be excluded from valuesForCalculation"
+    );
     assert.deepStrictEqual(result.valuesForCalculation[0], [0.44, 0.41], "first data row");
     assert.deepStrictEqual(result.valuesForCalculation[2], [5605, 1320], "BASE row included");
   });
@@ -357,12 +702,12 @@ describe("normalizeSelectedRange", () => {
     // The empty row lies between actual numeric rows so bodyDataEndRow does NOT
     // trim it away — the gap check must fire and block normalization.
     const values = [
-      ["Группа",  "A",  "B",  "C" ],
-      ["Label1",  10,   20,   30  ],
-      ["Label2",  40,   50,   60  ],
-      [null,      null, null, null],
-      ["Label3",  70,   80,   90  ],
-      ["Label4",  10,   20,   30  ],
+      ["Группа", "A", "B", "C"],
+      ["Label1", 10, 20, 30],
+      ["Label2", 40, 50, 60],
+      [null, null, null, null],
+      ["Label3", 70, 80, 90],
+      ["Label4", 10, 20, 30],
     ];
     const result = normalizeSelectedRange(values);
     assert.strictEqual(result.normalizationNeeded, true);


### PR DESCRIPTION
## Summary

Fixes full-table normalization for repeat Run scenarios where selectedRange.text contains numeric display values with trailing significance markers, such as 21% b or 21% b c.

The normalizer now cleans only the internal structural text grid used for detection, so marker-bearing numeric display values are treated as numeric without mutating labels, banner text, or output values.

Also fixes extended NPS full-table normalization where numeric scale labels (1..10) caused the first label column to be misclassified as data.

## Changes

- Strip trailing marker suffixes only from numeric-looking structural text values.
- Preserve labels and banner text such as BASE, Bottom-3, and Wave (quarter).
- Add a narrow extended NPS label-column fallback.
- Add regression tests for:
  - repeat full-table Run with marked proportion values;
  - extended NPS full-table shape with numeric scale labels.

## Validation

- 
pm.cmd test — passed, 28 tests
- 
pm.cmd run build — passed with existing webpack warnings for ssets/rit-icon-1024.png
- git diff --check — passed, CRLF warnings only

## Manual smoke

Passed:
- Basic proportions full-table: Run → Run again; labels/banner preserved.
- Extended NPS full-table Run; left labels preserved.
- Extended NPS full-table: Run → Run again; labels/banner preserved.
- Means / variance / BASE full-table: Run → Run again; labels and banner text preserved.
- Strict numeric-only Run: pass-through unchanged.
- Run → Clear strict numeric: baseline Clear behavior unchanged.
- Banner letters ON/OFF and respect banner structure ON/OFF: no label/header destruction observed.

## Notes

This PR does not change Run orchestration, writer behavior, Clear significance, or banner marker writing.

Known separate issue:
- Full-table Run with banner letters ON, respect structure OFF, and vertically merged/sparse banner cells may still miss banner letters. That is handled in a separate task.