### PR TITLE
Normalize Clear significance to data body

### DIFF
--- a/src/taskpane/taskpane.js
+++ b/src/taskpane/taskpane.js
@@ -970,26 +970,81 @@ async function clearSignificanceFromSelection() {
   await Excel.run(async (context) => {
     const selectedRange = context.workbook.getSelectedRange();
 
-    selectedRange.load(["values", "numberFormat"]);
+    // Read-only load: needed to decide whether to operate on the whole
+    // selection (strict numeric case) or only on the detected data body
+    // (forgiving full-table case). No writes happen before the target is known.
+    selectedRange.load(["values", "text"]);
 
     await context.sync();
 
     const selectedValues = selectedRange.values;
-    const selectedNumberFormats = selectedRange.numberFormat;
+    const selectedText = selectedRange.text;
+
+    if (
+      !selectedValues ||
+      selectedValues.length < 1 ||
+      !selectedValues[0] ||
+      selectedValues[0].length < 1
+    ) {
+      setStatusMessage("Нет данных в выделенном диапазоне.");
+      return;
+    }
+
+    const cleanedValues = removeSignificanceMarkersFromMatrix(selectedValues);
+    const normalized = normalizeSelectedRange(cleanedValues, selectedText);
+
+    // State 3: broad/full-table-like selection but decomposition failed.
+    // Block and return without mutating anything.
+    if (normalized.normalizationNeeded && !normalized.normalizationApplied) {
+      const codes =
+        normalized.blockingReasons && normalized.blockingReasons.length > 0
+          ? ` [${normalized.blockingReasons.join(", ")}]`
+          : "";
+      setStatusMessage(`${normalized.blockingMessage}${codes}`);
+      return;
+    }
+
+    // Resolve the clear target:
+    //   - State 1 (pass-through): the original selection is numeric-only.
+    //   - State 2 (normalized):   only the detected data body subrange.
+    let clearTargetRange;
+
+    if (normalized.normalizationNeeded && normalized.normalizationApplied) {
+      const bodyRowCount = normalized.valuesForCalculation.length;
+      const bodyColCount = normalized.valuesForCalculation[0].length;
+
+      if (bodyRowCount < 1 || bodyColCount < 1) {
+        setStatusMessage("Нет данных в выделенном диапазоне.");
+        return;
+      }
+
+      clearTargetRange = selectedRange
+        .getCell(normalized.dataRowOffset, normalized.dataColOffset)
+        .getResizedRange(bodyRowCount - 1, bodyColCount - 1);
+    } else {
+      clearTargetRange = selectedRange;
+    }
+
+    clearTargetRange.load(["values", "numberFormat"]);
+
+    await context.sync();
+
+    const targetValues = clearTargetRange.values;
+    const targetNumberFormats = clearTargetRange.numberFormat;
 
     const nextValues = [];
     const nextNumberFormats = [];
 
-    for (let rowIndex = 0; rowIndex < selectedValues.length; rowIndex++) {
+    for (let rowIndex = 0; rowIndex < targetValues.length; rowIndex++) {
       const valueRow = [];
       const formatRow = [];
 
-      for (let columnIndex = 0; columnIndex < selectedValues[rowIndex].length; columnIndex++) {
-        const rawValue = selectedValues[rowIndex][columnIndex];
+      for (let columnIndex = 0; columnIndex < targetValues[rowIndex].length; columnIndex++) {
+        const rawValue = targetValues[rowIndex][columnIndex];
 
         if (typeof rawValue === "number") {
           valueRow.push(rawValue);
-          formatRow.push(selectedNumberFormats[rowIndex][columnIndex]);
+          formatRow.push(targetNumberFormats[rowIndex][columnIndex]);
           continue;
         }
 
@@ -1009,11 +1064,11 @@ async function clearSignificanceFromSelection() {
       nextNumberFormats.push(formatRow);
     }
 
-    selectedRange.numberFormat = nextNumberFormats;
-    selectedRange.values = nextValues;
+    clearTargetRange.numberFormat = nextNumberFormats;
+    clearTargetRange.values = nextValues;
 
-    selectedRange.format.font.bold = false;
-    selectedRange.format.fill.clear();
+    clearTargetRange.format.font.bold = false;
+    clearTargetRange.format.fill.clear();
 
     await context.sync();
 


### PR DESCRIPTION
## Summary

Makes Clear significance support forgiving full-table selections safely.

Clear now resolves the target before any mutation:
- strict numeric selected data body: clears the original selected range as before;
- normalized full-table selection: clears only the detected data body subrange;
- blocked broad/multi-table selection: shows the normalizer blocking message and writes nothing.

## Changes

- Load selected range values/text read-only before deciding the clear target.
- Use 
ormalizeSelectedRange(cleanedValues, selectedText) to identify normalized data body offsets.
- Load values/number formats from the resolved clear target only.
- Apply existing marker-removal, number-format restore, bold clear, and fill clear only to the resolved target.

## Non-goals

- Does not remove banner/header significance letters.
- Does not write to 
ormalized.bannerRows.
- Does not mutate header/banner/label cells.
- Does not change Run behavior, statistical comparison logic, normalization, or the core Excel writer.

Banner/header marker cleanup remains deferred to #85.

## Validation

- 
pm.cmd test — passed, 28 tests
- 
pm.cmd run build — passed with existing webpack warnings
- git diff --check — passed

## Manual smoke

Passed:
- Strict numeric proportions: Run → Clear.
- Strict numeric means: Run → Clear.
- Full-table proportions: Run → select full table → Clear.
- Full-table proportions repeat: Run → Run again → Clear full table.
- Full-table means with parenthesized banner text: Clear full table.
- Extended NPS full-table: Run → Clear full table.
- Broad multi-table selection: Clear blocks and writes nothing.
- Banner letters case: Clear full table clears data body only; banner letters remain as expected and are deferred to #85.

## Notes

This PR intentionally leaves banner/header significance letters untouched. That behavior is covered by #85 and should be implemented separately.