### PR TITLE
Clear banner significance markers

### DIFF
--- a/src/taskpane/taskpane.js
+++ b/src/taskpane/taskpane.js
@@ -1072,8 +1072,98 @@ async function clearSignificanceFromSelection() {
 
     await context.sync();
 
+    await clearBannerMarkersAboveRange(context, clearTargetRange);
+
     setStatusMessage("Significance markers removed.");
   });
+}
+
+/**
+ * Removes RIT-generated trailing banner significance markers from the visible
+ * banner/header cells above the data body that was just cleared.
+ *
+ * PURPOSE:
+ * Mirrors the Run "mark letters in banner" placement so Clear undoes the same
+ * cells Run wrote into, including sparse / vertically merged banner layouts
+ * where the nearest non-empty cell above receives the marker.
+ *
+ * RULES:
+ * - Scans the row immediately above the data body plus up to
+ *   BANNER_UPPER_SCAN_LIMIT additional rows above, matching Run.
+ * - Removes only trailing markers recognized by getTrailingBannerMarker,
+ *   which restricts matches to single-character significance labels.
+ *   Ordinary parenthesized header text such as "Wave (quarter)",
+ *   "Brand (new)", or "Волна (квартал)" is preserved.
+ * - Never writes to the data body or to the label column.
+ */
+async function clearBannerMarkersAboveRange(context, targetRange) {
+  const BANNER_UPPER_SCAN_LIMIT = 5;
+
+  targetRange.load(["rowIndex", "columnIndex", "columnCount"]);
+
+  await context.sync();
+
+  const targetStartRowIndex = targetRange.rowIndex;
+  const targetStartColumnIndex = targetRange.columnIndex;
+  const targetColumnCount = targetRange.columnCount;
+
+  if (targetStartRowIndex === 0 || targetColumnCount < 1) {
+    return;
+  }
+
+  const totalScanRowCount = Math.min(BANNER_UPPER_SCAN_LIMIT + 1, targetStartRowIndex);
+
+  if (totalScanRowCount < 1) {
+    return;
+  }
+
+  const bannerScanRange = targetRange.worksheet.getRangeByIndexes(
+    targetStartRowIndex - totalScanRowCount,
+    targetStartColumnIndex,
+    totalScanRowCount,
+    targetColumnCount
+  );
+
+  bannerScanRange.load("text");
+
+  await context.sync();
+
+  const bannerTexts = bannerScanRange.text;
+  const cellWriteQueue = [];
+
+  for (let rowOffset = 0; rowOffset < totalScanRowCount; rowOffset++) {
+    const rowTexts = bannerTexts[rowOffset] || [];
+
+    for (let columnIndex = 0; columnIndex < targetColumnCount; columnIndex++) {
+      const currentText = rowTexts[columnIndex];
+
+      if (currentText === null || currentText === undefined || currentText === "") {
+        continue;
+      }
+
+      if (!getTrailingBannerMarker(currentText)) {
+        continue;
+      }
+
+      cellWriteQueue.push({
+        rowIndex: targetStartRowIndex - totalScanRowCount + rowOffset,
+        colIndex: targetStartColumnIndex + columnIndex,
+        text: removeTrailingBannerMarker(currentText),
+      });
+    }
+  }
+
+  if (cellWriteQueue.length === 0) {
+    return;
+  }
+
+  for (const { rowIndex, colIndex, text } of cellWriteQueue) {
+    const cell = targetRange.worksheet.getRangeByIndexes(rowIndex, colIndex, 1, 1);
+
+    cell.values = [[text]];
+  }
+
+  await context.sync();
 }
 
 /**


### PR DESCRIPTION
## Summary

Extends Clear significance so it removes RIT-generated banner/header significance markers written by the “mark letters in banner” option.

Clear now:
- preserves the #96 body-only cleanup behavior;
- clears data body markers, bold, and fill as before;
- scans visible banner/header cells above the cleared data body;
- removes only recognized trailing RIT banner markers;
- preserves ordinary parenthesized text such as Wave (quarter), Волна (квартал), and Brand (new).

## Changes

- Add clearBannerMarkersAboveRange(context, targetRange).
- Call banner marker cleanup after the resolved Clear target is cleared.
- Match the Run banner scan window: immediate row above data body plus up to 5 rows above.
- Use existing marker-specific helpers:
  - getTrailingBannerMarker()
  - emoveTrailingBannerMarker()

## Non-goals

- Does not change Run behavior.
- Does not change normalization.
- Does not change statistical comparison logic.
- Does not change the core Excel writer.
- Does not use broad trailing-parentheses cleanup.

## Validation

- 
pm.cmd test — passed, 28 tests
- 
pm.cmd run build — passed with existing webpack warnings
- git diff --check — passed

## Manual smoke

Passed:
- Strict numeric + banner letters: Run → select data body → Clear.
- Full-table + banner letters: Run → select full table → Clear.
- Sparse/merged banner + respect OFF: markers removed from visible upper banner labels.
- Respect structure ON: banner markers removed without damaging structure or labels.
- Parenthesized labels preserved: Wave (quarter), Волна (квартал), Brand (new), Всё покупаю сам(а).
- firstColumnIsTotal: stale markers in Total/header removed; ordinary Total letter is not introduced.
- Broad multi-table selection: Clear blocks and writes nothing.

## Known limitation

A user-authored banner header ending with a single-letter parenthesized token that exactly matches a RIT significance label, for example Foo (a), may be treated as a banner marker by Clear. This is consistent with the existing marker-specific helper behavior and avoids broad parenthesis cleanup.