### PR TITLE
Fix banner-aware Total detection

### DIFF
--- a/src/core/banner-detector.js
+++ b/src/core/banner-detector.js
@@ -114,6 +114,8 @@ export function detectBannerStructure(bannerContext, settings = {}) {
     groupLevel: groupLevelResult.groupLevel,
   });
 
+  markUpperLevelTotalsForSparseLowerLabels(columnDescriptors, upperScanRows);
+
   const globalTotalColumnIndex = detectGlobalTotalColumnIndex(columnDescriptors);
 
   markGlobalTotalColumn(columnDescriptors, globalTotalColumnIndex);
@@ -951,25 +953,136 @@ function detectGlobalTotalColumnIndex(columnDescriptors) {
 
   const lowerLabelIsTotal = isTotalBannerLabel(firstDescriptor.normalizedLowerLabel);
 
-  const groupLabelIsTotal = isTotalBannerLabel(
-    normalizeBannerLabel(firstDescriptor.comparisonGroupLabel)
-  );
+  const normalizedGroupLabel = normalizeBannerLabel(firstDescriptor.comparisonGroupLabel);
+  const groupLabelIsTotal = isTotalBannerLabel(normalizedGroupLabel);
 
   if (groupLabelIsTotal) {
-    const firstGroupKey = firstDescriptor.comparisonGroupKey;
-    const firstGroupSize = columnDescriptors.filter(
-      (descriptor) => descriptor.comparisonGroupKey === firstGroupKey
-    ).length;
-
-    if (firstGroupSize > 1) {
+    if (countDescriptorsInSameGroup(columnDescriptors, firstDescriptor) > 1) {
       return null;
     }
 
     return firstDescriptor.columnIndex;
   }
 
+  // First column is a stand-alone Total/Всего with no parent group span
+  // covering it at the picked banner level. Treat it as global so non-total
+  // sibling groups can be compared against it.
+  if (
+    lowerLabelIsTotal &&
+    !normalizedGroupLabel &&
+    countDescriptorsInSameGroup(columnDescriptors, firstDescriptor) === 1
+  ) {
+    return firstDescriptor.columnIndex;
+  }
+
   if (lowerLabelIsTotal && groupLabelIsTotal) {
     return firstDescriptor.columnIndex;
+  }
+
+  return null;
+}
+
+function countDescriptorsInSameGroup(columnDescriptors, descriptor) {
+  return columnDescriptors.filter(
+    (candidate) => candidate.comparisonGroupKey === descriptor.comparisonGroupKey
+  ).length;
+}
+
+/**
+ * Promotes columns with empty lower banner labels to local Total when the
+ * nearest visible upper banner cell in that column is total-like.
+ *
+ * Mirrors the writer's "nearest non-empty cell above" rule so that a Total
+ * label living in a sparse/merged upper banner row is not silently treated
+ * as a normal comparable column.
+ */
+function markUpperLevelTotalsForSparseLowerLabels(columnDescriptors, upperScanRows) {
+  if (!columnDescriptors || columnDescriptors.length === 0) {
+    return;
+  }
+
+  if (!Array.isArray(upperScanRows) || upperScanRows.length === 0) {
+    return;
+  }
+
+  for (const descriptor of columnDescriptors) {
+    if (descriptor.isTotal) {
+      continue;
+    }
+
+    if (descriptor.normalizedLowerLabel) {
+      continue;
+    }
+
+    for (let rowOffset = 0; rowOffset < upperScanRows.length; rowOffset++) {
+      const upperRow = upperScanRows[rowOffset] || [];
+      const upperText = normalizeRawBannerCellValue(upperRow[descriptor.columnIndex]);
+
+      if (!upperText) {
+        continue;
+      }
+
+      if (isTotalBannerLabel(normalizeBannerLabel(upperText))) {
+        descriptor.isTotal = true;
+        descriptor.isLocalTotal = true;
+        descriptor.totalType = TOTAL_TYPE.LOCAL;
+
+        attachSparseTotalToAdjacentGroup(descriptor, columnDescriptors);
+      }
+
+      break;
+    }
+  }
+}
+
+/**
+ * Attaches a sparse upper-level local Total descriptor to the adjacent
+ * named group so that comparison-pair builders treat it as that group's
+ * local Total reference.
+ *
+ * Only descriptors whose own group identity is empty (no upper-level group
+ * span at the picked group level) are reattached. The nearest non-Total
+ * descriptor with a non-empty group label is preferred to the right; the
+ * left side is used as a fallback for trailing sparse Totals.
+ */
+function attachSparseTotalToAdjacentGroup(totalDescriptor, columnDescriptors) {
+  if (totalDescriptor.comparisonGroupLabel) {
+    return;
+  }
+
+  const adjacent =
+    findAdjacentNamedGroupDescriptor(totalDescriptor, columnDescriptors, 1) ||
+    findAdjacentNamedGroupDescriptor(totalDescriptor, columnDescriptors, -1);
+
+  if (!adjacent) {
+    return;
+  }
+
+  totalDescriptor.comparisonGroupKey = adjacent.comparisonGroupKey;
+  totalDescriptor.comparisonGroupLabel = adjacent.comparisonGroupLabel;
+}
+
+function findAdjacentNamedGroupDescriptor(totalDescriptor, columnDescriptors, step) {
+  for (
+    let index = totalDescriptor.columnIndex + step;
+    index >= 0 && index < columnDescriptors.length;
+    index += step
+  ) {
+    const candidate = columnDescriptors[index];
+
+    if (!candidate) {
+      continue;
+    }
+
+    if (candidate.isTotal) {
+      continue;
+    }
+
+    if (!candidate.comparisonGroupLabel) {
+      continue;
+    }
+
+    return candidate;
   }
 
   return null;

--- a/tests/core/banner-detector.test.mjs
+++ b/tests/core/banner-detector.test.mjs
@@ -5,7 +5,10 @@ import {
   buildBannerDetectionDebugSummary,
   detectBannerStructure,
 } from "../../src/core/banner-detector.js";
-import { buildBannerLocalSignificanceLabelMap } from "../../src/core/significance.js";
+import {
+  buildBannerLocalSignificanceLabelMap,
+  buildColumnComparisonPairs,
+} from "../../src/core/significance.js";
 
 function getGroupLevelRowOffset(result) {
   return result.columnDescriptors[0].source.groupLevelRowOffset;
@@ -181,5 +184,274 @@ describe("detectBannerStructure - group level selection", () => {
         },
       ]
     );
+  });
+});
+
+describe("detectBannerStructure - sparse lower banner totals", () => {
+  it("marks columns with empty lower label as local Total when nearest upper cell is total-like", () => {
+    const bannerContext = {
+      selectedColumnCount: 6,
+      lowerBannerRow: ["", "Male", "Female", "", "18-24", "25-34"],
+      upperScanRows: [
+        ["Всего", "M-prefix", "F-prefix", "Total", "Young", "Old"],
+        ["", "Gender", "", "Age", "", ""],
+      ],
+    };
+
+    const result = detectBannerStructure(bannerContext);
+
+    const totalDescriptors = result.columnDescriptors.filter(
+      (descriptor) => descriptor.isTotal
+    );
+
+    assert.deepStrictEqual(
+      totalDescriptors.map((descriptor) => descriptor.columnIndex),
+      [0, 3]
+    );
+
+    for (const columnIndex of [0, 3]) {
+      const descriptor = result.columnDescriptors[columnIndex];
+      assert.strictEqual(descriptor.isTotal, true);
+      assert.strictEqual(descriptor.isLocalTotal, true);
+      assert.strictEqual(descriptor.totalType, "local");
+    }
+
+    assert.ok(result.totalColumnIndexes.includes(0));
+    assert.ok(result.totalColumnIndexes.includes(3));
+    assert.strictEqual(result.globalTotalColumnIndex, null);
+
+    const labelMap = buildBannerLocalSignificanceLabelMap(result);
+
+    assert.deepStrictEqual(
+      Array.from({ length: 6 }, (_, columnIndex) => labelMap.get(columnIndex) || ""),
+      ["", "a", "b", "", "a", "b"]
+    );
+
+    assert.deepStrictEqual(
+      result.groups.map((group) => ({
+        label: group.label,
+        columnIndexes: group.columnIndexes,
+        localTotalColumnIndexes: group.localTotalColumnIndexes,
+      })),
+      [
+        { label: "Gender", columnIndexes: [0, 1, 2], localTotalColumnIndexes: [0] },
+        { label: "Age", columnIndexes: [3, 4, 5], localTotalColumnIndexes: [3] },
+      ]
+    );
+  });
+
+  it("produces local Total comparison pairs so non-total siblings compare against the sparse Total", () => {
+    const bannerContext = {
+      selectedColumnCount: 6,
+      lowerBannerRow: ["", "Male", "Female", "", "18-24", "25-34"],
+      upperScanRows: [
+        ["Всего", "M-prefix", "F-prefix", "Total", "Young", "Old"],
+        ["", "Gender", "", "Age", "", ""],
+      ],
+    };
+
+    const result = detectBannerStructure(bannerContext);
+    const pairs = buildColumnComparisonPairs(
+      6,
+      { respectBannerStructure: true },
+      new Set(),
+      result
+    );
+
+    const totalPairs = pairs
+      .filter((pair) => pair.comparisonType === "bannerTotal")
+      .map((pair) => [pair.firstColumnIndex, pair.secondColumnIndex]);
+
+    assert.deepStrictEqual(totalPairs, [
+      [0, 1],
+      [0, 2],
+      [3, 4],
+      [3, 5],
+    ]);
+
+    const segmentPairs = pairs
+      .filter((pair) => pair.comparisonType === "bannerGroup")
+      .map((pair) => [pair.firstColumnIndex, pair.secondColumnIndex]);
+
+    assert.deepStrictEqual(segmentPairs, [
+      [1, 2],
+      [4, 5],
+    ]);
+  });
+
+  it("skips over an empty upper row and honors the next visible upper cell", () => {
+    const bannerContext = {
+      selectedColumnCount: 4,
+      lowerBannerRow: ["", "Male", "", "Female"],
+      upperScanRows: [
+        ["", "", "", ""],
+        ["Total", "M-prefix", "Всего", "F-prefix"],
+      ],
+    };
+
+    const result = detectBannerStructure(bannerContext);
+
+    assert.strictEqual(result.columnDescriptors[0].isTotal, true);
+    assert.strictEqual(result.columnDescriptors[0].isLocalTotal, true);
+    assert.strictEqual(result.columnDescriptors[2].isTotal, true);
+    assert.strictEqual(result.columnDescriptors[2].isLocalTotal, true);
+    assert.strictEqual(result.columnDescriptors[1].isTotal, false);
+    assert.strictEqual(result.columnDescriptors[3].isTotal, false);
+  });
+
+  it("does not mark a column as total when the nearest upper cell is a non-total label", () => {
+    const bannerContext = {
+      selectedColumnCount: 4,
+      lowerBannerRow: ["", "Male", "Female", "25-34"],
+      upperScanRows: [
+        ["Brand", "M-prefix", "F-prefix", "Age"],
+        ["", "Gender", "", "Age"],
+      ],
+    };
+
+    const result = detectBannerStructure(bannerContext);
+
+    for (const descriptor of result.columnDescriptors) {
+      assert.strictEqual(descriptor.isTotal, false);
+      assert.strictEqual(descriptor.isLocalTotal, false);
+    }
+
+    assert.deepStrictEqual(result.totalColumnIndexes, []);
+  });
+
+  it("does not change behavior when the lower banner row already carries the Total label", () => {
+    const bannerContext = {
+      selectedColumnCount: 3,
+      lowerBannerRow: ["Total", "Male", "Female"],
+      upperScanRows: [["", "Gender", ""]],
+    };
+
+    const result = detectBannerStructure(bannerContext);
+
+    assert.strictEqual(result.columnDescriptors[0].isTotal, true);
+    assert.strictEqual(result.columnDescriptors[1].isTotal, false);
+    assert.strictEqual(result.columnDescriptors[2].isTotal, false);
+
+    const labelMap = buildBannerLocalSignificanceLabelMap(result);
+
+    assert.deepStrictEqual(
+      Array.from({ length: 3 }, (_, columnIndex) => labelMap.get(columnIndex) || ""),
+      ["", "a", "b"]
+    );
+  });
+});
+
+describe("detectBannerStructure - global Total promotion", () => {
+  it("promotes a stand-alone first Total column to global when no parent group covers it", () => {
+    const bannerContext = {
+      selectedColumnCount: 4,
+      lowerBannerRow: ["Всего", "Daily", "Weekly", "Monthly"],
+      upperScanRows: [
+        ["", "Пользование категорией", "Пользование категорией", "Пользование категорией"],
+      ],
+    };
+
+    const result = detectBannerStructure(bannerContext);
+
+    assert.strictEqual(result.globalTotalColumnIndex, 0);
+    assert.strictEqual(result.columnDescriptors[0].isGlobalTotal, true);
+    assert.strictEqual(result.columnDescriptors[0].isLocalTotal, false);
+    assert.strictEqual(result.columnDescriptors[0].totalType, "global");
+
+    const labelMap = buildBannerLocalSignificanceLabelMap(result);
+
+    assert.deepStrictEqual(
+      Array.from({ length: 4 }, (_, columnIndex) => labelMap.get(columnIndex) || ""),
+      ["", "a", "b", "c"]
+    );
+
+    const pairs = buildColumnComparisonPairs(
+      4,
+      { respectBannerStructure: true },
+      new Set(),
+      result
+    );
+
+    const totalPairs = pairs
+      .filter((pair) => pair.comparisonType === "bannerTotal")
+      .map((pair) => [pair.firstColumnIndex, pair.secondColumnIndex, pair.totalReferenceType]);
+
+    assert.deepStrictEqual(totalPairs, [
+      [0, 1, "global"],
+      [0, 2, "global"],
+      [0, 3, "global"],
+    ]);
+  });
+
+  it("keeps repeated Total columns inside named groups as local Totals (no global promotion)", () => {
+    const bannerContext = {
+      selectedColumnCount: 6,
+      lowerBannerRow: ["Всего", "Male", "Female", "Всего", "18-24", "25-34"],
+      upperScanRows: [
+        ["Gender", "Gender", "Gender", "Age", "Age", "Age"],
+      ],
+    };
+
+    const result = detectBannerStructure(bannerContext);
+
+    assert.strictEqual(result.globalTotalColumnIndex, null);
+    assert.deepStrictEqual(result.totalColumnIndexes, [0, 3]);
+
+    for (const columnIndex of [0, 3]) {
+      const descriptor = result.columnDescriptors[columnIndex];
+      assert.strictEqual(descriptor.isTotal, true);
+      assert.strictEqual(descriptor.isLocalTotal, true);
+      assert.strictEqual(descriptor.isGlobalTotal, false);
+    }
+
+    const pairs = buildColumnComparisonPairs(
+      6,
+      { respectBannerStructure: true },
+      new Set(),
+      result
+    );
+
+    const totalPairs = pairs
+      .filter((pair) => pair.comparisonType === "bannerTotal")
+      .map((pair) => [pair.firstColumnIndex, pair.secondColumnIndex, pair.totalReferenceType]);
+
+    assert.deepStrictEqual(totalPairs, [
+      [0, 1, "local"],
+      [0, 2, "local"],
+      [3, 4, "local"],
+      [3, 5, "local"],
+    ]);
+  });
+
+  it("keeps sparse upper-level Totals attached to adjacent named groups as local (no global promotion)", () => {
+    const bannerContext = {
+      selectedColumnCount: 6,
+      lowerBannerRow: ["", "Male", "Female", "", "18-24", "25-34"],
+      upperScanRows: [
+        ["Всего", "M-prefix", "F-prefix", "Total", "Young", "Old"],
+        ["", "Gender", "", "Age", "", ""],
+      ],
+    };
+
+    const result = detectBannerStructure(bannerContext);
+
+    assert.strictEqual(result.globalTotalColumnIndex, null);
+    assert.strictEqual(result.columnDescriptors[0].isLocalTotal, true);
+    assert.strictEqual(result.columnDescriptors[0].isGlobalTotal, false);
+    assert.strictEqual(result.columnDescriptors[3].isLocalTotal, true);
+    assert.strictEqual(result.columnDescriptors[3].isGlobalTotal, false);
+  });
+
+  it("does not promote when the first Total column sits inside a multi-column parent group span", () => {
+    const bannerContext = {
+      selectedColumnCount: 3,
+      lowerBannerRow: ["Total", "Male", "Female"],
+      upperScanRows: [["Total", "Total", "Total"]],
+    };
+
+    const result = detectBannerStructure(bannerContext);
+
+    assert.strictEqual(result.globalTotalColumnIndex, null);
+    assert.strictEqual(result.columnDescriptors[0].isLocalTotal, true);
   });
 });


### PR DESCRIPTION
## Summary

Fixes banner-aware Total detection for sparse and standalone Total/Всего banner structures.

This resolves issue #90 where banner letters and Total comparisons could fail when Total/Всего appeared in sparse or lower-level banner layouts.

## Changes

- Detect sparse upper-level Total/Всего labels as local Total references when the immediate lower banner cell is blank.
- Attach sparse local Totals to the adjacent named group so sibling columns compare against the detected Total.
- Promote first-column standalone/lower Total/Всего with no parent group to global Total.
- Preserve repeated local Totals inside named groups as local, not global.
- Add regression tests for:
  - sparse upper-level local Totals;
  - local Total comparison pairs;
  - first-column global Total detection;
  - repeated local Totals;
  - non-Total guard cases.

## Validation

- 
pm.cmd test — passed, 37 tests
- 
pm.cmd run build — passed with existing webpack warnings
- git diff --check — passed

## Manual smoke

Passed:
- Global Total case: first-column Всего has no banner letter and data cells compare vs Global Total.
- Strict data-only and full-table selections produce the same behavior.
- Sparse upper local Total: local Total has no banner letter and siblings compare against it.
- Repeated local Totals inside named groups remain local and are not promoted to global.
- Existing complex banner scenarios remain stable.
- respect structure OFF behavior is unchanged.
- Run → Clear still clears data markers and banner markers.

## Notes

This PR does not change taskpane writer behavior, normalization, metric detection, Excel writer logic, or statistical calculation internals.

Closes #90.