### PR TITLE
Fix wave-aware nested banner detection

### DIFF
--- a/src/core/banner-detector.js
+++ b/src/core/banner-detector.js
@@ -120,7 +120,23 @@ export function detectBannerStructure(bannerContext, settings = {}) {
 
   markGlobalTotalColumn(columnDescriptors, globalTotalColumnIndex);
 
-  const groups = buildGroupsFromColumnDescriptors(columnDescriptors, settings);
+  const nestedWaveGroupKeys =
+    settings && settings.autoDetectWaveBanners
+      ? detectGroupKeysWithNestedWaveDimension({
+          columnDescriptors,
+          lowerBannerRow: normalizedLowerBannerRow,
+          upperScanRows,
+          groupLevelRowOffset: groupLevelResult.groupLevel
+            ? groupLevelResult.groupLevel.rowOffset
+            : null,
+        })
+      : new Set();
+
+  const groups = buildGroupsFromColumnDescriptors(
+    columnDescriptors,
+    settings,
+    nestedWaveGroupKeys
+  );
 
   const waveGroups = groups.filter(
     (group) => group.recommendedComparisonMode === RECOMMENDED_COMPARISON_MODE.PREVIOUS_COLUMN
@@ -303,7 +319,11 @@ function buildColumnDescriptors({ selectedColumnCount, lowerBannerRow, groupLeve
 /**
  * Builds group objects from descriptors.
  */
-function buildGroupsFromColumnDescriptors(columnDescriptors, calculationSettings = {}) {
+function buildGroupsFromColumnDescriptors(
+  columnDescriptors,
+  calculationSettings = {},
+  nestedWaveGroupKeys = new Set()
+) {
   const groupsByKey = new Map();
 
   for (const descriptor of columnDescriptors) {
@@ -312,7 +332,9 @@ function buildGroupsFromColumnDescriptors(columnDescriptors, calculationSettings
         calculationSettings && calculationSettings.autoDetectWaveBanners;
 
       const isWaveGroup =
-        shouldAutoDetectWaveBanners && isWaveGroupLabel(descriptor.comparisonGroupLabel);
+        shouldAutoDetectWaveBanners &&
+        (isWaveGroupLabel(descriptor.comparisonGroupLabel) ||
+          nestedWaveGroupKeys.has(descriptor.comparisonGroupKey));
 
       groupsByKey.set(descriptor.comparisonGroupKey, {
         groupKey: descriptor.comparisonGroupKey,
@@ -1109,6 +1131,117 @@ function markGlobalTotalColumn(columnDescriptors, globalTotalColumnIndex) {
 
   descriptor.isGlobalTotal = true;
   descriptor.isLocalTotal = false;
+}
+
+/**
+ * Detects which comparison-group keys host a nested/repeated wave dimension
+ * inside the group rather than at the parent group label.
+ *
+ * Two signals promote a group to wave-aware:
+ * - lower banner labels in the group's columns look like concrete wave values
+ *   (e.g. 2025Q4, 2026Q1) for at least two columns;
+ * - any upper banner row other than the chosen group level row contains a
+ *   wave / period / quarter descriptor label (e.g. "Волна (квартал)") for at
+ *   least two of the group's columns.
+ *
+ * Single-column groups are never promoted because previous-column wave
+ * comparison only makes sense across two or more adjacent wave columns.
+ */
+function detectGroupKeysWithNestedWaveDimension({
+  columnDescriptors,
+  lowerBannerRow,
+  upperScanRows,
+  groupLevelRowOffset,
+}) {
+  const groupColumnsByKey = new Map();
+
+  for (const descriptor of columnDescriptors) {
+    if (!groupColumnsByKey.has(descriptor.comparisonGroupKey)) {
+      groupColumnsByKey.set(descriptor.comparisonGroupKey, []);
+    }
+
+    groupColumnsByKey.get(descriptor.comparisonGroupKey).push(descriptor.columnIndex);
+  }
+
+  const groupLevelRowIndex =
+    typeof groupLevelRowOffset === "number" ? -groupLevelRowOffset - 1 : null;
+
+  const waveGroupKeys = new Set();
+
+  for (const [groupKey, columnIndexes] of groupColumnsByKey) {
+    if (columnIndexes.length < 2) {
+      continue;
+    }
+
+    if (countWaveValueLabelsInColumns(columnIndexes, lowerBannerRow) >= 2) {
+      waveGroupKeys.add(groupKey);
+      continue;
+    }
+
+    if (
+      hasWaveDescriptorInIntermediateUpperRow(columnIndexes, upperScanRows, groupLevelRowIndex)
+    ) {
+      waveGroupKeys.add(groupKey);
+    }
+  }
+
+  return waveGroupKeys;
+}
+
+function countWaveValueLabelsInColumns(columnIndexes, row) {
+  if (!row) {
+    return 0;
+  }
+
+  let count = 0;
+
+  for (const columnIndex of columnIndexes) {
+    const cellText = normalizeRawBannerCellValue(row[columnIndex]);
+
+    if (cellText && isTechnicalWaveValueLabel(cellText)) {
+      count++;
+    }
+  }
+
+  return count;
+}
+
+function hasWaveDescriptorInIntermediateUpperRow(
+  columnIndexes,
+  upperScanRows,
+  groupLevelRowIndex
+) {
+  if (!Array.isArray(upperScanRows) || upperScanRows.length === 0) {
+    return false;
+  }
+
+  for (let rowIndex = 0; rowIndex < upperScanRows.length; rowIndex++) {
+    if (rowIndex === groupLevelRowIndex) {
+      continue;
+    }
+
+    const row = upperScanRows[rowIndex];
+
+    if (!row) {
+      continue;
+    }
+
+    let descriptorCount = 0;
+
+    for (const columnIndex of columnIndexes) {
+      const cellText = normalizeRawBannerCellValue(row[columnIndex]);
+
+      if (cellText && isTechnicalWaveDescriptorLabel(cellText)) {
+        descriptorCount++;
+      }
+    }
+
+    if (descriptorCount >= 2) {
+      return true;
+    }
+  }
+
+  return false;
 }
 
 /**

--- a/tests/core/banner-detector.test.mjs
+++ b/tests/core/banner-detector.test.mjs
@@ -84,13 +84,34 @@ describe("detectBannerStructure - group level selection", () => {
       result.groups.map((group) => ({
         label: group.label,
         columnIndexes: group.columnIndexes,
+        recommendedComparisonMode: group.recommendedComparisonMode,
       })),
       [
-        { label: "Total", columnIndexes: [0, 1, 2, 3] },
-        { label: "Category usage", columnIndexes: [4, 5, 6, 7] },
-        { label: "Gender", columnIndexes: [8, 9] },
-        { label: "Age", columnIndexes: [10, 11] },
-        { label: "Geo", columnIndexes: [12, 13] },
+        {
+          label: "Total",
+          columnIndexes: [0, 1, 2, 3],
+          recommendedComparisonMode: "previousColumn",
+        },
+        {
+          label: "Category usage",
+          columnIndexes: [4, 5, 6, 7],
+          recommendedComparisonMode: "previousColumn",
+        },
+        {
+          label: "Gender",
+          columnIndexes: [8, 9],
+          recommendedComparisonMode: "previousColumn",
+        },
+        {
+          label: "Age",
+          columnIndexes: [10, 11],
+          recommendedComparisonMode: "previousColumn",
+        },
+        {
+          label: "Geo",
+          columnIndexes: [12, 13],
+          recommendedComparisonMode: "previousColumn",
+        },
       ]
     );
 
@@ -99,8 +120,8 @@ describe("detectBannerStructure - group level selection", () => {
     });
 
     assert.deepStrictEqual(
-      Array.from({ length: 6 }, (_, columnIndex) => labelMap.get(columnIndex) || ""),
-      ["a", "b", "c", "d", "a", "b"]
+      Array.from({ length: 14 }, (_, columnIndex) => labelMap.get(columnIndex) || ""),
+      ["", "", "", "", "", "", "", "", "", "", "", "", "", ""]
     );
   });
 
@@ -125,10 +146,19 @@ describe("detectBannerStructure - group level selection", () => {
       result.groups.map((group) => ({
         label: group.label,
         columnIndexes: group.columnIndexes,
+        recommendedComparisonMode: group.recommendedComparisonMode,
       })),
       [
-        { label: "Всего", columnIndexes: [0, 1] },
-        { label: "Пользование категорией", columnIndexes: [2, 3, 4, 5] },
+        {
+          label: "Всего",
+          columnIndexes: [0, 1],
+          recommendedComparisonMode: "previousColumn",
+        },
+        {
+          label: "Пользование категорией",
+          columnIndexes: [2, 3, 4, 5],
+          recommendedComparisonMode: "previousColumn",
+        },
       ]
     );
 
@@ -138,7 +168,7 @@ describe("detectBannerStructure - group level selection", () => {
 
     assert.deepStrictEqual(
       Array.from({ length: 6 }, (_, columnIndex) => labelMap.get(columnIndex) || ""),
-      ["a", "b", "a", "b", "c", "d"]
+      ["", "", "", "", "", ""]
     );
   });
 
@@ -157,6 +187,163 @@ describe("detectBannerStructure - group level selection", () => {
       })),
       [{ label: "Gender", columnIndexes: [0, 1] }]
     );
+  });
+
+  it("promotes every category group with a nested Волна (квартал) dimension to wave-aware", () => {
+    const bannerContext = {
+      selectedColumnCount: 12,
+      lowerBannerRow: [
+        "2025Q4",
+        "2026Q1",
+        "2025Q4",
+        "2026Q1",
+        "2025Q4",
+        "2026Q1",
+        "2025Q4",
+        "2026Q1",
+        "2025Q4",
+        "2026Q1",
+        "2025Q4",
+        "2026Q1",
+      ],
+      upperScanRows: [
+        [
+          "Волна (квартал)",
+          "Волна (квартал)",
+          "Волна (квартал)",
+          "Волна (квартал)",
+          "Волна (квартал)",
+          "Волна (квартал)",
+          "Волна (квартал)",
+          "Волна (квартал)",
+          "Волна (квартал)",
+          "Волна (квартал)",
+          "Волна (квартал)",
+          "Волна (квартал)",
+        ],
+        [
+          "Всего",
+          "",
+          "Всё покупаю сам",
+          "",
+          "Большую часть",
+          "",
+          "Половину",
+          "",
+          "Меньшую часть",
+          "",
+          "Почти не участвую",
+          "",
+        ],
+      ],
+    };
+
+    const result = detectBannerStructure(bannerContext, { autoDetectWaveBanners: true });
+
+    assert.strictEqual(result.globalTotalColumnIndex, null);
+    assert.deepStrictEqual(result.totalColumnIndexes, []);
+
+    assert.deepStrictEqual(
+      result.groups.map((group) => ({
+        label: group.label,
+        columnIndexes: group.columnIndexes,
+        recommendedComparisonMode: group.recommendedComparisonMode,
+        semanticType: group.semanticType,
+      })),
+      [
+        {
+          label: "Всего",
+          columnIndexes: [0, 1],
+          recommendedComparisonMode: "previousColumn",
+          semanticType: "wave",
+        },
+        {
+          label: "Всё покупаю сам",
+          columnIndexes: [2, 3],
+          recommendedComparisonMode: "previousColumn",
+          semanticType: "wave",
+        },
+        {
+          label: "Большую часть",
+          columnIndexes: [4, 5],
+          recommendedComparisonMode: "previousColumn",
+          semanticType: "wave",
+        },
+        {
+          label: "Половину",
+          columnIndexes: [6, 7],
+          recommendedComparisonMode: "previousColumn",
+          semanticType: "wave",
+        },
+        {
+          label: "Меньшую часть",
+          columnIndexes: [8, 9],
+          recommendedComparisonMode: "previousColumn",
+          semanticType: "wave",
+        },
+        {
+          label: "Почти не участвую",
+          columnIndexes: [10, 11],
+          recommendedComparisonMode: "previousColumn",
+          semanticType: "wave",
+        },
+      ]
+    );
+
+    const labelMap = buildBannerLocalSignificanceLabelMap(result, {
+      autoDetectWaveBanners: true,
+    });
+
+    assert.deepStrictEqual(
+      Array.from({ length: 12 }, (_, columnIndex) => labelMap.get(columnIndex) || ""),
+      ["", "", "", "", "", "", "", "", "", "", "", ""]
+    );
+
+    const pairs = buildColumnComparisonPairs(
+      12,
+      { respectBannerStructure: true, autoDetectWaveBanners: true },
+      new Set(),
+      result
+    );
+
+    const previousColumnPairs = pairs
+      .filter((pair) => pair.comparisonType === "previousColumn")
+      .map((pair) => [pair.firstColumnIndex, pair.secondColumnIndex]);
+
+    assert.deepStrictEqual(previousColumnPairs, [
+      [0, 1],
+      [2, 3],
+      [4, 5],
+      [6, 7],
+      [8, 9],
+      [10, 11],
+    ]);
+
+    const crossGroupPairs = pairs.filter(
+      (pair) =>
+        pair.comparisonType !== "previousColumn" &&
+        pair.comparisonType !== "bannerTotal"
+    );
+
+    assert.deepStrictEqual(crossGroupPairs, []);
+  });
+
+  it("keeps nested-wave behavior off when autoDetectWaveBanners is disabled", () => {
+    const bannerContext = {
+      selectedColumnCount: 4,
+      lowerBannerRow: ["2025Q4", "2026Q1", "2025Q4", "2026Q1"],
+      upperScanRows: [
+        ["Волна (квартал)", "Волна (квартал)", "Волна (квартал)", "Волна (квартал)"],
+        ["Всего", "", "Всё покупаю сам", ""],
+      ],
+    };
+
+    const result = detectBannerStructure(bannerContext, { autoDetectWaveBanners: false });
+
+    for (const group of result.groups) {
+      assert.notStrictEqual(group.recommendedComparisonMode, "previousColumn");
+      assert.notStrictEqual(group.semanticType, "wave");
+    }
   });
 
   it("keeps a pure wave-only banner as the group level when no semantic row exists", () => {


### PR DESCRIPTION
## Summary

Fixes wave-aware banner detection for nested wave labels across category groups.

When espect banner structure and utoDetectWaveBanners are enabled, RIT now recognizes groups where the wave dimension is nested inside each group, for example:

- category group: Всего, Всё покупаю сам, Большую часть, etc.
- nested banner label: Волна (квартал)
- wave values: 2025Q4, 2026Q1

Each eligible group is promoted to wave-aware previous-column mode.

## Changes

- Detect nested/repeated wave dimensions inside banner groups.
- Promote eligible multi-column groups to previousColumn recommended comparison mode.
- Preserve behavior when utoDetectWaveBanners is disabled.
- Keep multi-column Всего wave groups from being promoted to a single global Total.
- Add regression coverage for nested Волна (квартал) groups, auto-wave-off behavior, and previous-column pair generation.

## Validation

- 
pm.cmd test — passed, 39 tests
- 
pm.cmd run build — passed with existing webpack warnings
- git diff --check — passed

## Manual smoke

Passed:

- Nested Волна (квартал) table with multiple groups:
  - Всего
  - Всё покупаю сам
  - Большую часть
  - Половину
  - Меньшую часть
  - Почти не участвую
- utoDetectWaveBanners ON + espect banner structure ON:
  - arrows are used for Q4 → Q1 within every group;
  - no banner significance letters are added;
  - no cross-category comparisons are created.
- utoDetectWaveBanners OFF:
  - behavior remains ordinary banner-aware behavior.
- Multi-column Всего group with waves is not promoted to global Total.
- Existing local/global Total behavior remains stable.
- Manual previous-column mode remains unchanged.
- Run → Clear still clears markers correctly.

## Notes

This PR does not change statistical calculation logic, writer performance logic, taskpane orchestration, or manual selected-range workflow.

Closes #99.