### PR TITLE
Refresh project status and roadmap docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,6 +85,27 @@ Only modify high-risk files when the task or issue explicitly allows it.
 - Clear significance should restore numeric-looking cleaned values where possible.
 - Do not change `src/core/excel-writer.js` without an explicit writer/output issue.
 
+## Selected-range normalization guardrail
+
+Run and Clear share a selected-range normalization step. Every selection
+must resolve into exactly one of three states before any Excel mutation:
+
+- **Pass-through** — the selection is already a clean numeric data area and
+  is used as-is.
+- **Normalized** — the selection includes safe-to-trim context (e.g. a
+  banner row, a label column, a full-table shape) and is reduced to a clean
+  numeric data area following the rules in
+  `docs/SELECTED_RANGE_NORMALIZATION.md`.
+- **Blocked** — the selection is unsafe (ambiguous boundaries, broad
+  sheet-wide or worksheet-wide selections, or otherwise outside the
+  supported shapes) and must stop before any Excel mutation, with a clear
+  user-facing message.
+
+Unsafe broad selections must not silently fall through to Run/Clear: they
+must be blocked at the normalization layer. Do not bypass this guardrail
+to "just make it work" — extend the normalization spec instead. See
+`docs/SELECTED_RANGE_NORMALIZATION.md` for the authoritative rules.
+
 ## Banner rules
 
 - Banner-aware comparisons must preserve the manual selected-range model.

--- a/README.md
+++ b/README.md
@@ -195,6 +195,14 @@ Technical banner diagnostics are hidden from normal output. The status panel sho
 - multiple local Totals in one group;
 - missing banner rows above selection.
 
+## Documentation
+
+- [docs/TABLE_STRUCTURE_MATRIX.md](docs/TABLE_STRUCTURE_MATRIX.md) — structural support coverage (supported / partial / unsupported / future).
+- [docs/TEST_CASES.md](docs/TEST_CASES.md) — manual smoke validation checklist.
+- [docs/STATUS.md](docs/STATUS.md) — technical health and current focus.
+- [docs/ROADMAP.md](docs/ROADMAP.md) — phase plan and direction.
+- [docs/SELECTED_RANGE_NORMALIZATION.md](docs/SELECTED_RANGE_NORMALIZATION.md) — selected-range normalization model.
+
 ## Development notes
 
 Primary architecture:

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -2,32 +2,58 @@
 
 Рабочий roadmap проекта. Это не публичное обещание сроков, а список направлений развития от текущего MVP к более стабильному продукту.
 
-## Completed/stabilized
+## Phase 1 — Manual workflow stabilization (Completed)
+
+The manual selected-range workflow is stable. Run and Clear both go through
+the shared selected-range normalization path with banner-aware and
+wave-aware behavior.
+
 - [x] read-only table preview model exists as a core model but is not yet wired into UI
-- [x] shared text normalization utilities exist
+- [x] shared text normalization utilities
 - [x] banner-aware stabilization
 - [x] numeric output preservation
 - [x] Clear significance numeric restoration
 - [x] taskpane primary action layout improvement
 - [x] warning-only selected range guardrails
+- [x] selected-range normalization for full-table selections, used by Run and Clear
+- [x] repeat full-table normalization and extended NPS labels (#93)
+- [x] sparse/merged banner marker placement (#94)
+- [x] Clear full-table body-only restoration (#96)
+- [x] Clear banner/header marker clearing (#97)
+- [x] banner-aware Total detection (#98)
+- [x] nested wave-aware detection (#100)
+- [x] manual smoke checklist refresh (#101)
+
+## Current focus — Check table / preview foundation
+
+Expose the normalized interpretation model to the user before Excel
+mutation, so the user can verify how the add-in understood the table.
+The intent is to reuse the existing selected-range normalization output
+as the source of truth for the Check-table view rather than building a
+separate parsing path.
+
+- [ ] **Валидация перед расчетом**: Режим «Проверить таблицу», визуализирующий, как надстройка поняла структуру данных перед внесением изменений.
+- [ ] Decide whether and how to wire the existing read-only table preview model into UI on top of the normalized interpretation output.
 
 ## High-priority future/spec work
-- [ ] Design selected range normalization for full-table selections.
-- [ ] Decide whether and how to wire table preview UI.
+
 - [ ] Continue base placement product/spec work.
 - [ ] Multi-column row labels and weighted/effective bases remain discovery/spec first.
-- [ ] Custom modal dialogs remain separate and should not be mixed into selection normalization.
+- [ ] Custom modal dialogs remain separate and should not be mixed into preview wiring.
 
-## Фаза 1: Очистка и стабильность (Текущий этап)
+## Code health backlog (was Фаза 1)
 - [ ] **Рефакторинг UI-слоя**: Выделение `ui-controller.js` для работы с DOM и настройками. Очистка `taskpane.js`.
 - [ ] **Кастомные диалоги**: Замена нестабильных `window.confirm/alert` на HTML-модальные окна для консистентной работы в Excel Desktop и Web.
 - [ ] **Общие утилиты**: Создание `matrix-helpers.js` для DRY-логики обхода таблиц в детекторе метрик и баннеров.
 - [ ] **Оптимизация записи**: Усиление батчинга (группировки) операций форматирования в `excel-writer.js` для повышения производительности на больших таблицах.
 
-## Фаза 2: Улучшение парсинга (Smart Detection)
+## Smart detection backlog
 - [ ] **Поиск баз вне выделения**: Алгоритм автоматического поиска строки Total, если она находится непосредственно над выделенным диапазоном.
 - [ ] **Изоляция эвристик баннера**: Вынос логики распознавания сложных шапок (Report Title, Merged Spans) в отдельные тестируемые модули.
-- [ ] **Валидация перед расчетом**: Режим «Проверить таблицу», визуализирующий, как надстройка поняла структуру данных перед внесением изменений.
+
+## Automatic runner direction
+- [ ] Automatic runner should reuse the normalized interpretation / preview model.
+- [ ] Do not implement auto-runner as repeated blind calls to the manual Run path.
 
 ## Фаза 3: Расширение аналитики
 - [ ] **Взвешенные базы (Weighted bases)**: Поддержка корректного расчета значимости для данных с весами.

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1,232 +1,52 @@
 # STATUS.md
 
-## Current status
+Technical health and status report for Research Insights Toolkit.
 
-Research Insights Toolkit MVP functionality is implemented for the Excel-first workflow.
+For the user-facing feature overview, see [../README.md](../README.md).
+For structural coverage (supported / partial / unsupported table shapes), see
+[TABLE_STRUCTURE_MATRIX.md](TABLE_STRUCTURE_MATRIX.md).
+For the manual smoke validation checklist, see [TEST_CASES.md](TEST_CASES.md).
 
-The add-in currently supports:
+## Current phase
 
-- automatic metric block detection;
-- proportions significance testing;
-- means significance testing with SD or variance;
-- NPS significance testing from promoters/detractors structure;
-- NPS significance testing from SD or variance;
-- confidence level selector;
-- one-tailed / two-tailed testing;
-- local settings persistence;
-- reset to default settings;
-- small-base exclusion and fill;
-- Total comparison modes;
-- previous-column comparison mode;
-- banner-aware structure detection;
-- banner-aware group comparisons;
-- banner-aware local and global Total logic;
-- wave banner auto previous-column mode;
-- banner-local marker indexing;
-- banner letter writing into the lowest banner level;
-- clean user-facing status messages.
+Phase 1 — manual workflow stabilization — is complete. The manual
+selected-range workflow is stable: Run and Clear both go through the shared
+selected-range normalization path with banner-aware and wave-aware behavior.
 
-## Implemented UI settings
+Recent stabilization work landed in PRs #93, #94, #96, #97, #98, #100, #101.
 
-### Significance settings
+## Next focus
 
-Implemented:
+Check table / preview foundation: expose the normalized interpretation model
+to the user before Excel mutation, reusing the existing selected-range
+normalization output rather than introducing a separate parsing path. See
+[ROADMAP.md](ROADMAP.md) and [SELECTED_RANGE_NORMALIZATION.md](SELECTED_RANGE_NORMALIZATION.md).
 
-- `confidence-level`
-- `one-tailed-test`
-- `round-cell-values`
+## Engine health
 
-### Previous-column comparison
+- Selected-range normalization is the shared entry point for Run and Clear.
+- Banner detection, banner-letter writing, and wave-aware behavior are
+  considered stable for the structures listed as supported in
+  [TABLE_STRUCTURE_MATRIX.md](TABLE_STRUCTURE_MATRIX.md).
+- Numeric output preservation and Clear-significance numeric restoration are
+  in place. Cells without marker text remain numeric where possible; display
+  conventions (`28`, `28%`, `0.28`) are preserved.
+- Statistical engine (pooled z-test for proportions, Welch's t-test for
+  means, NPS structure, NPS spread) is unchanged and remains under project
+  control; external libraries are used only for threshold quantiles.
 
-Implemented:
+## Validation surface
 
-- `compare-with-previous-column`
-- `apply-previous-column-fill`
+- [TEST_CASES.md](TEST_CASES.md) — manual smoke checklist, refreshed in #101.
+- [TABLE_STRUCTURE_MATRIX.md](TABLE_STRUCTURE_MATRIX.md) — structure coverage source of truth.
+- [GOLD_STANDARD_TEST_SUITE.md](GOLD_STANDARD_TEST_SUITE.md) — validation planning source for non-trivial changes.
 
-Behavior:
+## Known limitations
 
-- previous-column mode writes arrows instead of letter markers;
-- arrow is written only into the right/current column;
-- upward difference uses `↑`;
-- downward difference uses `↓`;
-- fill is enabled by default when previous-column mode is selected;
-- user may manually disable previous-column fill;
-- previous-column mode disables banner letter writing;
-- previous-column mode is incompatible with compare-only-with-Total.
-
-### Banner settings
-
-Implemented:
-
-- `write-banner-letters`
-- `respect-banner-structure`
-
-Behavior:
-
-- without banner structure, banner letters follow selected-column indexing;
-- with banner structure, banner letters are written only to the lowest banner level;
-- upper banner levels are not modified;
-- labels are local to each detected banner group;
-- Total columns never receive ordinary banner letters;
-- wave groups using auto previous-column mode do not receive banner letters.
-
-### Label detection
-
-Implemented:
-
-- default label lookup immediately to the left of selected range;
-- optional lookup from the left side of the sheet via `labels-on-left-side`;
-- numeric columns between selected data and real text labels are skipped.
-
-### Total comparison settings
-
-Implemented:
-
-- `compare-only-with-total`
-- `exclude-total-from-comparisons`
-- `first-column-is-total`
-- `total-in-each-banner`
-
-Current behavior:
-
-- without banner structure, supported manual Total mode is primarily `first-column-is-total`;
-- with banner structure enabled, manual Total placement checkboxes are disabled;
-- Total placement is then detected from banner structure;
-- compare-only-with-Total and exclude-Total remain meaningful with banner structure.
-
-### Fill settings
-
-Implemented:
-
-- `significant-fill-color`
-- `lower-than-total-fill-color`
-- `fill-only-total-comparisons`
-- `small-base-fill-color`
-
-Fill priority:
-
-1. small base fill
-2. lower than Total fill
-3. normal significance fill
-4. no fill
-
-### Small bases
-
-Implemented:
-
-- `exclude-small-bases`
-- `small-base-threshold`
-
-Behavior:
-
-- columns with base lower than threshold are excluded before significance calculation;
-- small-base fill is applied to the whole affected column within the calculation block;
-- the base row itself is also filled;
-- if a manual first-column Total has a small base, calculation stops with an error.
-
-### Settings storage
-
-Implemented:
-
-- `settings-storage-mode = none`
-- `settings-storage-mode = local`
-- reset button
-
-Behavior:
-
-- local settings are stored in `localStorage`;
-- reset restores default settings and clears saved local settings;
-- cloud storage remains reserved for future implementation.
-
-## Banner engine status
-
-Implemented MVP:
-
-- one-level banner detection;
-- two-level banner detection;
-- repeated group label detection;
-- reconstructed span detection for merged-like headers;
-- local Total detection;
-- global Total detection;
-- group-aware ordinary comparisons;
-- group-local cell markers;
-- local Total as group reference when no global Total exists;
-- global Total as the only Total reference when detected;
-- local Totals compared with global Total when global Total exists;
-- local Totals not used as group references when global Total exists;
-- Total columns excluded from ordinary group comparisons;
-- previous-column comparison inside banner groups;
-- automatic previous-column mode for wave groups;
-- banner-aware lower-level letter writing;
-- user-visible banner messages filtered to important events only.
-
-## Wave banner behavior
-
-Wave-like groups are detected from group labels such as:
-
-- `wave`
-- `waves`
-- `волна`
-- `волны`
-- `period`
-- `periods`
-- `период`
-- `периоды`
-- `замер`
-- `замеры`
-
-When a wave group is detected and global previous-column mode is not manually enabled:
-
-- previous-column comparison is applied only inside wave groups;
-- non-wave groups continue to use ordinary group comparisons;
-- UI checkbox state is not changed;
-- previous-column fill is applied automatically for wave groups;
-- banner letters are not written for wave groups;
-- status message explains that auto previous-column was applied.
-
-Plain numeric labels such as `1, 2, 3` are not used as wave signals.
-
-## Statistical engine status
-
-Implemented:
-
-- pooled z-test for proportions;
-- Welch’s t-test for means;
-- NPS from promoter/detractor structure;
-- NPS from spread;
-- one-tailed and two-tailed threshold modes;
-- modular threshold functions using distribution quantiles.
-
-Notes:
-
-- product-specific comparison routing remains custom;
-- external/statistical libraries are used only for threshold calculation;
-- formulas remain under project control.
-
-## User-facing status messages
-
-Implemented:
-
-- default success status is concise;
-- technical banner diagnostics are hidden;
-- only user-relevant banner messages are shown.
-
-Visible banner message types include:
-
-- global Total used;
-- auto previous-column applied for wave groups;
-- compare-only-with-Total produced no valid Total pairs;
-- multiple local Totals in one group;
-- malformed or unsupported banner structure;
-- no banner rows above selection.
-
-## Known technical debt
-
-- Some old diagnostic helpers for merge/span investigation may remain in `taskpane.js` behind no active call path.
-- `formatBannerDetectionDiagnostics()` remains useful for development diagnostics but should not be used in normal user status.
 - Google Sheets support is not implemented.
 - Cloud settings storage is not implemented.
-- Full multi-level banner support beyond MVP is not implemented.
+- Multi-level banner support is implemented for supported research-table shapes, but broader arbitrary header layouts remain out of scope.
 - Report-title detection and broader table-boundary detection are not fully implemented.
 - Total outside selection is specified but may need additional edge-case hardening.
-- The add-in remains Excel-first.
+- Some development-only diagnostic helpers remain in `taskpane.js` behind no active user-facing call path.
+- Runtime implementation remains Excel-first; new core behavior should still be designed platform-neutral where possible.


### PR DESCRIPTION
## Summary

Refreshes project documentation after the manual workflow stabilization checkpoint.

Updates:

- docs/ROADMAP.md
  - marks Phase 1 manual workflow stabilization as completed;
  - sets Check table / preview foundation as the current focus;
  - reframes automatic runner as future work that should reuse the normalized interpretation model.

- docs/STATUS.md
  - turns the file into a concise technical health/status report;
  - removes duplicated exhaustive feature/settings lists;
  - links to README, table structure matrix, smoke tests, roadmap, gold-standard suite, and selected-range normalization spec.

- README.md
  - adds a compact Documentation section linking to key project docs.

- AGENTS.md
  - adds the selected-range normalization three-state guardrail:
    Pass-through / Normalized / Blocked;
  - emphasizes that unsafe broad selections must stop before Excel mutation.

## Validation

Docs-only change.

No product code changed.
No tests changed.