### PR TITLE
docs: document selected-range interpretation adapter contract (#122)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -15,6 +15,7 @@ Automatic worksheet/workbook scanning is still not implemented.
 
 ## Module Responsibilities
 - `src/taskpane/taskpane.js` — Excel/UI controller. Orchestrates the flow. No statistical calculations. Owns Office.js interaction and selected range reads.
+- `src/taskpane/selected-range-interpreter.js` — Excel/taskpane adapter that interprets the user's selected range into a stable object shared by Run and Check. See [Selected-Range Interpretation Adapter](#selected-range-interpretation-adapter) below.
 - `src/core/metric-detector.js` — Detects metric rows and constructs block plans.
 - `src/core/banner-detector.js` — Platform-independent banner structure detection.
 - `src/core/significance.js` — Statistical tests, comparison routing, marker creation, and fill reasons.
@@ -22,6 +23,59 @@ Automatic worksheet/workbook scanning is still not implemented.
 - `src/core/config/dictionary.config.js` — Config-driven metric and banner dictionaries.
 - `src/core/excel-writer.js` — Handles writing values and formatting back to Excel. Owns data-cell output behavior (including numeric output preservation).
 - Banner detection and banner-letter placement are separate concerns.
+
+## Selected-Range Interpretation Adapter
+
+`src/taskpane/selected-range-interpreter.js` is the Excel/taskpane adapter that converts a raw Office.js range selection into the stable interpretation object consumed by both Run and Check.
+
+### What it owns
+
+- Stripping significance markers from raw values (`cleanedValues`).
+- Calling `normalizeSelectedRange` to classify the selection as pass-through, normalized, or blocked.
+- Loading left-label values from the worksheet (immediately left of the selection, or from the sheet's leftmost columns when `labelsOnLeftSide` is on).
+- Loading banner rows from the worksheet above the data range.
+- Detecting embedded label/unit columns that the normalizer left inside the selection.
+- Sanitizing banner cell text so previously written RIT markers do not corrupt detection on re-runs.
+- Deriving `writeTargetRange` — the Excel Range that Run writes significance markers back into.
+- Returning the canonical interpretation object (see invariants below).
+
+### What it must not own
+
+- Statistical calculations or significance tests — those belong in `src/core/significance.js`.
+- Metric-row detection — that belongs in `src/core/metric-detector.js`.
+- Banner structure detection — that belongs in `src/core/banner-detector.js`.
+- Excel write-back (markers, fills) — that belongs in `src/core/excel-writer.js`.
+- UI state, status messages, or taskpane DOM access — those belong in `src/taskpane/taskpane.js`.
+
+### Run/Check flow (after PR #120)
+
+Both Run and Check call `interpretSelectedRange()` with the same arguments and receive the same interpretation object. They diverge only after interpretation:
+
+- **Run** — passes `valuesForCalculation`, `leftLabelValues`, and `bannerContext` to detection and significance, then writes markers back to `writeTargetRange` via `excel-writer.js`.
+- **Check** — passes the same values to detection and significance, then builds a read-only preview model. It never writes to the sheet.
+
+### Interpretation states
+
+`interpretSelectedRange()` always returns one of three states:
+
+| `state` | Meaning |
+|---|---|
+| `"passThrough"` | The selection is a clean numeric data area; used as-is. |
+| `"normalized"` | A broader selection was safely decomposed to a clean numeric data area. |
+| `"blocked"` | The selection is ambiguous or unsafe; `blockingMessage` explains why. Run and Check must stop before any Excel mutation when blocked. |
+
+### Invariants
+
+These invariants hold for every non-blocked interpretation result:
+
+- `valuesForCalculation` width equals `writeTargetRange.columnCount`.
+- `valuesForCalculation` width equals `bannerContext.selectedColumnCount` when a banner context is present.
+- Label, unit, and header columns are excluded from `valuesForCalculation`.
+- Label, unit, and header columns are excluded from the `writeTargetRange` (Run never writes into them).
+
+### Current platform limitation
+
+The adapter intentionally sits at the taskpane level, not in `src/core/`, because it depends on Office.js context and Range objects to load labels and banner rows from the worksheet. A future decomposition could extract a pure platform-neutral core that handles normalization and column detection without any Office.js dependency, leaving only the worksheet I/O calls in the adapter. That refactor should not be done until the adapter's contract is stable and tested. See `docs/DECISIONS.md` for the rationale.
 
 ## Core vs Office.js Boundary
 - `src/core/*` modules (like `significance.js`, `metric-detector.js`, `banner-detector.js`) are pure JavaScript logic and should remain Office.js-free. They should not contain direct Office.js API calls or UI DOM access.

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -1,0 +1,66 @@
+# Architecture Decision Records
+
+This file records significant architecture decisions for Research Insights Toolkit.
+Each entry names the decision, its context, and the reasoning so future contributors
+understand why the code is shaped the way it is.
+
+---
+
+## ADR-001 — Keep selected-range interpretation in the taskpane adapter, not in core
+
+**Date:** 2026-05-17
+**Status:** Active
+**Related PR:** #120, #122
+
+### Context
+
+PR #120 extracted shared selected-range interpretation for Run and Check into
+`src/taskpane/selected-range-interpreter.js`. Before that PR, both Run and Check
+each loaded labels, banner rows, and write-target ranges independently, leading
+to subtle drift between what Run calculated and what Check previewed.
+
+### Decision
+
+`selected-range-interpreter.js` is an **Excel/taskpane adapter**, not a core
+module. It lives in `src/taskpane/` and is allowed to depend on Office.js
+context and Range objects. It is not placed in `src/core/`.
+
+### Rationale
+
+The adapter still needs Office.js to load left-label values and banner rows from
+worksheet cells adjacent to the selection. Separating that I/O into a pure-core
+module would require passing fully loaded arrays in, which means the caller (taskpane)
+would have to know which rows and columns to pre-load — reintroducing the coupling
+the extraction was meant to remove.
+
+The right future decomposition is:
+
+1. Extract a pure platform-neutral function that accepts pre-loaded arrays and
+   returns normalization, embedded-label detection, and column-stripping results.
+2. Keep a thin Excel adapter that performs the Office.js I/O and then calls (1).
+
+That refactor should happen only after the adapter contract is stable and the
+invariants are covered by tests.
+
+### Invariants this decision protects
+
+- `valuesForCalculation` width equals `writeTargetRange.columnCount`.
+- `valuesForCalculation` width equals `bannerContext.selectedColumnCount` when banner context is present.
+- Label, unit, and header columns are excluded from both `valuesForCalculation` and `writeTargetRange`.
+- Run and Check consume the same interpreted values, labels, and banner context — they diverge only in what they do after interpretation.
+
+### Implications for future platform ports
+
+**Google Sheets:** The adapter pattern makes a Sheets port tractable. A
+`sheets-range-interpreter.js` would implement the same `interpretSelectedRange()`
+contract, loading adjacent cells via the Sheets API instead of Office.js. Core
+detection and significance modules would not need changes because they consume
+the platform-neutral interpretation object.
+
+**VBA / COM add-in:** A VBA bridge would produce the same interpretation object
+shape (as a JSON payload, for example) and hand it to the same core pipeline.
+The adapter boundary is the porting seam.
+
+Duplicating selection interpretation logic across platforms should be treated as
+a defect. New Run/Check/Auto Runner work should route through the adapter rather
+than reload labels and banner rows independently.


### PR DESCRIPTION
## Summary

- Adds a **Selected-Range Interpretation Adapter** section to `docs/ARCHITECTURE.md` covering: what the adapter owns and must not own, the three interpretation states (pass-through / normalized / blocked), the Run/Check divergence point post-#120, and the four key invariants.
- Creates `docs/DECISIONS.md` (ADR-001) explaining why the adapter stays at the taskpane level rather than moving to `src/core/`, and what the adapter boundary means for future Google Sheets and VBA ports.

No code changes.

## Closes

Closes #122

## Validation

Documentation-only PR — no build required.

## Assumptions / limitations

- `DECISIONS.md` is a new file; the issue listed it as an acceptable location alongside `ARCHITECTURE.md`.
- The adapter contract documented here reflects the code as merged in PR #120. No behavior beyond what is already in `selected-range-interpreter.js` is described.
- No roadmap promises beyond what the issue explicitly asked for (Google Sheets and VBA are discussed only as future porting motivation, not as planned features).

🤖 Generated with [Claude Code](https://claude.com/claude-code)