### PR TITLE
Harden base subtype label detection

### DIFF
--- a/src/core/config/dictionary.config.js
+++ b/src/core/config/dictionary.config.js
@@ -58,6 +58,7 @@ export const METRIC_DICTIONARY = [
     baseSubtype: "effective",
     keywords: [
       "effective base",
+      "base effective",
       "effective n",
       "эффективная база",
       "эффективное n",
@@ -68,6 +69,7 @@ export const METRIC_DICTIONARY = [
     baseSubtype: "unweighted",
     keywords: [
       "unweighted base",
+      "base unweighted",
       "unweighted n",
       "невзвешенная база",
       "невзвешенное n",
@@ -78,6 +80,7 @@ export const METRIC_DICTIONARY = [
     baseSubtype: "weighted",
     keywords: [
       "weighted base",
+      "base weighted",
       "weighted n",
       "взвешенная база",
       "взвешенное n",

--- a/src/core/metric-detector.js
+++ b/src/core/metric-detector.js
@@ -91,25 +91,26 @@ export function extractRowLabelFromLeftCells(leftLabelRowValues) {
     return "";
   }
 
-  for (
-    let labelColumnIndex = leftLabelRowValues.length - 1;
-    labelColumnIndex >= 0;
-    labelColumnIndex--
-  ) {
-    const currentLabelValue = leftLabelRowValues[labelColumnIndex];
+  // Collect all non-empty, non-numeric text cells left-to-right so that
+  // split two-column labels (e.g. ["Base", "weighted"]) are concatenated
+  // and detected as a single label ("Base weighted").
+  const parts = [];
 
-    if (isNumericLikeCellValue(currentLabelValue)) {
+  for (let i = 0; i < leftLabelRowValues.length; i++) {
+    const cellValue = leftLabelRowValues[i];
+
+    if (isNumericLikeCellValue(cellValue)) {
       continue;
     }
 
-    const normalizedLabel = normalizeLabelText(currentLabelValue);
+    const normalizedLabel = normalizeLabelText(cellValue);
 
     if (normalizedLabel) {
-      return String(currentLabelValue);
+      parts.push(String(cellValue));
     }
   }
 
-  return "";
+  return parts.join(" ");
 }
 
 /**

--- a/tests/core/base-subtype-preview.test.mjs
+++ b/tests/core/base-subtype-preview.test.mjs
@@ -124,6 +124,48 @@ describe("base subtype selection — preview model metadata", () => {
     );
   });
 
+  it('"BASE weighted" suffix label → weighted fallback warning', () => {
+    const model = makeModel(
+      ["Agree", "Disagree", "BASE weighted"],
+      [[0.4, 0.6], [0.6, 0.4], [100, 200]]
+    );
+    const block = findBlock(model, "proportion");
+    assert.ok(block, "expected a proportion block");
+    assert.strictEqual(block.baseSubtype, "weighted");
+    assert.ok(
+      warningCodes(model).includes("WEIGHTED_BASE_FALLBACK"),
+      `expected WEIGHTED_BASE_FALLBACK; got: ${JSON.stringify(warningCodes(model))}`
+    );
+  });
+
+  it('"Base unweighted" suffix label → unweighted selected, no warning', () => {
+    const model = makeModel(
+      ["Agree", "Disagree", "Base unweighted"],
+      [[0.4, 0.6], [0.6, 0.4], [100, 200]]
+    );
+    const block = findBlock(model, "proportion");
+    assert.ok(block, "expected a proportion block");
+    assert.strictEqual(block.baseSubtype, "unweighted");
+    assert.ok(
+      !warningCodes(model).includes("WEIGHTED_BASE_FALLBACK"),
+      `unexpected WEIGHTED_BASE_FALLBACK; got: ${JSON.stringify(warningCodes(model))}`
+    );
+  });
+
+  it('"Base effective" suffix label → effective selected, no warning', () => {
+    const model = makeModel(
+      ["Agree", "Disagree", "Base effective"],
+      [[0.4, 0.6], [0.6, 0.4], [100, 200]]
+    );
+    const block = findBlock(model, "proportion");
+    assert.ok(block, "expected a proportion block");
+    assert.strictEqual(block.baseSubtype, "effective");
+    assert.ok(
+      !warningCodes(model).includes("WEIGHTED_BASE_FALLBACK"),
+      `unexpected WEIGHTED_BASE_FALLBACK; got: ${JSON.stringify(warningCodes(model))}`
+    );
+  });
+
   it("ordinary BASE table → baseSubtype null, baseSelection populated, no warning", () => {
     const model = makeModel(
       ["Agree", "Disagree", "BASE"],
@@ -148,5 +190,59 @@ describe("base subtype selection — preview model metadata", () => {
     );
     // rowSubtype on row diagnostics is also null for plain base
     assert.strictEqual(model.rowDiagnostics[2].rowSubtype, null);
+  });
+});
+
+// ─── Vertically merged / sparse Base labels ───────────────────────────────────
+
+describe("vertically merged / sparse Base labels", () => {
+  it("basic merged Base: labeled row detected as base, empty rows below fall outside the block", () => {
+    // In Excel a merged Base cell spanning rows 3-5 exposes the label only
+    // on the first physical row; subsequent rows arrive as empty strings with
+    // no meaningful data.  Current behavior: the labeled row is detected as
+    // the base; the empty/null rows below form orphaned empty rows that are
+    // not included in any calculation block.
+    const model = makeModel(
+      ["Agree", "Disagree", "Base", "", ""],
+      [
+        [0.4, 0.6],
+        [0.6, 0.4],
+        [100, 200],
+        [null, null],
+        [null, null],
+      ]
+    );
+    const block = findBlock(model, "proportion");
+    assert.ok(block, "proportion block must be detected");
+    assert.deepStrictEqual(block.valueRowIndexes, [0, 1]);
+    assert.strictEqual(block.baseRowIndex, 2, "base must be the labeled row");
+  });
+
+  it("split-data merged Base: base data spread across multiple rows — NOT SUPPORTED (regression documentation)", () => {
+    // Edge case: if the data values for a merged Base cell are spread across
+    // its physical rows (different columns on different rows), only the data
+    // in the labeled row (index 2) is used as the base.  Subsequent rows
+    // (indexes 3-4) are misclassified as empty proportion rows and their
+    // data is ignored.
+    //
+    // This shape is NOT supported.  Documented here so any future fix has a
+    // baseline.  Do not change these assertions without a dedicated issue.
+    const model = makeModel(
+      ["Agree", "Disagree", "Base", "", ""],
+      [
+        [0.4, null, null],
+        [null, 0.6, null],
+        [100, null, null],
+        [null, 200, null],
+        [null, null, 150],
+      ]
+    );
+    const block = findBlock(model, "proportion");
+    // The preview model may or may not surface a block here (depends on
+    // numeric-evidence checks for the base row).  What must NOT happen is
+    // that rows 3 or 4 are selected as the base row.
+    if (block !== undefined) {
+      assert.strictEqual(block.baseRowIndex, 2, "if a block is detected, base must be the labeled row");
+    }
   });
 });

--- a/tests/core/metric-detector.test.mjs
+++ b/tests/core/metric-detector.test.mjs
@@ -2,7 +2,9 @@ import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import {
   buildCalculationBlocks,
+  classifyMetricLabel,
   detectMetricRowsFromLeftLabels,
+  extractRowLabelFromLeftCells,
 } from "../../src/core/metric-detector.js";
 
 function detectBlocks(values, labels) {
@@ -10,6 +12,116 @@ function detectBlocks(values, labels) {
   const detectionResult = detectMetricRowsFromLeftLabels(values, leftLabelValues);
   return buildCalculationBlocks(detectionResult);
 }
+
+// ─── Suffix base-subtype label detection ──────────────────────────────────────
+
+describe("classifyMetricLabel — suffix base-subtype patterns", () => {
+  it('"BASE weighted" is classified as weighted base', () => {
+    const r = classifyMetricLabel("BASE weighted");
+    assert.strictEqual(r.rowType, "base");
+    assert.strictEqual(r.baseSubtype, "weighted");
+  });
+
+  it('"Base weighted" is classified as weighted base', () => {
+    const r = classifyMetricLabel("Base weighted");
+    assert.strictEqual(r.rowType, "base");
+    assert.strictEqual(r.baseSubtype, "weighted");
+  });
+
+  it('"Base unweighted" is classified as unweighted base', () => {
+    const r = classifyMetricLabel("Base unweighted");
+    assert.strictEqual(r.rowType, "base");
+    assert.strictEqual(r.baseSubtype, "unweighted");
+  });
+
+  it('"Base effective" is classified as effective base', () => {
+    const r = classifyMetricLabel("Base effective");
+    assert.strictEqual(r.rowType, "base");
+    assert.strictEqual(r.baseSubtype, "effective");
+  });
+
+  it('"Base" (plain) remains plain base — no baseSubtype set', () => {
+    const r = classifyMetricLabel("Base");
+    assert.strictEqual(r.rowType, "base");
+    assert.strictEqual(r.baseSubtype, undefined);
+  });
+
+  it('"BASE" (all-caps plain) remains plain base — no baseSubtype set', () => {
+    const r = classifyMetricLabel("BASE");
+    assert.strictEqual(r.rowType, "base");
+    assert.strictEqual(r.baseSubtype, undefined);
+  });
+});
+
+// ─── Split two-column label extraction ───────────────────────────────────────
+
+describe("extractRowLabelFromLeftCells — split two-column base-subtype labels", () => {
+  it('["Base", "weighted"] → concatenated label "Base weighted"', () => {
+    assert.strictEqual(extractRowLabelFromLeftCells(["Base", "weighted"]), "Base weighted");
+  });
+
+  it('["Base", "unweighted"] → concatenated label "Base unweighted"', () => {
+    assert.strictEqual(extractRowLabelFromLeftCells(["Base", "unweighted"]), "Base unweighted");
+  });
+
+  it('["Base", "effective"] → concatenated label "Base effective"', () => {
+    assert.strictEqual(extractRowLabelFromLeftCells(["Base", "effective"]), "Base effective");
+  });
+
+  it('single-cell ["Base"] still returns "Base" unchanged', () => {
+    assert.strictEqual(extractRowLabelFromLeftCells(["Base"]), "Base");
+  });
+
+  it('numeric cell is skipped — ["Base", 100] → "Base"', () => {
+    assert.strictEqual(extractRowLabelFromLeftCells(["Base", 100]), "Base");
+  });
+
+  it('empty cell is skipped — ["", "Agree"] → "Agree"', () => {
+    assert.strictEqual(extractRowLabelFromLeftCells(["", "Agree"]), "Agree");
+  });
+});
+
+// ─── Split two-column labels — end-to-end block detection ────────────────────
+
+describe("split two-column base-subtype labels — end-to-end block detection", () => {
+  function detectSplitBlocks(rowLabels, values) {
+    // rowLabels is an array of [col1, col2] or [col1] arrays
+    const detectionResult = detectMetricRowsFromLeftLabels(values, rowLabels);
+    return buildCalculationBlocks(detectionResult);
+  }
+
+  it('[Base][weighted] split label → proportion block with weighted baseSubtype', () => {
+    const blocks = detectSplitBlocks(
+      [["Agree"], ["Disagree"], ["Base", "weighted"]],
+      [[0.4, 0.6], [0.6, 0.4], [100, 200]]
+    );
+    assert.strictEqual(blocks.length, 1);
+    assert.strictEqual(blocks[0].metricType, "proportion");
+    assert.strictEqual(blocks[0].baseSubtype, "weighted");
+  });
+
+  it('[Base][unweighted] split label → proportion block with unweighted baseSubtype', () => {
+    const blocks = detectSplitBlocks(
+      [["Agree"], ["Disagree"], ["Base", "unweighted"]],
+      [[0.4, 0.6], [0.6, 0.4], [100, 200]]
+    );
+    assert.strictEqual(blocks.length, 1);
+    assert.strictEqual(blocks[0].metricType, "proportion");
+    assert.strictEqual(blocks[0].baseSubtype, "unweighted");
+  });
+
+  it('[Base][effective] split label → proportion block with effective baseSubtype', () => {
+    const blocks = detectSplitBlocks(
+      [["Agree"], ["Disagree"], ["Base", "effective"]],
+      [[0.4, 0.6], [0.6, 0.4], [100, 200]]
+    );
+    assert.strictEqual(blocks.length, 1);
+    assert.strictEqual(blocks[0].metricType, "proportion");
+    assert.strictEqual(blocks[0].baseSubtype, "effective");
+  });
+});
+
+// ─── Explicit base requirement ────────────────────────────────────────────────
 
 describe("buildCalculationBlocks - explicit base requirement", () => {
   it("does not invent a proportion base from the last selected row", () => {


### PR DESCRIPTION
## Summary

Hardens base subtype detection for additional prepared-table label shapes found after exposing base subtype information in Check preview.

This PR improves detector behavior only. It does not change formulas, Run calculation logic, or writer behavior.

## Changes

- Add suffix base-subtype dictionary patterns:
  - `base effective`
  - `base unweighted`
  - `base weighted`

- Update row-label extraction to concatenate non-empty, non-numeric left-label cells left-to-right.
  - `[Base] [weighted]` now becomes `Base weighted`
  - `[Base] [unweighted]` now becomes `Base unweighted`
  - `[Base] [effective]` now becomes `Base effective`

- Add regression tests for:
  - suffix base subtype labels;
  - split two-column base subtype labels;
  - end-to-end block detection with split labels;
  - basic vertically merged / sparse Base labels;
  - documented unsupported split-data merged Base shape.

## Validation

- `npm.cmd test` — passed, 91/91
- `npm.cmd run build` — passed with existing webpack size warnings only
- `git diff --check` — passed

## Manual smoke

Passed:

- `BASE weighted` → weighted base subtype + fallback warning in Check.
- `Base unweighted` → unweighted base subtype, no fallback warning.
- `Base effective` → effective base subtype, no fallback warning.
- `[Base] [weighted]` split label → weighted subtype + fallback warning.
- `[Base] [unweighted]` split label → unweighted subtype.
- plain `BASE` remains plain Base.
- Run/Check `[row label | % | data]` still works.
- Run/Check NPS `[scale label | % | data]` still works.

## Known limitations

- `n weighted` / `n unweighted` suffix forms are intentionally not supported in this PR because the current substring matcher could produce false positives such as `when weighted`.
- Vertically merged Base labels are only partially supported. Basic sparse merged labels are covered, but split base values across multiple physical rows of a merged label are not supported yet.
- A separate issue tracks the unrelated banner-letter placement bug for mean-only partial banner selections with an empty/helper column before data.

## Notes

- No `significance.js` changes.
- No `excel-writer.js` changes.
- No formula changes.
- No UI changes.