### PR TITLE
Skip normalized helper columns for banner-aware runs

### DIFF
--- a/src/taskpane/selected-range-interpreter.js
+++ b/src/taskpane/selected-range-interpreter.js
@@ -296,6 +296,49 @@ function detectEmbeddedLabelColumns(cleanedValues) {
   return embeddedLabelCols;
 }
 
+/**
+ * Counts consecutive all-blank columns at the start of selectedText.
+ *
+ * PURPOSE: Detects a leading empty/helper column that sits between the external
+ * row-label column and the first real data column (e.g. a visual spacer in a
+ * mean-only table).  detectEmbeddedLabelColumns only recognises columns with
+ * genuine text or known unit indicators; a column whose every cell displays as
+ * blank is left untouched and ends up in writeTargetRange, causing banner
+ * letters to be written into the helper cell.
+ *
+ * Uses selectedText (the displayed cell text) rather than cleanedValues so
+ * that cells which are visually empty but carry a non-empty underlying value
+ * — such as 0 formatted as ";;;" — are also detected correctly.  A real data
+ * column always displays something (e.g. "4.2", "150", "0%"); a helper column
+ * shows nothing.
+ *
+ * RULE: a column qualifies when every cell's displayed text is "", null, or
+ * undefined.  Always leaves at least one column as data (colCount >= 2 guard).
+ * Only called when detectEmbeddedLabelColumns returns 0.
+ */
+export function detectLeadingEmptyColumns(selectedText) {
+  if (!Array.isArray(selectedText) || !Array.isArray(selectedText[0])) return 0;
+  const colCount = selectedText[0].length;
+  if (colCount < 2) return 0;
+
+  let emptyCols = 0;
+
+  for (let col = 0; col < colCount - 1; col++) {
+    const isColBlank = selectedText.every((row) => {
+      const cell = row && row[col];
+      return cell === "" || cell === null || cell === undefined;
+    });
+
+    if (isColBlank) {
+      emptyCols++;
+    } else {
+      break;
+    }
+  }
+
+  return emptyCols;
+}
+
 // ─── Banner context adapter ────────────────────────────────────────────────────
 
 /**
@@ -669,6 +712,66 @@ export async function interpretSelectedRange(
       }
     }
 
+    // Tertiary check: strip leading all-visually-empty columns from the
+    // effective normalized body.  The normalizer's label-column detection
+    // recognises text-like leading columns (e.g. column A = "Среднее",
+    // "Variance", "BASE") and sets dataColOffset accordingly, but it does
+    // NOT strip helper/spacer columns that are all-blank (e.g. column B in a
+    // mean-only table where the user selected A:N and the normalizer sets
+    // dataColOffset=1 for column A, leaving column B as valuesForCalculation
+    // column 0 with all-"" entries).
+    //
+    // Uses textForCalculation (displayed text) rather than valuesForCalculation
+    // so that cells formatted as ";;;" (value hidden) are also treated as blank.
+    // A real data column always renders something ("4.2", "150", "0%"); a helper
+    // column renders nothing regardless of its underlying value.
+    //
+    // This strip MUST happen before dataBodyRange is built so that
+    // writeTargetRange, bannerContext.selectedColumnCount, and
+    // valuesForCalculation width are all aligned to real data columns.
+    const additionalLeadingEmptyCols = detectLeadingEmptyColumns(textForCalculation);
+    if (additionalLeadingEmptyCols > 0) {
+      valuesForCalculation = valuesForCalculation.map(
+        (row) => row.slice(additionalLeadingEmptyCols)
+      );
+      textForCalculation = textForCalculation.map(
+        (row) => row.slice(additionalLeadingEmptyCols)
+      );
+      effectiveDataColOffset += additionalLeadingEmptyCols;
+
+      // Keep effectiveBannerContext aligned to the new data width so
+      // buildRunBannerContext produces the correct selectedColumnCount.
+      // The scanRows shape is what the normalizer returns; the
+      // lowerBannerRow/upperScanRows shape is produced by
+      // buildRunBannerContext (should not appear here yet, but handled
+      // defensively).
+      if (effectiveBannerContext) {
+        if (Array.isArray(effectiveBannerContext.scanRows)) {
+          effectiveBannerContext = {
+            ...effectiveBannerContext,
+            scanRows: effectiveBannerContext.scanRows.map((row) =>
+              Array.isArray(row) ? row.slice(additionalLeadingEmptyCols) : row
+            ),
+            columnCount:
+              (effectiveBannerContext.columnCount || 0) - additionalLeadingEmptyCols,
+          };
+        } else if (Array.isArray(effectiveBannerContext.lowerBannerRow)) {
+          effectiveBannerContext = {
+            ...effectiveBannerContext,
+            lowerBannerRow: effectiveBannerContext.lowerBannerRow.slice(
+              additionalLeadingEmptyCols
+            ),
+            upperScanRows: (effectiveBannerContext.upperScanRows || []).map((row) =>
+              Array.isArray(row) ? row.slice(additionalLeadingEmptyCols) : row
+            ),
+            selectedColumnCount:
+              (effectiveBannerContext.selectedColumnCount || 0) -
+              additionalLeadingEmptyCols,
+          };
+        }
+      }
+    }
+
     const dataBodyRange = selectedRange
       .getCell(normalized.dataRowOffset, effectiveDataColOffset)
       .getResizedRange(
@@ -738,6 +841,16 @@ export async function interpretSelectedRange(
 
   // Check for embedded label/unit columns before loading external labels.
   const embeddedLabelCols = detectEmbeddedLabelColumns(cleanedValues);
+  // When there are no embedded text/unit label columns, check for a leading
+  // all-empty helper column (common in mean-only tables where a visual spacer
+  // sits between the external row-label column and the first data column).
+  // detectEmbeddedLabelColumns does not catch these because they contain no
+  // genuine text or unit indicators, so they would otherwise be included in
+  // writeTargetRange and receive a spurious banner letter.
+  const leadingEmptyCols = embeddedLabelCols === 0
+    ? detectLeadingEmptyColumns(selectedText)
+    : 0;
+
 
   let valuesForCalculation;
   let textForCalculation;
@@ -754,6 +867,24 @@ export async function interpretSelectedRange(
         selectedRange.rowCount - 1,
         selectedRange.columnCount - embeddedLabelCols - 1
       );
+  } else if (leadingEmptyCols > 0) {
+    // Strip leading empty helper columns from the write target and calculation
+    // range so that banner context, significance calculation, and banner-letter
+    // placement are all aligned to the real data columns.  Labels must still be
+    // loaded from the worksheet because the empty columns carry no label text.
+    valuesForCalculation = cleanedValues.map((row) => row.slice(leadingEmptyCols));
+    textForCalculation = selectedText.map((row) => row.slice(leadingEmptyCols));
+    writeTargetRange = selectedRange
+      .getCell(0, leadingEmptyCols)
+      .getResizedRange(
+        selectedRange.rowCount - 1,
+        selectedRange.columnCount - leadingEmptyCols - 1
+      );
+    leftLabelValues = await loadLabelValuesForSelectedRange(
+      context,
+      selectedRange,
+      calculationSettings
+    );
   } else {
     leftLabelValues = await loadLabelValuesForSelectedRange(
       context,
@@ -798,7 +929,7 @@ export async function interpretSelectedRange(
     bannerContext,
     writeTargetRange,
     dataRowOffset: 0,
-    dataColOffset: embeddedLabelCols,
+    dataColOffset: embeddedLabelCols > 0 ? embeddedLabelCols : leadingEmptyCols,
     dataRowCount: valuesForCalculation.length,
     dataColCount,
     normalizationStatusLines: [],

--- a/src/taskpane/taskpane.js
+++ b/src/taskpane/taskpane.js
@@ -39,6 +39,7 @@ import { normalizeSelectedRange } from "../core/range-normalizer";
 import {
   interpretSelectedRange,
   loadLabelValuesForSelectedRange,
+  detectLeadingEmptyColumns,
 } from "./selected-range-interpreter";
 
 const USER_VISIBLE_BANNER_MESSAGE_CODES = new Set([
@@ -750,7 +751,21 @@ async function clearSignificanceFromSelection() {
 
     if (normalized.normalizationNeeded && normalized.normalizationApplied) {
       const bodyRowCount = normalized.valuesForCalculation.length;
-      const bodyColCount = normalized.valuesForCalculation[0].length;
+      let bodyColCount = normalized.valuesForCalculation[0].length;
+      let effectiveClearColOffset = normalized.dataColOffset;
+
+      // Mirror the tertiary strip in interpretSelectedRange State 2: the
+      // normalizer may leave leading all-blank helper columns (e.g. column B
+      // in a mean-only table) inside the normalized body.  Clear must exclude
+      // those same columns so it does not widen the clear target beyond the
+      // real data body.
+      const clearLeadingEmptyCols = detectLeadingEmptyColumns(
+        normalized.textForCalculation
+      );
+      if (clearLeadingEmptyCols > 0) {
+        bodyColCount -= clearLeadingEmptyCols;
+        effectiveClearColOffset += clearLeadingEmptyCols;
+      }
 
       if (bodyRowCount < 1 || bodyColCount < 1) {
         setStatusMessage("Нет данных в выделенном диапазоне.");
@@ -758,10 +773,26 @@ async function clearSignificanceFromSelection() {
       }
 
       clearTargetRange = selectedRange
-        .getCell(normalized.dataRowOffset, normalized.dataColOffset)
+        .getCell(normalized.dataRowOffset, effectiveClearColOffset)
         .getResizedRange(bodyRowCount - 1, bodyColCount - 1);
     } else {
-      clearTargetRange = selectedRange;
+      // Pass-through: the selection is a clean numeric-only range.
+      // Detect leading all-blank helper columns and exclude them from the
+      // clear target so that Clear does not remove fill/formatting from helper
+      // cells.  Uses the same detectLeadingEmptyColumns function as Run's
+      // interpretSelectedRange passThrough path.
+      const leadingBlankColsForClear = detectLeadingEmptyColumns(selectedText);
+
+      if (leadingBlankColsForClear > 0) {
+        clearTargetRange = selectedRange
+          .getCell(0, leadingBlankColsForClear)
+          .getResizedRange(
+            selectedRange.rowCount - 1,
+            selectedRange.columnCount - leadingBlankColsForClear - 1
+          );
+      } else {
+        clearTargetRange = selectedRange;
+      }
     }
 
     clearTargetRange.load(["values", "numberFormat"]);


### PR DESCRIPTION
## Summary

Fixes banner-letter placement for normalized mean-only selections where an empty/helper column before the real data columns could receive `(a)` and have its formatting cleared.

This is a narrow selected-range interpretation / cleanup-target fix.

## Root cause

For full-table / normalized mean-only selections, the normalizer correctly stripped the row-label/title column and returned:

- `dataColOffset: 1`
- `valuesForCalculation` starting at the next column

However, the first normalized body column could still be an all-empty helper/spacer column.

That meant the effective calculation/write range started at the helper column instead of the first real data column:

- `writeTargetRange` included the helper column
- `bannerContext.selectedColumnCount` included the helper column
- banner local letters assigned `(a)` to the helper column
- Run wrote `(a)` into the empty/helper banner cell
- Run/Clear cleanup could clear fill/formatting in that helper column

## Changes

### selected-range interpreter

- Exports and reuses `detectLeadingEmptyColumns`.
- Applies a tertiary leading-empty-column strip in normalized State 2 after normalization and embedded-label stripping.
- Slices `valuesForCalculation` and `textForCalculation` past leading empty/helper columns.
- Advances the effective data column offset before building `writeTargetRange`.
- Trims/slices effective banner context so banner width stays aligned to the real data columns.

Invariant preserved:

- `valuesForCalculation[0].length`
- `writeTargetRange.columnCount`
- `bannerContext.selectedColumnCount`

all describe the same real data columns.

### Clear path

- Applies the same leading-empty-column adjustment in the normalized Clear path.
- Reuses the shared helper for pass-through Clear.
- Prevents Clear from clearing fill/formatting in helper columns outside the interpreted data body.

## Validation

- `npm.cmd test` — passed, 91/91
- `npm.cmd run build` — passed with existing webpack size warnings only
- `git diff --check` — passed

## Manual smoke

Passed:

- Full-table / normalized mean-only selection:
  - no `(a)` appears in the helper column;
  - helper column fill/formatting is not cleared after Run;
  - helper column fill/formatting is not cleared by Clear;
  - Reset does not lead to helper-column formatting loss;
  - banner letters start above the real data columns only.

- Ordinary mean table without helper column still works.
- Proportion partial/full banner Run still works.
- NPS `[scale label | % | data]` Run/Check still works.
- Run → Run without Clear remains idempotent.
- Clear removes generated markers only from interpreted data/banner cells.

## Notes

- No `significance.js` changes.
- No `excel-writer.js` changes.
- No formula changes.
- No base subtype detection changes.
- Diagnostic logging was removed before PR.

Closes #127.