### PR TITLE
Harden Table Inventory as read-only candidate finder

### DIFF
--- a/src/core/table-inventory-scanner.js
+++ b/src/core/table-inventory-scanner.js
@@ -7,12 +7,22 @@
  * Office.js-free: input is a plain 2D values array with sheet offset metadata.
  * Calls buildTablePreviewModel as the interpretation engine for each candidate.
  *
- * DOES NOT:
- * - Call Office.js or depend on Excel context
- * - Write to Excel
- * - Run significance calculation
- * - Implement workbook-scope scanning
- * - Detect side-by-side tables within the same row band
+ * ROLE: read-only candidate finder only.
+ *   - Returns candidates for the user to inspect via Check Table.
+ *   - Does NOT claim a candidate is ready for Run significance.
+ *   - Does NOT write to the workbook.
+ *
+ * KNOWN LIMITATIONS (intentionally preserved, not blocking):
+ *   - Side-by-side tables within one contiguous row band are not detected
+ *     separately; the entire band appears as a single (possibly uncertain) candidate.
+ *   - Non-empty commentary rows between two tables prevent band splitting;
+ *     the tables are merged into one band.
+ *   - Multi-column labels beyond the two-column heuristic may degrade split quality.
+ *   - Title inference from rows above the band is heuristic and may mis-assign
+ *     text that belongs to an unrelated preceding section.
+ *   - Candidates with no explicit Base row are not flagged by the scanner;
+ *     Check Table should be used for authoritative interpretation.
+ *   - Inventory candidate ranges should route to Check Table, not directly to Run.
  */
 
 import { buildTablePreviewModel } from "./table-preview-model";
@@ -295,11 +305,12 @@ function inferTitle(values, band) {
   const rowAbove = values[localStartRow - 1];
 
   if (isRowEmpty(rowAbove)) {
-    // Separator row above — look two rows up for a title
+    // Separator row above — look two rows up for a title.
+    // Confidence is medium: the text could belong to a preceding section.
     if (localStartRow >= 2) {
       const text = firstNonEmptyNonNumericText(values[localStartRow - 2]);
       if (text) {
-        return { title: text, titleConfidence: "high", titleSource: "twoRowsAbove" };
+        return { title: text, titleConfidence: "medium", titleSource: "twoRowsAbove" };
       }
     }
   } else {
@@ -315,31 +326,56 @@ function inferTitle(values, band) {
 
 // ─── Item builder ─────────────────────────────────────────────────────────────
 
+/**
+ * Derives a plain-language candidate status from model quality signals.
+ *
+ * "available"  — looks like a recognisable table with no blocking issues or
+ *                uncertain boundaries; worth checking via Check Table.
+ * "uncertain"  — table-like but has blocking issues, quality warnings, or an
+ *                ambiguous label/data boundary; Check Table may still work but
+ *                results should be verified.
+ * "rejected"   — no metric rows detected; unlikely to be a RIT research table.
+ *
+ * This replaces the former canRunSignificance flag which implied Run-readiness.
+ * The scanner is a candidate finder only; Check Table is the authoritative step.
+ */
+function deriveCandidateStatus({ isLikelyTable, hasBlockingIssues, warningCount, labelSplitConfidence }) {
+  if (!isLikelyTable) return "rejected";
+  if (hasBlockingIssues || labelSplitConfidence === "uncertain" || warningCount > 0) return "uncertain";
+  return "available";
+}
+
 function buildTableInventoryItem({ band, model, titleInfo, rangeAddress, sheetName, labelSplitConfidence }) {
   const { summary, qualitySummary, calculationBlocks } = model;
   const tableId = sheetName + "!" + rangeAddress;
 
   const isLikelyTable = summary.detectedMetricRows > 0;
+  // canRunCheckTable: true when the candidate looks table-like enough to pass to
+  // Check Table. Does NOT imply the candidate is ready for Run significance.
   const canRunCheckTable = isLikelyTable;
 
-  const reasonsIfNotRunnable = [];
+  const candidateNotes = [];
   if (!isLikelyTable) {
-    reasonsIfNotRunnable.push("Нет опознанных строк метрик");
+    candidateNotes.push("Нет опознанных строк метрик");
   } else if (calculationBlocks.length === 0) {
-    reasonsIfNotRunnable.push("Нет блоков расчёта");
+    candidateNotes.push("Нет блоков расчёта");
   }
   if (isLikelyTable && qualitySummary.hasBlockingIssues) {
-    reasonsIfNotRunnable.push("Критические проблемы качества");
+    candidateNotes.push("Критические проблемы качества");
   }
   if (labelSplitConfidence === "uncertain") {
-    reasonsIfNotRunnable.push("Разделение лейблов и данных не определено (uncertain)");
+    candidateNotes.push("Граница лейблов/данных не определена");
+  }
+  if (isLikelyTable && qualitySummary.warningCount > 0) {
+    candidateNotes.push(`Предупреждений в превью: ${qualitySummary.warningCount}`);
   }
 
-  const canRunSignificance =
-    canRunCheckTable &&
-    calculationBlocks.length > 0 &&
-    !qualitySummary.hasBlockingIssues &&
-    labelSplitConfidence === "confident";
+  const candidateStatus = deriveCandidateStatus({
+    isLikelyTable,
+    hasBlockingIssues: qualitySummary.hasBlockingIssues,
+    warningCount: qualitySummary.warningCount,
+    labelSplitConfidence,
+  });
 
   let previewSummary = "";
   if (isLikelyTable) {
@@ -365,8 +401,8 @@ function buildTableInventoryItem({ band, model, titleInfo, rangeAddress, sheetNa
     previewSummary,
     isLikelyTable,
     canRunCheckTable,
-    canRunSignificance,
-    reasonsIfNotRunnable,
+    candidateStatus,
+    candidateNotes,
     labelSplitConfidence,
     warningsCount: isLikelyTable ? qualitySummary.warningCount : 0,
     criticalCount: isLikelyTable ? qualitySummary.criticalCount : 0,

--- a/src/taskpane/taskpane.js
+++ b/src/taskpane/taskpane.js
@@ -1300,16 +1300,18 @@ async function runTableInventory() {
       if (item.warningsCount > 0) warnParts.push(`Предупреждений: ${item.warningsCount}`);
       if (warnParts.length > 0) lines.push(`   ${warnParts.join(". ")}.`);
 
-      if (!item.isLikelyTable) {
-        lines.push("   Не опознана как таблица RIT.");
-      }
+      // candidateStatus replaces the former "Значимость: да/нет" line.
+      // Inventory is a candidate finder only; Check Table is the authoritative step.
+      const statusLabel =
+        item.candidateStatus === "available"
+          ? "Кандидат — рекомендуется «Проверить таблицу»"
+          : item.candidateStatus === "uncertain"
+          ? "Кандидат (неопределён) — требует «Проверить таблицу»"
+          : "Не опознан как таблица RIT";
+      lines.push(`   ${statusLabel}.`);
 
-      lines.push(
-        `   Проверка: ${item.canRunCheckTable ? "да" : "нет"}. Значимость: ${item.canRunSignificance ? "да" : "нет"}.`
-      );
-
-      if (item.reasonsIfNotRunnable.length > 0) {
-        lines.push(`   [${item.reasonsIfNotRunnable.join("; ")}]`);
+      if (item.candidateNotes && item.candidateNotes.length > 0) {
+        lines.push(`   [${item.candidateNotes.join("; ")}]`);
       }
 
       lines.push("");

--- a/tests/core/table-inventory-scanner.test.mjs
+++ b/tests/core/table-inventory-scanner.test.mjs
@@ -92,4 +92,147 @@ describe("scanWorksheetForTables", () => {
     assert.strictEqual(item.columnCount, 4);
     assert.strictEqual(item.isLikelyTable, true);
   });
+
+  // ─── New hardening tests for issue #110 ──────────────────────────────────
+
+  it("item does not expose canRunSignificance — scanner is a candidate finder only", () => {
+    const values = [
+      ["Label1", 10, 20, 30],
+      ["Label2", 40, 50, 60],
+      ["Base", 100, 100, 100],
+    ];
+    const items = scanWorksheetForTables({ values, ...OFFSET });
+    assert.ok(items.length >= 1, "expected at least one item");
+    assert.strictEqual(
+      items[0].canRunSignificance,
+      undefined,
+      "canRunSignificance must not exist on inventory items"
+    );
+    assert.ok(
+      ["available", "uncertain", "rejected"].includes(items[0].candidateStatus),
+      `candidateStatus must be available/uncertain/rejected; got ${items[0].candidateStatus}`
+    );
+  });
+
+  it("clean table with base produces candidateStatus=available", () => {
+    const values = [
+      ["Label1", 10, 20, 30],
+      ["Label2", 40, 50, 60],
+      ["Base", 100, 100, 100],
+    ];
+    const items = scanWorksheetForTables({ values, ...OFFSET });
+    assert.ok(items.length >= 1);
+    assert.strictEqual(items[0].candidateStatus, "available");
+  });
+
+  it("table with no explicit Base row is not presented as Run-ready — no canRunSignificance field", () => {
+    const values = [
+      ["Label1", 10, 20, 30],
+      ["Label2", 40, 50, 60],
+      ["Label3", 70, 80, 90],
+    ];
+    const items = scanWorksheetForTables({ values, ...OFFSET });
+    // Without a Base row the scanner may produce 0 or 1 items depending on metric detection.
+    // If an item exists, it must not carry canRunSignificance (the key safety property).
+    if (items.length > 0) {
+      assert.strictEqual(items[0].canRunSignificance, undefined, "canRunSignificance must not exist");
+      // "rejected" is acceptable — no Base means no complete metric blocks.
+      assert.ok(
+        ["available", "uncertain", "rejected"].includes(items[0].candidateStatus),
+        `candidateStatus must be a recognised value; got ${items[0].candidateStatus}`
+      );
+    }
+    // If items.length === 0, the scanner correctly found nothing to over-promise on.
+  });
+
+  it("candidate with preview warnings is surfaced as uncertain", () => {
+    // All-100 rows trigger a quality warning in the preview model.
+    const values = [
+      ["Label1", 100, 100, 100],
+      ["Label2", 100, 100, 100],
+      ["Base", 1000, 1000, 1000],
+    ];
+    const items = scanWorksheetForTables({ values, ...OFFSET });
+    assert.ok(items.length >= 1, "expected at least one item");
+    const item = items[0];
+    // Warnings must be reflected in the candidate status.
+    if (item.warningsCount > 0) {
+      assert.strictEqual(
+        item.candidateStatus,
+        "uncertain",
+        "item with preview warnings must be uncertain, not available"
+      );
+    }
+  });
+
+  it("side-by-side tables in one row band appear as one candidate and expose no canRunSignificance", () => {
+    // Known limitation: scanner cannot split side-by-side tables within one band.
+    // This test documents the limitation and ensures no over-promising.
+    const values = [
+      ["", "Total", "Male", "", "Total", "Female"],
+      ["Metric A", 100, 60, "Metric B", 200, 120],
+      ["Metric A2", 150, 90, "Metric B2", 250, 150],
+      ["Base", 1000, 600, "Base", 2000, 1200],
+    ];
+    const items = scanWorksheetForTables({ values, ...OFFSET });
+    // Entire band is treated as one candidate (known limitation).
+    assert.strictEqual(items.length, 1, "side-by-side tables are reported as one band (known limitation)");
+    assert.strictEqual(items[0].canRunSignificance, undefined, "canRunSignificance must not exist");
+    assert.ok(
+      ["available", "uncertain", "rejected"].includes(items[0].candidateStatus),
+      "candidateStatus must be a recognised value"
+    );
+  });
+
+  it("non-empty commentary row between two tables merges them — no split, no false confidence", () => {
+    // Tables separated by a non-empty row are merged into one band (known limitation).
+    // The merged candidate must not report canRunSignificance.
+    const values = [
+      ["Label1", 10, 20, 30],
+      ["Label2", 40, 50, 60],
+      ["Base", 100, 100, 100],
+      ["Note: preliminary data", null, null, null],  // non-empty, prevents band split
+      ["Label3", 70, 80, 90],
+      ["Label4", 10, 20, 30],
+      ["Base", 200, 200, 200],
+    ];
+    const items = scanWorksheetForTables({ values, ...OFFSET });
+    // Should be 1 merged band, not 2.
+    assert.strictEqual(items.length, 1, "non-empty note row prevents band split — expect 1 merged candidate");
+    assert.strictEqual(items[0].canRunSignificance, undefined, "canRunSignificance must not exist");
+  });
+
+  it("title inferred two rows above band via empty separator gets medium confidence", () => {
+    // Row 0: section title. Row 1: empty separator. Rows 2-4: table band.
+    // twoRowsAbove inference should be medium confidence, not high.
+    const values = [
+      ["Section Title", null, null],
+      [null, null, null],
+      ["Label1", 10, 20],
+      ["Label2", 30, 40],
+      ["Base", 100, 100],
+    ];
+    const items = scanWorksheetForTables({ values, ...OFFSET });
+    assert.ok(items.length >= 1, "expected at least one item");
+    const item = items[0];
+    if (item.titleSource === "twoRowsAbove") {
+      assert.strictEqual(
+        item.titleConfidence,
+        "medium",
+        "twoRowsAbove title confidence must be medium (text may belong to a preceding section)"
+      );
+    }
+  });
+
+  it("item exposes candidateNotes not reasonsIfNotRunnable", () => {
+    const values = [
+      ["Label1", 10, 20],
+      ["Label2", 30, 40],
+      ["Base", 100, 100],
+    ];
+    const items = scanWorksheetForTables({ values, ...OFFSET });
+    assert.ok(items.length >= 1);
+    assert.ok(Array.isArray(items[0].candidateNotes), "candidateNotes must be an array");
+    assert.strictEqual(items[0].reasonsIfNotRunnable, undefined, "reasonsIfNotRunnable must not exist");
+  });
 });


### PR DESCRIPTION
## Summary

Hardens Table Inventory so it is clearly treated as a read-only candidate finder, not as an authoritative Run-readiness detector.

Inventory now surfaces candidate confidence and notes, and no longer exposes or renders `canRunSignificance`.

## Changes

### Scanner contract

- Documents Table Inventory as read-only candidate finder.
- Preserves known limitations:
  - no side-by-side table detection within one row band;
  - non-empty commentary rows can merge adjacent tables;
  - label split heuristic is limited;
  - title inference is heuristic;
  - candidates should route to Check Table, not directly to Run.

### Candidate status

Replaces the old `canRunSignificance` concept with:

- `candidateStatus: available`
- `candidateStatus: uncertain`
- `candidateStatus: rejected`

Adds `candidateNotes` as softer notes for preview warnings, uncertain boundaries, missing metric rows, or no calculation blocks.

### Taskpane wording

Removes the old user-facing line:

- `Проверка: да/нет. Значимость: да/нет.`

Replaces it with candidate-oriented wording:

- `Кандидат — рекомендуется «Проверить таблицу».`
- `Кандидат (неопределён) — требует «Проверить таблицу».`
- `Не опознан как таблица RIT.`

### Title confidence

Lowers `twoRowsAbove` title inference confidence from `high` to `medium`, because the text may belong to a preceding section.

## Tests

Adds inventory scanner coverage for:

- no `canRunSignificance` field on inventory items;
- clean table with Base → `candidateStatus=available`;
- no-Base table does not present Run-ready state;
- preview warnings → `candidateStatus=uncertain`;
- side-by-side tables remain one candidate and do not overpromise;
- non-empty commentary row between tables remains one merged candidate and does not overpromise;
- `twoRowsAbove` title confidence is `medium`;
- `candidateNotes` replaces `reasonsIfNotRunnable`.

## Validation

- `npm.cmd test` — passed, 99/99
- `npm.cmd run build` — passed with existing webpack size warnings only
- `git diff --check` — passed

## Manual smoke

Passed:

- Empty sheet: no tables found, no error.
- One clean table: one candidate, sensible range.
- Two stacked tables separated by blank row: two candidates.
- Banner-heavy table with title: title/range/summary sensible.
- Sheet with only `2025Q4` / `2026Q1` banner labels: no false candidate.
- Side-by-side tables: output does not overpromise.
- Non-empty commentary row between tables: output does not overpromise.
- Check Table still works unchanged.
- Run/Clear still work unchanged.
- Inventory does not mutate workbook.

## Notes

- No Run/Clear behavior changes.
- No statistical logic changes.
- No workbook mutation.
- No hyperlinks/content sheet/backlinks.
- No auto-runner behavior.

Closes #110.