### PR TITLE
Fix partial banner+data subset selection for 2-column ranges (#132)

### DIFF
--- a/src/core/range-normalizer.js
+++ b/src/core/range-normalizer.js
@@ -39,7 +39,7 @@
 // Minimum selection size for structural analysis.
 // Smaller selections are always treated as pass-through.
 const GATE_MIN_ROWS = 3;
-const GATE_MIN_COLS = 3;
+const GATE_MIN_COLS = 2;
 
 // Pass-through gate: left-column pattern.
 // First column is text-heavy AND the remaining columns are numeric-heavy.
@@ -287,6 +287,13 @@ function isTitleLikeRow(values, rowIndex, colCount) {
   }
 
   if (!hasText || nonEmptyCount === 0 || nonEmptyCount > MAX_TITLE_ROW_NON_EMPTY_CELLS) {
+    return false;
+  }
+
+  // A row that fills most columns is a banner row, not a sparse title row.
+  // This guards 2-column selections where any fully-filled text row would
+  // otherwise satisfy the ≤3 cell count and be misclassified as a title.
+  if (colCount > 0 && nonEmptyCount / colCount > BANNER_MIN_FILL_FRACTION) {
     return false;
   }
 

--- a/tests/core/range-normalizer.test.mjs
+++ b/tests/core/range-normalizer.test.mjs
@@ -866,6 +866,100 @@ describe("normalizeSelectedRange", () => {
     assert.deepStrictEqual(result.blockingReasons, []);
   });
 
+  // ── Issue #132: 2-column partial banner + data subset selections ─────────────
+
+  it("2-col banner+data subset normalizes: banner rows separated from data body", () => {
+    // Simulates selecting cols B-C of "Ваш пол" where col A (row labels) is outside
+    // the selection.  The selection contains 1 banner row at top and data rows below.
+    // With GATE_MIN_COLS=2 the gate passes and banner is properly separated.
+    const values = [
+      ["2025Q4", "2026Q1"],   // banner row: wide text
+      [0.44,     0.41],       // Мужской
+      [0.56,     0.59],       // Женский
+      [5605,     1320],       // BASE
+    ];
+    const result = normalizeSelectedRange(values);
+
+    assert.strictEqual(result.normalizationNeeded, true, "2-col banner+data must trigger normalization");
+    assert.strictEqual(result.normalizationApplied, true, "must normalize, not block");
+    assert.deepStrictEqual(result.bannerRows, [0], "row 0 is the banner row");
+    assert.strictEqual(result.dataRowOffset, 1, "data body starts at row 1");
+    assert.strictEqual(result.valuesForCalculation.length, 3, "three data rows");
+    assert.deepStrictEqual(result.valuesForCalculation[0], [0.44, 0.41], "first data row");
+    assert.deepStrictEqual(result.valuesForCalculation[2], [5605, 1320], "BASE row included");
+    assert.deepStrictEqual(result.blockingReasons, []);
+  });
+
+  it("2-col banner+data subset with rawText preserves banner labels in bannerContext", () => {
+    // 2-column selection of two data columns (no label column in selection).
+    // Two banner rows at top carry column headers.  rawText carries the original
+    // text; cleanedValues has the numeric body after significance marker removal.
+    // bannerContext.scanRows must be sourced from rawText, not cleanedValues.
+    const rawText = [
+      ["Волна (квартал)", "Всего"],   // wide banner row 1
+      ["2025Q4", "2026Q1"],           // wide banner row 2
+      ["44%",  "41%"],                // data row (Мужской)
+      ["56%",  "59%"],                // data row (Женский)
+      ["5605", "1320"],               // BASE
+    ];
+    const cleanedValues = [
+      ["Волна (квартал)", "Всего"],   // unchanged (no markers)
+      ["2025Q4",          "2026Q1"],  // unchanged
+      [0.44, 0.41],                   // cleaned numeric
+      [0.56, 0.59],
+      [5605, 1320],
+    ];
+
+    const result = normalizeSelectedRange(cleanedValues, rawText);
+
+    assert.strictEqual(result.normalizationApplied, true, "must normalize");
+    assert.deepStrictEqual(result.bannerRows, [0, 1], "both banner rows detected");
+    assert.strictEqual(result.dataRowOffset, 2, "data starts after 2 banner rows");
+    assert.strictEqual(result.valuesForCalculation.length, 3, "three data rows");
+    assert.deepStrictEqual(result.bannerContext.scanRows[0], ["Волна (квартал)", "Всего"],
+      "first banner row from rawText");
+    assert.deepStrictEqual(result.bannerContext.scanRows[1], ["2025Q4", "2026Q1"],
+      "second banner row from rawText");
+    assert.strictEqual(result.bannerContext.columnCount, 2);
+    assert.deepStrictEqual(result.blockingReasons, []);
+  });
+
+  it("2-col purely numeric selection still passes through (no normalization)", () => {
+    // A 2-col selection of pure numbers must not trigger normalization — there is
+    // nothing structural to decompose.
+    const values = [
+      [0.44, 0.41],
+      [0.56, 0.59],
+      [5605, 1320],
+    ];
+    const result = normalizeSelectedRange(values);
+
+    assert.strictEqual(result.normalizationNeeded, false, "pure numeric 2-col must pass through");
+    assert.strictEqual(result.normalizationApplied, false);
+    assert.deepStrictEqual(result.blockingReasons, []);
+  });
+
+  it("2-col banner-only selection (no data rows) blocks with BODY_TOO_SHORT", () => {
+    // Selecting only the banner header rows without any data body must be blocked —
+    // there is nothing to calculate.
+    const values = [
+      ["Всего",  "Кат A"],  // banner
+      ["2025Q4", "2025Q4"], // banner
+    ];
+    const result = normalizeSelectedRange(values);
+
+    // Either not needed (too few rows for the gate) or blocked — must not produce
+    // a successful normalization with valuesForCalculation.
+    const noDataToCalculate =
+      result.normalizationNeeded === false ||
+      (result.normalizationApplied === false && result.blockingReasons.length > 0);
+    assert.ok(noDataToCalculate, `expected pass-through or blocked, got: ${JSON.stringify(result)}`);
+    assert.ok(
+      !result.normalizationApplied || result.valuesForCalculation.length === 0,
+      "must not produce a non-empty valuesForCalculation for a banner-only selection"
+    );
+  });
+
   it("[label | 0%-unit-col | data] with mixed 0% values does not strip non-uniform column", () => {
     // If col[1] has different values (not all uniform), it must NOT be treated as a
     // unit column even if some cells are "0%".  This protects real data columns.


### PR DESCRIPTION
## Summary

- **`GATE_MIN_COLS` lowered from 3 → 2** in `range-normalizer.js` so that 2-column selections enter the normalization path instead of falling to pass-through state. In pass-through, `detectEmbeddedLabelColumns` falsely fires on banner-row text values (e.g. `"2025Q4"` survives significance-marker stripping), producing empty row labels and causing `buildCalculationBlocks` to return `[]` → Check shows "Блоки расчёта: не обнаружены."
- **`isTitleLikeRow` fill-fraction guard added** to prevent fully-filled 2-column banner rows (like `["2025Q4", "2026Q1"]`) from being misclassified as title rows. The new check (`nonEmptyCount / colCount > BANNER_MIN_FILL_FRACTION`) excludes wide rows from title detection while leaving all existing sparse title rows (single cell in col[0], rest empty) completely unchanged.

## What changed

| File | Change |
|---|---|
| `src/core/range-normalizer.js` | `GATE_MIN_COLS = 3` → `2`; fill-fraction guard in `isTitleLikeRow` |
| `tests/core/range-normalizer.test.mjs` | 4 new tests under "Issue #132" section |

## New tests

1. **2-col banner+data subset normalizes** — single banner row separated from data body; `valuesForCalculation` has 3 correct rows
2. **2-col banner+data with rawText** — two banner rows; `bannerContext.scanRows` sourced from `rawText`
3. **2-col purely numeric still passes through** — pure-numeric 2-col stays in pass-through (regression guard)
4. **2-col banner-only blocks** — selection with no data body below banner rows does not produce false `valuesForCalculation`

## Validation

```
npm test   → 103/103 pass
npm run build → clean (3 pre-existing bundle-size warnings only)
```

## Reviewer notes

- No changes to `significance.js`, `excel-writer.js`, formula logic, `taskpane.js`, Table Inventory, auto-runner, or UI — strictly within the allowed scope for #132.
- The fill-fraction guard uses the existing `BANNER_MIN_FILL_FRACTION = 0.5` constant (strict `>`), so a 1-cell row in a 2-column table (fill = 50%) still qualifies as a title row, while a fully-filled 2-column banner row (fill = 100%) does not.
- All 25 existing `normalizeSelectedRange` tests continue to pass unchanged.

## Manual smoke checklist

1. Select 2 data columns of a "Ваш пол" table **including banner rows** → Check → calculation block visible
2. Select same 2 columns **data body only** (no banner rows) → Check → still works
3. Select full table → Check → unchanged
4. Select pure 2×3 numeric block → Check → unchanged pass-through