### PR TITLE
Add selected-base validity checks to Check table preview (#131)

### DIFF
--- a/src/core/range-normalizer.js
+++ b/src/core/range-normalizer.js
@@ -813,8 +813,13 @@ function buildNormalizedModel(
   bodyStartRow,
   bodyEndRow,
   confidence,
-  warnings
+  warnings,
+  fullBodyEndRow
 ) {
+  // fullBodyEndRow is the pre-trim body end (before findLastDataBodyRow).
+  // bodyEndRow is the trimmed end actually used for data slicing.
+  const safeFullBodyEndRow = fullBodyEndRow !== undefined ? fullBodyEndRow : bodyEndRow;
+
   const labelColumns = labelColCount > 0 ? buildIndexRange(0, labelColCount - 1) : [];
   const dataColumns  = buildIndexRange(dataColStart, dataColEnd);
   const bodyRows     = buildIndexRange(bodyStartRow, bodyEndRow);
@@ -828,10 +833,22 @@ function buildNormalizedModel(
   // Significance marker removal (applied to values before normalization) can erase
   // pure-letter label cells like "mean" or "BASE". Use text (Office.js selectedRange.text,
   // never marker-stripped) when it covers the body rows.
-  const leftLabelSource = text.length > bodyEndRow ? text : values;
+  const leftLabelSource = text.length > safeFullBodyEndRow ? text : values;
   const leftLabelValues = labelColCount > 0
     ? sliceGrid(leftLabelSource, bodyStartRow, bodyEndRow, 0, labelColCount - 1)
     : [];
+
+  // Rows trimmed by findLastDataBodyRow (blank/non-numeric trailing rows excluded from
+  // valuesForCalculation). The Check preview uses this to detect base rows whose data
+  // was stripped — without affecting Run calculations or the bodyRows slice.
+  const trailingBodyRows = safeFullBodyEndRow > bodyEndRow
+    ? {
+        values: sliceGrid(values, bodyEndRow + 1, safeFullBodyEndRow, dataColStart, dataColEnd),
+        leftLabelValues: labelColCount > 0
+          ? sliceGrid(leftLabelSource, bodyEndRow + 1, safeFullBodyEndRow, 0, labelColCount - 1)
+          : [],
+      }
+    : { values: [], leftLabelValues: [] };
 
   // Banner scan rows are sliced to data columns only so they align with
   // valuesForCalculation. detectBannerStructure expects column indices to
@@ -872,6 +889,7 @@ function buildNormalizedModel(
     warnings,
     blockingReasons: [],
     blockingMessage: "",
+    trailingBodyRows,
   };
 }
 
@@ -1086,6 +1104,7 @@ export function normalizeSelectedRange(rawValues, rawText, options = {}) {
     bodyStartRow,
     bodyDataEndRow,
     confidence,
-    warnings
+    warnings,
+    bodyEndRow   // full pre-trim end row — used only for trailingBodyRows
   );
 }

--- a/src/core/table-preview-model.js
+++ b/src/core/table-preview-model.js
@@ -140,6 +140,10 @@ export function buildTablePreviewModel(input) {
     ...checkBaseConsistency(safeValues, calculationBlocks, bannerStructure),
     ...checkNpsMismatch(safeValues, calculationBlocks),
     ...checkWeightedBaseFallback(calculationBlocks),
+    // Inspect rawBlocks (pre-filter) so that blank/non-numeric base rows are
+    // flagged even when blockHasPreviewEvidence later drops the block from
+    // calculationBlocks.  Deduplication by base row index is done inside.
+    ...checkSelectedBaseValidity(safeValues, rawBlocks, safeSettings),
   ];
 
   const qualitySummary = buildQualitySummary(dataQualityIssues);
@@ -1171,6 +1175,158 @@ function checkWeightedBaseFallback(calculationBlocks) {
       relatedColumnIndexes: [],
       evidence: { baseRowIndex: block.baseRowIndex, baseSubtype: "weighted" },
     });
+  }
+
+  return issues;
+}
+
+/**
+ * Checks that the selected base row for each raw block candidate contains usable values.
+ *
+ * Runs against rawBlocks (before blockHasPreviewEvidence filtering) so that a
+ * blank or non-numeric base row is flagged even when the block is later dropped
+ * from the final calculationBlocks list.
+ *
+ * Deduplicates by base row index — a shared base row is only inspected once.
+ *
+ * Issue codes and severities:
+ *   BASE_NO_VALID_VALUES     — critical: row has no numeric positive values at all
+ *   BASE_BLANK_VALUES        — warning: some cells are blank (other columns still valid)
+ *   BASE_NON_NUMERIC_VALUES  — warning: some cells are non-numeric (other columns still valid)
+ *   BASE_NON_POSITIVE_VALUES — warning: some cells are zero or negative (other columns still valid)
+ *   BASE_BELOW_THRESHOLD     — warning: some cells are below settings.smallBaseThreshold
+ */
+function checkSelectedBaseValidity(values, blocks, settings) {
+  const issues = [];
+  const seenBaseRows = new Set();
+
+  const threshold =
+    settings && typeof settings.smallBaseThreshold === "number"
+      ? settings.smallBaseThreshold
+      : null;
+
+  for (const block of blocks || []) {
+    // Use == null to handle both null and undefined — raw blocks are not yet
+    // normalised so baseRowIndex may be undefined rather than null.
+    if (block.baseRowIndex == null) continue;
+    if (seenBaseRows.has(block.baseRowIndex)) continue;
+    seenBaseRows.add(block.baseRowIndex);
+
+    const rowIndex = block.baseRowIndex;
+    const rawRow = Array.isArray(values) ? values[rowIndex] : null;
+    if (!Array.isArray(rawRow) || rawRow.length === 0) continue;
+
+    let blankCount = 0;
+    let nonNumericCount = 0;
+    let nonPositiveCount = 0;
+    let belowThresholdCount = 0;
+
+    for (const cell of rawRow) {
+      if (cell === null || cell === undefined || cell === "") {
+        blankCount++;
+        continue;
+      }
+      const s = String(cell).trim();
+      if (!s) {
+        blankCount++;
+        continue;
+      }
+      const n = Number(s.replace(",", "."));
+      if (Number.isNaN(n)) {
+        nonNumericCount++;
+        continue;
+      }
+      if (n <= 0) {
+        nonPositiveCount++;
+        continue;
+      }
+      // n is positive numeric
+      if (threshold !== null && n < threshold) {
+        belowThresholdCount++;
+      }
+    }
+
+    const totalCount = rawRow.length;
+    const invalidCount = blankCount + nonNumericCount + nonPositiveCount;
+    const rowLabel = `Row ${rowIndex + 1}`;
+
+    if (invalidCount === totalCount) {
+      // No usable base value in any column — significance is impossible.
+      issues.push({
+        code: "BASE_NO_VALID_VALUES",
+        severity: "critical",
+        message:
+          `${rowLabel}: selected base row has no valid numeric positive values ` +
+          `across all ${totalCount} column(s). Significance cannot be calculated.`,
+        rowIndex,
+        columnIndex: null,
+        relatedRowIndexes: [],
+        relatedColumnIndexes: [],
+        evidence: { blankCount, nonNumericCount, nonPositiveCount, totalCount },
+      });
+      continue;
+    }
+
+    // Partial issues — some valid columns remain.
+    if (blankCount > 0) {
+      issues.push({
+        code: "BASE_BLANK_VALUES",
+        severity: "warning",
+        message:
+          `${rowLabel}: selected base row has ${blankCount} blank cell(s) out of ${totalCount}. ` +
+          `Significance cannot be calculated for those columns.`,
+        rowIndex,
+        columnIndex: null,
+        relatedRowIndexes: [],
+        relatedColumnIndexes: [],
+        evidence: { blankCount, totalCount },
+      });
+    }
+
+    if (nonNumericCount > 0) {
+      issues.push({
+        code: "BASE_NON_NUMERIC_VALUES",
+        severity: "warning",
+        message:
+          `${rowLabel}: selected base row has ${nonNumericCount} non-numeric cell(s) out of ${totalCount}. ` +
+          `Significance cannot be calculated for those columns.`,
+        rowIndex,
+        columnIndex: null,
+        relatedRowIndexes: [],
+        relatedColumnIndexes: [],
+        evidence: { nonNumericCount, totalCount },
+      });
+    }
+
+    if (nonPositiveCount > 0) {
+      issues.push({
+        code: "BASE_NON_POSITIVE_VALUES",
+        severity: "warning",
+        message:
+          `${rowLabel}: selected base row has ${nonPositiveCount} zero or negative value(s) out of ${totalCount}. ` +
+          `Significance cannot be calculated for those columns.`,
+        rowIndex,
+        columnIndex: null,
+        relatedRowIndexes: [],
+        relatedColumnIndexes: [],
+        evidence: { nonPositiveCount, totalCount },
+      });
+    }
+
+    if (belowThresholdCount > 0) {
+      issues.push({
+        code: "BASE_BELOW_THRESHOLD",
+        severity: "warning",
+        message:
+          `${rowLabel}: selected base row has ${belowThresholdCount} column(s) with base below ` +
+          `the small-base threshold (${threshold}). Results for those columns may be unreliable.`,
+        rowIndex,
+        columnIndex: null,
+        relatedRowIndexes: [],
+        relatedColumnIndexes: [],
+        evidence: { belowThresholdCount, threshold, totalCount },
+      });
+    }
   }
 
   return issues;

--- a/src/core/table-preview-model.js
+++ b/src/core/table-preview-model.js
@@ -22,6 +22,7 @@
 import {
   detectMetricRowsFromLeftLabels,
   buildCalculationBlocks,
+  classifyMetricLabel,
   normalizeLabelText,
 } from "./metric-detector";
 
@@ -109,7 +110,7 @@ const PREVIEW_NUMERIC_WITH_MARKER_SUFFIX_RE =
  * @returns {object} Preview model — plain JSON-compatible object.
  */
 export function buildTablePreviewModel(input) {
-  const { values, leftLabelValues, bannerContext, settings } = input || {};
+  const { values, leftLabelValues, bannerContext, settings, trailingBodyRows } = input || {};
 
   const safeValues = Array.isArray(values) ? values : [];
   const safeLeft = Array.isArray(leftLabelValues) ? leftLabelValues : [];
@@ -143,7 +144,9 @@ export function buildTablePreviewModel(input) {
     // Inspect rawBlocks (pre-filter) so that blank/non-numeric base rows are
     // flagged even when blockHasPreviewEvidence later drops the block from
     // calculationBlocks.  Deduplication by base row index is done inside.
-    ...checkSelectedBaseValidity(safeValues, rawBlocks, safeSettings),
+    // trailingBodyRows covers base rows the normalizer stripped entirely because
+    // their data was all-blank — they never appear in rawBlocks at all.
+    ...checkSelectedBaseValidity(safeValues, rawBlocks, safeSettings, trailingBodyRows),
   ];
 
   const qualitySummary = buildQualitySummary(dataQualityIssues);
@@ -1196,7 +1199,7 @@ function checkWeightedBaseFallback(calculationBlocks) {
  *   BASE_NON_POSITIVE_VALUES — warning: some cells are zero or negative (other columns still valid)
  *   BASE_BELOW_THRESHOLD     — warning: some cells are below settings.smallBaseThreshold
  */
-function checkSelectedBaseValidity(values, blocks, settings) {
+function checkSelectedBaseValidity(values, blocks, settings, trailingBodyRows) {
   const issues = [];
   const seenBaseRows = new Set();
 
@@ -1325,6 +1328,38 @@ function checkSelectedBaseValidity(values, blocks, settings) {
         relatedRowIndexes: [],
         relatedColumnIndexes: [],
         evidence: { belowThresholdCount, threshold, totalCount },
+      });
+    }
+  }
+
+  // Secondary scan: trailing rows stripped by the normalizer.
+  // findLastDataBodyRow trims rows whose data is all-blank or all-non-numeric,
+  // so an invalid base row may not appear in values or rawBlocks at all.
+  // trailingBodyRows.leftLabelValues exposes those rows for label-based detection.
+  const trailingLeft = trailingBodyRows?.leftLabelValues;
+  if (Array.isArray(trailingLeft) && trailingLeft.length > 0) {
+    const valuesLength = Array.isArray(values) ? values.length : 0;
+    for (let i = 0; i < trailingLeft.length; i++) {
+      const labelRow = trailingLeft[i];
+      const rawLabel = Array.isArray(labelRow) ? labelRow[0] : undefined;
+      const classification = classifyMetricLabel(rawLabel);
+      if (classification?.rowType !== "base") continue;
+      const virtualRowIndex = valuesLength + i;
+      if (seenBaseRows.has(virtualRowIndex)) continue;
+      seenBaseRows.add(virtualRowIndex);
+      const trailingDataRow = trailingBodyRows.values?.[i];
+      const colCount = Array.isArray(trailingDataRow) ? trailingDataRow.length : 0;
+      issues.push({
+        code: "BASE_NO_VALID_VALUES",
+        severity: "critical",
+        message:
+          `Row ${virtualRowIndex + 1}: selected base row has no valid numeric positive values ` +
+          `across all ${colCount} column(s). Significance cannot be calculated.`,
+        rowIndex: virtualRowIndex,
+        columnIndex: null,
+        relatedRowIndexes: [],
+        relatedColumnIndexes: [],
+        evidence: { blankCount: colCount, nonNumericCount: 0, nonPositiveCount: 0, totalCount: colCount },
       });
     }
   }

--- a/src/taskpane/taskpane.js
+++ b/src/taskpane/taskpane.js
@@ -1051,6 +1051,7 @@ async function runCheckTable() {
       leftLabelValues,
       bannerContext,
       settings: calculationSettings,
+      trailingBodyRows: normalized?.trailingBodyRows,
     };
 
     const model = buildTablePreviewModel(modelInput);

--- a/tests/core/base-subtype-preview.test.mjs
+++ b/tests/core/base-subtype-preview.test.mjs
@@ -2,9 +2,9 @@ import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import { buildTablePreviewModel } from "../../src/core/table-preview-model.js";
 
-function makeModel(labels, values) {
+function makeModel(labels, values, settings = {}) {
   const leftLabelValues = labels.map((label) => [label]);
-  return buildTablePreviewModel({ values, leftLabelValues });
+  return buildTablePreviewModel({ values, leftLabelValues, settings });
 }
 
 function findBlock(model, metricType) {
@@ -244,5 +244,184 @@ describe("vertically merged / sparse Base labels", () => {
     if (block !== undefined) {
       assert.strictEqual(block.baseRowIndex, 2, "if a block is detected, base must be the labeled row");
     }
+  });
+});
+
+// ─── checkSelectedBaseValidity ────────────────────────────────────────────────
+
+describe("checkSelectedBaseValidity — selected base row quality issues", () => {
+  // Convenience: proportion table with a configurable base row and settings.
+  function baseModel(baseRow, settings = {}) {
+    return makeModel(
+      ["Agree", "Disagree", "BASE"],
+      [[0.4, 0.6], [0.6, 0.4], baseRow],
+      settings
+    );
+  }
+
+  // ── Valid base — no new issues ─────────────────────────────────────────────
+
+  it("valid ordinary BASE row → no base-validity issues", () => {
+    const model = baseModel([100, 200]);
+    const codes = warningCodes(model);
+    assert.ok(!codes.includes("BASE_NO_VALID_VALUES"), "unexpected BASE_NO_VALID_VALUES");
+    assert.ok(!codes.includes("BASE_BLANK_VALUES"), "unexpected BASE_BLANK_VALUES");
+    assert.ok(!codes.includes("BASE_NON_NUMERIC_VALUES"), "unexpected BASE_NON_NUMERIC_VALUES");
+    assert.ok(!codes.includes("BASE_NON_POSITIVE_VALUES"), "unexpected BASE_NON_POSITIVE_VALUES");
+    assert.ok(!codes.includes("BASE_BELOW_THRESHOLD"), "unexpected BASE_BELOW_THRESHOLD");
+  });
+
+  // ── Partial invalids — warning, not critical ───────────────────────────────
+
+  it("one blank base cell → BASE_BLANK_VALUES warning (not critical)", () => {
+    const model = baseModel([100, ""]);
+    const codes = warningCodes(model);
+    assert.ok(codes.includes("BASE_BLANK_VALUES"),
+      `expected BASE_BLANK_VALUES; got: ${JSON.stringify(codes)}`);
+    assert.ok(!codes.includes("BASE_NO_VALID_VALUES"), "must not be critical while some valid remain");
+    const issue = model.dataQualityIssues.find((i) => i.code === "BASE_BLANK_VALUES");
+    assert.strictEqual(issue.severity, "warning");
+    assert.strictEqual(issue.evidence.blankCount, 1);
+  });
+
+  it("null base cell → BASE_BLANK_VALUES warning", () => {
+    const model = baseModel([100, null]);
+    assert.ok(warningCodes(model).includes("BASE_BLANK_VALUES"),
+      "null cell should count as blank");
+  });
+
+  it("non-numeric text base cell → BASE_NON_NUMERIC_VALUES warning (not critical)", () => {
+    const model = baseModel([100, "n/a"]);
+    const codes = warningCodes(model);
+    assert.ok(codes.includes("BASE_NON_NUMERIC_VALUES"),
+      `expected BASE_NON_NUMERIC_VALUES; got: ${JSON.stringify(codes)}`);
+    assert.ok(!codes.includes("BASE_NO_VALID_VALUES"), "must not be critical while some valid remain");
+    const issue = model.dataQualityIssues.find((i) => i.code === "BASE_NON_NUMERIC_VALUES");
+    assert.strictEqual(issue.severity, "warning");
+  });
+
+  it("zero base cell → BASE_NON_POSITIVE_VALUES warning (not critical)", () => {
+    const model = baseModel([0, 200]);
+    const codes = warningCodes(model);
+    assert.ok(codes.includes("BASE_NON_POSITIVE_VALUES"),
+      `expected BASE_NON_POSITIVE_VALUES; got: ${JSON.stringify(codes)}`);
+    assert.ok(!codes.includes("BASE_NO_VALID_VALUES"), "must not be critical while some valid remain");
+    const issue = model.dataQualityIssues.find((i) => i.code === "BASE_NON_POSITIVE_VALUES");
+    assert.strictEqual(issue.severity, "warning");
+  });
+
+  it("negative base cell → BASE_NON_POSITIVE_VALUES warning (not critical)", () => {
+    const model = baseModel([-5, 200]);
+    const codes = warningCodes(model);
+    assert.ok(codes.includes("BASE_NON_POSITIVE_VALUES"),
+      `expected BASE_NON_POSITIVE_VALUES; got: ${JSON.stringify(codes)}`);
+    assert.ok(!codes.includes("BASE_NO_VALID_VALUES"), "must not be critical while some valid remain");
+  });
+
+  // ── All invalid — critical ─────────────────────────────────────────────────
+
+  it("all zero/negative → BASE_NO_VALID_VALUES critical", () => {
+    const model = baseModel([0, -10]);
+    const codes = warningCodes(model);
+    assert.ok(codes.includes("BASE_NO_VALID_VALUES"),
+      `expected BASE_NO_VALID_VALUES; got: ${JSON.stringify(codes)}`);
+    const issue = model.dataQualityIssues.find((i) => i.code === "BASE_NO_VALID_VALUES");
+    assert.strictEqual(issue.severity, "critical");
+    assert.ok(model.qualitySummary.hasBlockingIssues, "qualitySummary must reflect critical");
+    assert.ok(!codes.includes("BASE_NON_POSITIVE_VALUES"), "partial code must not also fire");
+  });
+
+  it("mix of zero and blank → BASE_NO_VALID_VALUES critical", () => {
+    const model = baseModel([0, ""]);
+    const codes = warningCodes(model);
+    assert.ok(codes.includes("BASE_NO_VALID_VALUES"),
+      `expected BASE_NO_VALID_VALUES; got: ${JSON.stringify(codes)}`);
+    assert.strictEqual(
+      model.dataQualityIssues.find((i) => i.code === "BASE_NO_VALID_VALUES").severity,
+      "critical"
+    );
+  });
+
+  // ── Regression: block filtered but check still fires ──────────────────────
+  // blockHasPreviewEvidence drops a block when rowHasNumericEvidence returns
+  // false for the base row (all-blank or all-non-numeric strings fail
+  // isPreviewNumericCellValue).  checkSelectedBaseValidity must still fire
+  // because it runs against rawBlocks, not the filtered calculationBlocks.
+
+  it("all-blank base row → BASE_NO_VALID_VALUES critical even when block is filtered (regression)", () => {
+    const model = makeModel(
+      ["Agree", "Disagree", "BASE"],
+      [[0.4, 0.6], [0.6, 0.4], ["", ""]]
+    );
+    assert.strictEqual(model.calculationBlocks.length, 0,
+      "block must be absent — confirms the regression scenario");
+    const codes = warningCodes(model);
+    assert.ok(codes.includes("BASE_NO_VALID_VALUES"),
+      `expected BASE_NO_VALID_VALUES via rawBlocks path; got: ${JSON.stringify(codes)}`);
+    assert.strictEqual(
+      model.dataQualityIssues.find((i) => i.code === "BASE_NO_VALID_VALUES").severity,
+      "critical"
+    );
+  });
+
+  it("all-non-numeric base row → BASE_NO_VALID_VALUES critical even when block is filtered (regression)", () => {
+    const model = makeModel(
+      ["Agree", "Disagree", "BASE"],
+      [[0.4, 0.6], [0.6, 0.4], ["n/a", "n/a"]]
+    );
+    assert.strictEqual(model.calculationBlocks.length, 0,
+      "block must be absent — confirms the regression scenario");
+    const codes = warningCodes(model);
+    assert.ok(codes.includes("BASE_NO_VALID_VALUES"),
+      `expected BASE_NO_VALID_VALUES for all-non-numeric base; got: ${JSON.stringify(codes)}`);
+  });
+
+  // ── Small-base threshold ──────────────────────────────────────────────────
+
+  it("base below smallBaseThreshold → BASE_BELOW_THRESHOLD warning", () => {
+    const model = baseModel([25, 200], { smallBaseThreshold: 30 });
+    const codes = warningCodes(model);
+    assert.ok(codes.includes("BASE_BELOW_THRESHOLD"),
+      `expected BASE_BELOW_THRESHOLD; got: ${JSON.stringify(codes)}`);
+    assert.ok(!codes.includes("BASE_NO_VALID_VALUES"),
+      "below-threshold values are positive numeric, not critical");
+    const issue = model.dataQualityIssues.find((i) => i.code === "BASE_BELOW_THRESHOLD");
+    assert.strictEqual(issue.severity, "warning");
+    assert.strictEqual(issue.evidence.belowThresholdCount, 1);
+    assert.strictEqual(issue.evidence.threshold, 30);
+  });
+
+  it("no BASE_BELOW_THRESHOLD when smallBaseThreshold is absent from settings", () => {
+    const model = baseModel([25, 200]);
+    assert.ok(!warningCodes(model).includes("BASE_BELOW_THRESHOLD"),
+      "threshold check must be opt-in via settings");
+  });
+
+  // ── Deduplication ─────────────────────────────────────────────────────────
+
+  it("shared base row across multiple blocks is checked only once (no duplicate issues)", () => {
+    // NPS structure and proportion blocks often share the same base row.
+    const model = makeModel(
+      ["NPS", "Promoters", "Detractors", "BASE"],
+      [[0.66, 0.56], [0.72, 0.65], [0.06, 0.09], [100, 0]]
+    );
+    const baseIssues = model.dataQualityIssues.filter(
+      (i) => i.code === "BASE_NON_POSITIVE_VALUES" && i.rowIndex === 3
+    );
+    assert.strictEqual(baseIssues.length, 1, "same base row must not produce duplicate issues");
+  });
+
+  // ── Weighted Base fallback co-existence ───────────────────────────────────
+
+  it("Weighted Base fallback warning still fires alongside base-validity issues", () => {
+    const model = makeModel(
+      ["Agree", "Disagree", "Weighted Base"],
+      [[0.4, 0.6], [0.6, 0.4], [100, 0]]
+    );
+    const codes = warningCodes(model);
+    assert.ok(codes.includes("WEIGHTED_BASE_FALLBACK"),
+      `expected WEIGHTED_BASE_FALLBACK; got: ${JSON.stringify(codes)}`);
+    assert.ok(codes.includes("BASE_NON_POSITIVE_VALUES"),
+      `expected BASE_NON_POSITIVE_VALUES alongside WEIGHTED_BASE_FALLBACK; got: ${JSON.stringify(codes)}`);
   });
 });

--- a/tests/core/base-subtype-preview.test.mjs
+++ b/tests/core/base-subtype-preview.test.mjs
@@ -1,6 +1,7 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import { buildTablePreviewModel } from "../../src/core/table-preview-model.js";
+import { normalizeSelectedRange } from "../../src/core/range-normalizer.js";
 
 function makeModel(labels, values, settings = {}) {
   const leftLabelValues = labels.map((label) => [label]);
@@ -423,5 +424,92 @@ describe("checkSelectedBaseValidity — selected base row quality issues", () =>
       `expected WEIGHTED_BASE_FALLBACK; got: ${JSON.stringify(codes)}`);
     assert.ok(codes.includes("BASE_NON_POSITIVE_VALUES"),
       `expected BASE_NON_POSITIVE_VALUES alongside WEIGHTED_BASE_FALLBACK; got: ${JSON.stringify(codes)}`);
+  });
+});
+
+// ─── Integration: normalizer path ─────────────────────────────────────────────
+// These tests go through normalizeSelectedRange → buildTablePreviewModel to verify
+// that BASE_NO_VALID_VALUES fires even when findLastDataBodyRow strips the base row
+// from valuesForCalculation (the regression caught by smoke testing).
+
+function makeNormalizedModel(rawValues, settings = {}) {
+  const normalized = normalizeSelectedRange(rawValues);
+  return buildTablePreviewModel({
+    values: normalized.valuesForCalculation,
+    leftLabelValues: normalized.leftLabelValues,
+    settings,
+    trailingBodyRows: normalized.trailingBodyRows,
+  });
+}
+
+describe("checkSelectedBaseValidity — normalizer integration (regression guard)", () => {
+  it("all-blank base row via normalizer path → BASE_NO_VALID_VALUES (regression)", () => {
+    // Full-table selection including label column. The normalizer strips the blank
+    // BASE row from valuesForCalculation because findLastDataBodyRow sees no numeric
+    // data there. trailingBodyRows must carry the BASE label so the Check preview
+    // can still emit BASE_NO_VALID_VALUES.
+    const rawValues = [
+      ["Agree", 0.4, 0.6],
+      ["Disagree", 0.6, 0.4],
+      ["BASE", "", ""],
+    ];
+    const normalized = normalizeSelectedRange(rawValues);
+    assert.strictEqual(normalized.normalizationApplied, true, "normalizer must apply");
+    assert.strictEqual(normalized.valuesForCalculation.length, 2,
+      "blank BASE row must be excluded from valuesForCalculation");
+    assert.ok(Array.isArray(normalized.trailingBodyRows?.leftLabelValues),
+      "trailingBodyRows must carry the stripped rows");
+    assert.strictEqual(normalized.trailingBodyRows.leftLabelValues.length, 1,
+      "one trailing row (BASE) must be present");
+
+    const model = makeNormalizedModel(rawValues);
+    const codes = warningCodes(model);
+    assert.ok(codes.includes("BASE_NO_VALID_VALUES"),
+      `expected BASE_NO_VALID_VALUES via normalizer path; got: ${JSON.stringify(codes)}`);
+  });
+
+  it("all-non-numeric base row via normalizer path → BASE_NO_VALID_VALUES (regression)", () => {
+    const rawValues = [
+      ["Agree", 0.4, 0.6],
+      ["Disagree", 0.6, 0.4],
+      ["BASE", "n/a", "n/a"],
+    ];
+    const normalized = normalizeSelectedRange(rawValues);
+    assert.strictEqual(normalized.valuesForCalculation.length, 2,
+      "non-numeric BASE row must be excluded from valuesForCalculation");
+
+    const model = makeNormalizedModel(rawValues);
+    assert.ok(warningCodes(model).includes("BASE_NO_VALID_VALUES"),
+      "BASE_NO_VALID_VALUES must fire for all-non-numeric base in normalizer path");
+  });
+
+  it("valid BASE row via normalizer path → no BASE_NO_VALID_VALUES", () => {
+    const rawValues = [
+      ["Agree", 0.4, 0.6],
+      ["Disagree", 0.6, 0.4],
+      ["BASE", 100, 200],
+    ];
+    const model = makeNormalizedModel(rawValues);
+    assert.ok(!warningCodes(model).includes("BASE_NO_VALID_VALUES"),
+      "valid base must not fire BASE_NO_VALID_VALUES");
+  });
+
+  it("trailing footer row (non-base label) via normalizer → no false BASE_NO_VALID_VALUES", () => {
+    // A legitimate trailing footer row with non-base label must not trigger the warning.
+    const rawValues = [
+      ["Agree", 0.4, 0.6],
+      ["Disagree", 0.6, 0.4],
+      ["BASE", 100, 200],
+      ["Все респонденты", "", ""],
+    ];
+    const normalized = normalizeSelectedRange(rawValues);
+    assert.strictEqual(normalized.valuesForCalculation.length, 3,
+      "footer row must be excluded from valuesForCalculation");
+    assert.strictEqual(normalized.trailingBodyRows.leftLabelValues.length, 1,
+      "one trailing row (footer) must be present");
+
+    const model = makeNormalizedModel(rawValues);
+    assert.ok(!warningCodes(model).includes("BASE_NO_VALID_VALUES"),
+      "non-base trailing footer must not produce BASE_NO_VALID_VALUES");
   });
 });


### PR DESCRIPTION
## Summary

- Adds `checkSelectedBaseValidity()` to `src/core/table-preview-model.js`
- Runs against **rawBlocks** (before `blockHasPreviewEvidence` filtering) so invalid base values are flagged even when `calculationBlocks` is empty because of a blank or non-numeric base row
- Deduplicates by base row index — shared base rows checked only once
- 14 new tests in `tests/core/base-subtype-preview.test.mjs`

## Issue codes added

| Code | Severity | Trigger |
|------|----------|---------|
| `BASE_NO_VALID_VALUES` | critical | All base cells are blank / non-numeric / ≤ 0 |
| `BASE_BLANK_VALUES` | warning | ≥1 blank cell, at least one valid column remains |
| `BASE_NON_NUMERIC_VALUES` | warning | ≥1 non-numeric cell, at least one valid column remains |
| `BASE_NON_POSITIVE_VALUES` | warning | ≥1 zero or negative cell, at least one valid column remains |
| `BASE_BELOW_THRESHOLD` | warning | ≥1 cell below `settings.smallBaseThreshold` (opt-in) |

## Why rawBlocks and not calculationBlocks

`blockHasPreviewEvidence` calls `rowHasNumericEvidence` on the base row before deciding whether to include the block. Blank strings and non-numeric strings fail `isPreviewNumericCellValue`, so a fully blank or fully non-numeric base row causes the block to be dropped entirely from `calculationBlocks`. By running validity checks against `rawBlocks` the feature surfaces an issue even in those cases. The two regression tests (`all-blank` and `all-non-numeric`) assert `calculationBlocks.length === 0` as a baseline before checking that the issue still fires.

## Scope

- Check / preview only — no Run behavior changed
- No significance formula changes
- No UI controls added
- No per-column base fallback
- No raw-data effective base calculation
- `significance.js`, `excel-writer.js`, `selected-range-interpreter.js` not touched

## Known limitation

Partial banner + data **subset** selections for a table sub-range may produce no `rawBlocks` when the selected-range interpreter returns no valid data area. In that case no base validity issue fires. This scenario also fails Run and is an interpretation issue, not a base-validity issue; it was tracked and fixed separately in #132 / PR #133. After that fix the partial-banner subset path is unblocked and base validity checks should now fire normally for those selections.

## Test plan

- [ ] `npm.cmd test` — 117 pass, 0 fail
- [ ] `npm.cmd run build` — 0 errors
- [ ] `git diff --check` — clean
- [ ] Manual: ordinary BASE row → no new warnings
- [ ] Manual: one blank base cell → `BASE_BLANK_VALUES` warning
- [ ] Manual: one non-numeric base cell → `BASE_NON_NUMERIC_VALUES` warning
- [ ] Manual: zero/negative base cell → `BASE_NON_POSITIVE_VALUES` warning
- [ ] Manual: all-blank / all-zero base → `BASE_NO_VALID_VALUES` critical
- [ ] Manual: Weighted Base only → `WEIGHTED_BASE_FALLBACK` still fires
- [ ] Manual: Run behavior unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)