### PR TITLE
Stabilize Check table preview issue output

### DIFF
--- a/src/core/table-preview-model.js
+++ b/src/core/table-preview-model.js
@@ -150,6 +150,7 @@ export function buildTablePreviewModel(input) {
   ];
 
   const qualitySummary = buildQualitySummary(dataQualityIssues);
+  const userVisibleIssues = buildUserVisibleIssues(dataQualityIssues);
   const summary = buildSummary(safeValues, rowDiagnostics, calculationBlocks, bannerStructure);
 
   // Flat warnings array — a convenience alias for UI compatibility.
@@ -167,6 +168,7 @@ export function buildTablePreviewModel(input) {
     bannerStructure,
     dataQualityIssues,
     qualitySummary,
+    userVisibleIssues,
     summary,
     warnings,
   };
@@ -1390,6 +1392,34 @@ function buildQualitySummary(issues) {
     infoCount,
     hasBlockingIssues: criticalCount > 0,
   };
+}
+
+function buildUserVisibleIssues(issues) {
+  return [...(issues || [])]
+    .filter((issue) => issue?.severity === "critical" || issue?.severity === "warning")
+    .sort((left, right) => {
+      const severityRank = { critical: 0, warning: 1 };
+      const severityDelta =
+        (severityRank[left.severity] ?? Number.MAX_SAFE_INTEGER) -
+        (severityRank[right.severity] ?? Number.MAX_SAFE_INTEGER);
+      if (severityDelta !== 0) {
+        return severityDelta;
+      }
+
+      const leftRow = left.rowIndex ?? Number.MAX_SAFE_INTEGER;
+      const rightRow = right.rowIndex ?? Number.MAX_SAFE_INTEGER;
+      if (leftRow !== rightRow) {
+        return leftRow - rightRow;
+      }
+
+      const leftCol = left.columnIndex ?? Number.MAX_SAFE_INTEGER;
+      const rightCol = right.columnIndex ?? Number.MAX_SAFE_INTEGER;
+      if (leftCol !== rightCol) {
+        return leftCol - rightCol;
+      }
+
+      return String(left.code || "").localeCompare(String(right.code || ""));
+    });
 }
 
 // ─── Summary ───────────────────────────────────────────────────────────────

--- a/src/taskpane/taskpane.js
+++ b/src/taskpane/taskpane.js
@@ -1055,7 +1055,14 @@ async function runCheckTable() {
     };
 
     const model = buildTablePreviewModel(modelInput);
-    const { summary, qualitySummary, warnings, bannerStructure, calculationBlocks, rowDiagnostics } = model;
+    const {
+      summary,
+      qualitySummary,
+      userVisibleIssues,
+      bannerStructure,
+      calculationBlocks,
+      rowDiagnostics,
+    } = model;
 
     if (summary.rowCount === 0) {
       setCheckMessage("Выделенный диапазон пуст.");
@@ -1077,22 +1084,32 @@ async function runCheckTable() {
       lines.push(...bannerLines);
     }
 
+    const issueLines = formatCheckUserVisibleIssues(userVisibleIssues);
+    if (issueLines.length > 0) {
+      lines.push("");
+      lines.push(...issueLines);
+    }
+
     const blockLines = formatCheckCalculationBlocks(calculationBlocks, rowDiagnostics);
     if (blockLines.length > 0) {
       lines.push("");
       lines.push(...blockLines);
     }
 
-    if (warnings && warnings.length > 0) {
-      lines.push("");
-      lines.push("Предупреждения:");
-      for (const warning of warnings) {
-        lines.push(`- [${warning.severity}] ${warning.text}`);
-      }
-    }
-
     setCheckMessage(lines.join("\n"));
   });
+}
+
+function formatCheckUserVisibleIssues(issues) {
+  if (!Array.isArray(issues) || issues.length === 0) {
+    return [];
+  }
+
+  const lines = ["Проблемы проверки:"];
+  for (const issue of issues) {
+    lines.push(`- [${issue.severity}] ${issue.message}`);
+  }
+  return lines;
 }
 
 /**

--- a/tests/core/base-subtype-preview.test.mjs
+++ b/tests/core/base-subtype-preview.test.mjs
@@ -16,6 +16,10 @@ function warningCodes(model) {
   return model.warnings.map((w) => w.code);
 }
 
+function userVisibleIssueCodes(model) {
+  return (model.userVisibleIssues || []).map((issue) => issue.code);
+}
+
 describe("base subtype selection — preview model metadata", () => {
   it("Weighted Base only → selected as fallback, WEIGHTED_BASE_FALLBACK warning present", () => {
     const model = makeModel(
@@ -363,6 +367,12 @@ describe("checkSelectedBaseValidity — selected base row quality issues", () =>
       model.dataQualityIssues.find((i) => i.code === "BASE_NO_VALID_VALUES").severity,
       "critical"
     );
+    assert.deepStrictEqual(userVisibleIssueCodes(model), ["BASE_NO_VALID_VALUES"]);
+    assert.strictEqual(
+      model.userVisibleIssues.length,
+      model.qualitySummary.criticalCount + model.qualitySummary.warningCount,
+      "userVisibleIssues must stay aligned with summary counts"
+    );
   });
 
   it("all-non-numeric base row → BASE_NO_VALID_VALUES critical even when block is filtered (regression)", () => {
@@ -424,6 +434,10 @@ describe("checkSelectedBaseValidity — selected base row quality issues", () =>
       `expected WEIGHTED_BASE_FALLBACK; got: ${JSON.stringify(codes)}`);
     assert.ok(codes.includes("BASE_NON_POSITIVE_VALUES"),
       `expected BASE_NON_POSITIVE_VALUES alongside WEIGHTED_BASE_FALLBACK; got: ${JSON.stringify(codes)}`);
+    assert.deepStrictEqual(userVisibleIssueCodes(model), [
+      "BASE_NON_POSITIVE_VALUES",
+      "WEIGHTED_BASE_FALLBACK",
+    ]);
   });
 });
 

--- a/tests/core/table-preview-model.test.mjs
+++ b/tests/core/table-preview-model.test.mjs
@@ -36,6 +36,10 @@ function warningCodes(model) {
   return model.warnings.map((warning) => warning.code);
 }
 
+function userVisibleIssueCodes(model) {
+  return (model.userVisibleIssues || []).map((issue) => issue.code);
+}
+
 function findBlock(model, metricType) {
   return model.calculationBlocks.find((block) => block.metricType === metricType);
 }
@@ -377,6 +381,26 @@ describe("buildTablePreviewModel - explicit base requirement", () => {
 
     assert.deepStrictEqual(model.calculationBlocks, []);
     assert.strictEqual(model.summary.detectedBlocks, 0);
+  });
+
+  it("keeps user-visible preview issues available when no calculation blocks are detected", () => {
+    const model = makeCustomPreviewModel(
+      [
+        [0.21, 0.45, 0.33],
+        [0.15, 0.28, 0.57],
+        ["", "", ""],
+      ],
+      ["Agree", "Disagree", "BASE"]
+    );
+
+    assert.deepStrictEqual(model.calculationBlocks, []);
+    assert.deepStrictEqual(userVisibleIssueCodes(model), ["BASE_NO_VALID_VALUES"]);
+    assert.strictEqual(model.qualitySummary.criticalCount, 1);
+    assert.strictEqual(model.qualitySummary.warningCount, 0);
+    assert.strictEqual(
+      model.userVisibleIssues.length,
+      model.qualitySummary.criticalCount + model.qualitySummary.warningCount
+    );
   });
 
   it("still reports a proportion block when an explicit base is present", () => {


### PR DESCRIPTION
## Summary
Stabilizes the Check table preview output so critical and warning diagnostics stay user-visible even when no calculation blocks are detected.

## Root cause
The Check panel rendered the structural block summary before the preview diagnostics and relied on the legacy warnings alias directly. That made the generic Блоки расчёта: не обнаружены. line more prominent than the actionable base-validity diagnostics in empty-block scenarios, and it left the rendered issue list loosely coupled to the summary counts.

## Implementation
- add userVisibleIssues to the preview model as a stable, warning/critical-only list sorted with critical issues first
- render userVisibleIssues in the Check output before the calculation-block summary
- keep the Блоки расчёта: не обнаружены. line as structural context without letting it suppress preview diagnostics
- add regression coverage for empty-block base-validity scenarios and summary-count alignment

## Files changed
- src/core/table-preview-model.js
- src/taskpane/taskpane.js
- tests/core/base-subtype-preview.test.mjs
- tests/core/table-preview-model.test.mjs

## Validation
- 
pm.cmd test ✅
- 
pm.cmd run build ✅ (existing webpack asset-size warnings only)
- git diff --check ✅

## Scope / non-goals
- Check table / preview output only
- no Run behavior changes
- no significance formula changes
- no auto-runner
- no weighted-base calculation support
- no taskpane redesign

## Technical debt / limitations
- This PR stabilizes the text output contract used by the current Check panel; it does not introduce a broader rendering abstraction.
- The legacy warnings alias is kept for compatibility, while the Check panel now relies on userVisibleIssues for stable user-facing diagnostics.
