### PR TITLE
Extend Table Inventory to whole-workbook scanning

### DIFF
--- a/src/core/table-inventory-scanner.js
+++ b/src/core/table-inventory-scanner.js
@@ -83,6 +83,24 @@ function isTextOnlyCell(cell) {
   return !isNumericCell(cell);
 }
 
+function isLikelyOrdinalScaleLabelCell(cell) {
+  if (typeof cell === "number") {
+    return Number.isInteger(cell) && cell >= 0 && cell <= 10;
+  }
+
+  if (typeof cell !== "string") {
+    return false;
+  }
+
+  const trimmed = cell.trim();
+  if (!/^\d+$/.test(trimmed)) {
+    return false;
+  }
+
+  const value = Number(trimmed);
+  return Number.isInteger(value) && value >= 0 && value <= 10;
+}
+
 function firstNonEmptyNonNumericText(row) {
   for (const cell of row) {
     if (isCellEmpty(cell)) continue;
@@ -177,6 +195,39 @@ function computeTextFraction(values, startCol, endCol, startRow, endRow) {
   return textCount / totalNonEmpty;
 }
 
+function isLikelyRatingScaleLabelColumn(values, colIndex, startRow, endRow) {
+  let totalNonEmpty = 0;
+  let textOnlyCount = 0;
+  let ordinalScaleCount = 0;
+
+  for (let row = startRow; row <= endRow; row++) {
+    const rowArr = values[row];
+    if (!rowArr) continue;
+
+    const cell = rowArr[colIndex];
+    if (isCellEmpty(cell)) continue;
+
+    totalNonEmpty++;
+
+    if (isTextOnlyCell(cell)) {
+      textOnlyCount++;
+      continue;
+    }
+
+    if (isLikelyOrdinalScaleLabelCell(cell)) {
+      ordinalScaleCount++;
+    }
+  }
+
+  if (totalNonEmpty === 0) {
+    return false;
+  }
+
+  const labelLikeFraction = (textOnlyCount + ordinalScaleCount) / totalNonEmpty;
+
+  return textOnlyCount >= 2 && ordinalScaleCount >= 3 && labelLikeFraction >= 0.8;
+}
+
 function splitLabelData(values, band) {
   const { localStartRow, localEndRow, localTrimmedFirstCol, localTrimmedLastCol } = band;
   const trimmedWidth = localTrimmedLastCol - localTrimmedFirstCol + 1;
@@ -201,7 +252,9 @@ function splitLabelData(values, band) {
       localStartRow,
       localEndRow
     );
-    const col0IsText = col0Fraction >= LABEL_TEXT_FRACTION_THRESHOLD;
+    const col0IsText =
+      col0Fraction >= LABEL_TEXT_FRACTION_THRESHOLD ||
+      isLikelyRatingScaleLabelColumn(values, localTrimmedFirstCol, localStartRow, localEndRow);
 
     if (!col0IsText) {
       // First column looks numeric — split is ambiguous.

--- a/src/taskpane/taskpane.js
+++ b/src/taskpane/taskpane.js
@@ -1262,80 +1262,158 @@ function setCheckMessage(message) {
   }
 }
 
-async function runTableInventory() {
-  await Excel.run(async (context) => {
-    const worksheet = context.workbook.worksheets.getActiveWorksheet();
-    worksheet.load("name");
+function getInventoryCandidateStatusLabel(candidateStatus) {
+  if (candidateStatus === "available") {
+    return "Кандидат — рекомендуется «Проверить таблицу»";
+  }
 
-    const usedRange = worksheet.getUsedRangeOrNullObject();
-    usedRange.load(["isNullObject", "rowIndex", "columnIndex", "rowCount", "columnCount"]);
+  if (candidateStatus === "uncertain") {
+    return "Кандидат (неопределён) — требует «Проверить таблицу»";
+  }
 
-    await context.sync();
+  return "Не опознан как таблица RIT";
+}
 
-    if (usedRange.isNullObject) {
-      setInventoryMessage("Лист пуст. Таблицы не найдены.");
-      return;
-    }
+function formatInventoryItemLines(item, index) {
+  const lines = [];
+  const header = item.title ? `${index}. ${item.title} — ${item.rangeAddress}` : `${index}. ${item.rangeAddress}`;
 
-    const cellCount = usedRange.rowCount * usedRange.columnCount;
-    if (cellCount > SCAN_CELL_LIMIT) {
-      setInventoryMessage(
-        `Лист слишком большой для сканирования (${usedRange.rowCount} стр. × ${usedRange.columnCount} кол. = ${cellCount} ячеек, лимит: ${SCAN_CELL_LIMIT}).\nИспользуйте «Проверить таблицу» с выделенным диапазоном.`
-      );
-      return;
-    }
+  lines.push(header);
+  lines.push(`   ${item.rowCount} строк, ${item.columnCount} колонок.`);
 
-    usedRange.load("values");
-    await context.sync();
+  if (item.previewSummary) {
+    lines.push(`   ${item.previewSummary}.`);
+  }
 
-    const items = scanWorksheetForTables({
-      values: usedRange.values,
-      usedRangeRowOffset: usedRange.rowIndex,
-      usedRangeColOffset: usedRange.columnIndex,
-      sheetName: worksheet.name,
-    });
+  const warnParts = [];
+  if (item.criticalCount > 0) warnParts.push(`Критических: ${item.criticalCount}`);
+  if (item.warningsCount > 0) warnParts.push(`Предупреждений: ${item.warningsCount}`);
+  if (warnParts.length > 0) lines.push(`   ${warnParts.join(". ")}.`);
 
-    if (items.length === 0) {
-      setInventoryMessage("Таблицы не найдены. RIT не обнаружил блоков с данными на этом листе.");
-      return;
-    }
+  // candidateStatus replaces the former "Значимость: да/нет" line.
+  // Inventory is a candidate finder only; Check Table is the authoritative step.
+  lines.push(`   ${getInventoryCandidateStatusLabel(item.candidateStatus)}.`);
 
-    const lines = [`Найдено таблиц: ${items.length}.`, ""];
+  if (item.candidateNotes && item.candidateNotes.length > 0) {
+    lines.push(`   [${item.candidateNotes.join("; ")}]`);
+  }
 
-    items.forEach((item, idx) => {
-      const header = item.title
-        ? `${idx + 1}. ${item.title} — ${item.rangeAddress}`
-        : `${idx + 1}. ${item.rangeAddress}`;
-      lines.push(header);
-      lines.push(`   ${item.rowCount} строк, ${item.columnCount} колонок.`);
+  return lines;
+}
 
-      if (item.previewSummary) {
-        lines.push(`   ${item.previewSummary}.`);
-      }
+function formatWorkbookInventoryMessage({ scannedSheets, sheetResults, skippedSheets }) {
+  const totalCandidates = sheetResults.reduce((sum, sheetResult) => sum + sheetResult.items.length, 0);
+  const lines = [
+    `Таблиц в книге: ${totalCandidates}.`,
+    `Листов с кандидатами: ${sheetResults.length}.`,
+    `Просканировано листов: ${scannedSheets}.`,
+  ];
 
-      const warnParts = [];
-      if (item.criticalCount > 0) warnParts.push(`Критических: ${item.criticalCount}`);
-      if (item.warningsCount > 0) warnParts.push(`Предупреждений: ${item.warningsCount}`);
-      if (warnParts.length > 0) lines.push(`   ${warnParts.join(". ")}.`);
+  if (totalCandidates === 0) {
+    lines.push("");
+    lines.push("RIT не обнаружил в книге блоков данных, похожих на таблицы для проверки.");
+  }
 
-      // candidateStatus replaces the former "Значимость: да/нет" line.
-      // Inventory is a candidate finder only; Check Table is the authoritative step.
-      const statusLabel =
-        item.candidateStatus === "available"
-          ? "Кандидат — рекомендуется «Проверить таблицу»"
-          : item.candidateStatus === "uncertain"
-          ? "Кандидат (неопределён) — требует «Проверить таблицу»"
-          : "Не опознан как таблица RIT";
-      lines.push(`   ${statusLabel}.`);
+  for (const sheetResult of sheetResults) {
+    lines.push("");
+    lines.push(`Лист: ${sheetResult.sheetName}`);
 
-      if (item.candidateNotes && item.candidateNotes.length > 0) {
-        lines.push(`   [${item.candidateNotes.join("; ")}]`);
-      }
-
+    sheetResult.items.forEach((item, index) => {
+      lines.push(...formatInventoryItemLines(item, index + 1));
       lines.push("");
     });
 
-    setInventoryMessage(lines.join("\n").trimEnd());
+    if (lines[lines.length - 1] === "") {
+      lines.pop();
+    }
+  }
+
+  if (skippedSheets.length > 0) {
+    lines.push("");
+    lines.push("Пропущенные листы:");
+
+    skippedSheets.forEach((sheet) => {
+      if (sheet.reason === "empty") {
+        lines.push(`- ${sheet.sheetName}: пустой лист.`);
+        return;
+      }
+
+      lines.push(
+        `- ${sheet.sheetName}: слишком большой для сканирования (${sheet.rowCount} стр. × ${sheet.columnCount} кол. = ${sheet.cellCount} ячеек, лимит: ${SCAN_CELL_LIMIT}).`
+      );
+    });
+  }
+
+  lines.push("");
+  lines.push("Table Inventory — это только поиск кандидатов. Для проверки используйте «Проверить таблицу».");
+
+  return lines.join("\n").trimEnd();
+}
+
+async function runTableInventory() {
+  await Excel.run(async (context) => {
+    const worksheets = context.workbook.worksheets;
+    worksheets.load("items/name");
+
+    await context.sync();
+
+    const worksheetEntries = worksheets.items.map((worksheet) => {
+      const usedRange = worksheet.getUsedRangeOrNullObject();
+      usedRange.load(["isNullObject", "rowIndex", "columnIndex", "rowCount", "columnCount"]);
+
+      return { worksheet, usedRange };
+    });
+
+    await context.sync();
+
+    const scannedEntries = [];
+    const skippedSheets = [];
+
+    for (const entry of worksheetEntries) {
+      const { worksheet, usedRange } = entry;
+
+      if (usedRange.isNullObject) {
+        skippedSheets.push({ sheetName: worksheet.name, reason: "empty" });
+        continue;
+      }
+
+      const cellCount = usedRange.rowCount * usedRange.columnCount;
+      if (cellCount > SCAN_CELL_LIMIT) {
+        skippedSheets.push({
+          sheetName: worksheet.name,
+          reason: "tooLarge",
+          rowCount: usedRange.rowCount,
+          columnCount: usedRange.columnCount,
+          cellCount,
+        });
+        continue;
+      }
+
+      usedRange.load("values");
+      scannedEntries.push(entry);
+    }
+
+    await context.sync();
+
+    const sheetResults = scannedEntries
+      .map(({ worksheet, usedRange }) => ({
+        sheetName: worksheet.name,
+        items: scanWorksheetForTables({
+          values: usedRange.values,
+          usedRangeRowOffset: usedRange.rowIndex,
+          usedRangeColOffset: usedRange.columnIndex,
+          sheetName: worksheet.name,
+        }),
+      }))
+      .filter((sheetResult) => sheetResult.items.length > 0);
+
+    setInventoryMessage(
+      formatWorkbookInventoryMessage({
+        scannedSheets: scannedEntries.length,
+        sheetResults,
+        skippedSheets,
+      })
+    );
   });
 }
 

--- a/tests/core/table-inventory-scanner.test.mjs
+++ b/tests/core/table-inventory-scanner.test.mjs
@@ -235,4 +235,57 @@ describe("scanWorksheetForTables", () => {
     assert.ok(Array.isArray(items[0].candidateNotes), "candidateNotes must be an array");
     assert.strictEqual(items[0].reasonsIfNotRunnable, undefined, "reasonsIfNotRunnable must not exist");
   });
+
+  it("rating/NPS scale labels in the first column keep the label split confident", () => {
+    const values = [
+      ["Score", "Total", "Male", "Female"],
+      ["1 - very unlikely", 5, 4, 6],
+      ["2", 6, 5, 7],
+      ["3", 7, 6, 8],
+      ["4", 8, 7, 9],
+      ["5", 9, 8, 10],
+      ["6", 10, 9, 11],
+      ["7", 11, 10, 12],
+      ["8", 12, 11, 13],
+      ["9", 13, 12, 14],
+      ["10 - very likely", 14, 13, 15],
+      ["Bottom-3", 18, 17, 19],
+      ["Mid-4", 32, 30, 34],
+      ["Top-3", 50, 53, 47],
+      ["Detractors", 20, 19, 18],
+      ["Neutral", 30, 29, 31],
+      ["Promoters", 50, 52, 51],
+      ["NPS", 30, 33, 33],
+      ["BASE", 1000, 500, 500],
+    ];
+
+    const items = scanWorksheetForTables({ values, ...OFFSET });
+    assert.ok(items.length >= 1, "expected at least one item");
+
+    const item = items[0];
+    assert.strictEqual(item.labelSplitConfidence, "confident");
+    assert.ok(
+      !item.candidateNotes.includes("Граница лейблов/данных не определена"),
+      "rating/NPS label column should not produce an uncertain label/data boundary note"
+    );
+  });
+
+  it("pure numeric first columns still stay uncertain when they look like data, not labels", () => {
+    const values = [
+      [1, 10, 20, 30],
+      [2, 40, 50, 60],
+      [3, 70, 80, 90],
+      [4, 100, 110, 120],
+    ];
+
+    const items = scanWorksheetForTables({ values, ...OFFSET });
+
+    if (items.length > 0) {
+      assert.strictEqual(
+        items[0].labelSplitConfidence,
+        "uncertain",
+        "pure numeric first columns must not become confidently label-like"
+      );
+    }
+  });
 });


### PR DESCRIPTION
## Summary
- extend Table Inventory from active-sheet-only scanning to whole-workbook scanning in the Office.js/taskpane layer
- reuse the existing pure scanWorksheetForTables() scanner and keep workbook inventory read-only
- group candidates by worksheet name and report skipped empty or too-large sheets without blocking other sheets

## Files changed
- src/taskpane/taskpane.js

## Validation
- npm.cmd test
- npm.cmd run build
- git diff --check

## Manual smoke notes / limitations
- Not run manually in Excel in this environment
- Empty sheets are summarized as skipped
- Sheets above SCAN_CELL_LIMIT are skipped and reported, while other sheets continue scanning
- Inventory output still routes users toward Check Table and does not imply Run-readiness