### PR TITLE
Content sheet: first-position placement, client mode, and hyperlinks (#147 slice)

### DIFF
--- a/src/taskpane/taskpane.css
+++ b/src/taskpane/taskpane.css
@@ -495,6 +495,25 @@ b {
   background: #dcfce7;
 }
 
+.inventory-mode-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 6px;
+  font-size: 12px;
+  color: var(--rs-color-muted);
+}
+
+.inventory-mode-select {
+  flex: 1;
+  padding: 3px 6px;
+  border: 1px solid var(--rs-color-border);
+  border-radius: var(--rs-radius-sm);
+  font-size: 12px;
+  background: var(--rs-color-bg);
+  color: var(--rs-color-text);
+}
+
 .check-panel {
   margin-top: 8px;
   border-color: #bbf7d0;

--- a/src/taskpane/taskpane.html
+++ b/src/taskpane/taskpane.html
@@ -55,6 +55,13 @@
           <button id="check-table" class="check-action-button">Проверить таблицу</button>
           <button id="find-tables" class="check-action-button">Найти таблицы</button>
         </div>
+        <div class="inventory-mode-row">
+          <label for="content-output-mode">Режим Content</label>
+          <select id="content-output-mode" class="inventory-mode-select">
+            <option value="minimal-check">С минимальной проверкой</option>
+            <option value="client">Для клиента</option>
+          </select>
+        </div>
       </section>
 
       <section id="status-panel" class="status-panel" style="display: none">

--- a/src/taskpane/taskpane.html
+++ b/src/taskpane/taskpane.html
@@ -56,7 +56,7 @@
           <button id="find-tables" class="check-action-button">Найти таблицы</button>
         </div>
         <div class="inventory-mode-row">
-          <label for="content-output-mode">Режим Content</label>
+          <label for="content-output-mode">Формат оглавления</label>
           <select id="content-output-mode" class="inventory-mode-select">
             <option value="minimal-check">С минимальной проверкой</option>
             <option value="client">Для клиента</option>

--- a/src/taskpane/taskpane.js
+++ b/src/taskpane/taskpane.js
@@ -68,6 +68,8 @@ const INVENTORY_CONTENT_COLUMNS = [
   "Critical",
 ];
 
+const INVENTORY_CLIENT_COLUMNS = ["#", "Название таблицы", "Подзаголовок", "Лист", "Ссылка"];
+
 function formatBannerUserMessages(bannerStructure) {
   if (!bannerStructure || !bannerStructure.messages) {
     return "";
@@ -1538,6 +1540,34 @@ function buildInventoryContentSkippedRows(skippedSheets) {
   });
 }
 
+function readContentOutputModeFromPanel() {
+  const select = document.getElementById("content-output-mode");
+  return select ? select.value : "minimal-check";
+}
+
+function getContentTableHyperlinkTarget(sheetName, rangeAddress) {
+  if (!sheetName || !rangeAddress) return null;
+  const escaped = sheetName.replace(/'/g, "''");
+  const needsQuotes = /[^A-Za-z0-9_]/.test(escaped);
+  const quotedSheet = needsQuotes ? `'${escaped}'` : escaped;
+  return `${quotedSheet}!${rangeAddress}`;
+}
+
+function buildClientContentRows(sheetResults) {
+  const rows = [];
+  let index = 1;
+  for (const sheetResult of sheetResults) {
+    for (const item of sheetResult.items) {
+      rows.push([index, item.title || "", "", item.sheetName || sheetResult.sheetName, item.rangeAddress || ""]);
+      index++;
+    }
+  }
+  if (rows.length === 0) {
+    rows.push(["", "Кандидаты не обнаружены", "", "", ""]);
+  }
+  return rows;
+}
+
 async function ensureInventoryContentWorksheet(context) {
   const worksheets = context.workbook.worksheets;
   const worksheet = worksheets.getItemOrNullObject(INVENTORY_CONTENT_SHEET_NAME);
@@ -1552,16 +1582,12 @@ async function ensureInventoryContentWorksheet(context) {
   return worksheets.add(INVENTORY_CONTENT_SHEET_NAME);
 }
 
-async function writeInventoryContentSheet(context, inventoryResults) {
-  const worksheet = await ensureInventoryContentWorksheet(context);
-  const existingUsedRange = worksheet.getUsedRangeOrNullObject();
-  existingUsedRange.load("isNullObject");
-
-  await context.sync();
-
-  if (!existingUsedRange.isNullObject) {
-    existingUsedRange.unmerge();
-    existingUsedRange.clear();
+function writeMinimalCheckContent(worksheet, inventoryResults) {
+  const allItems = [];
+  for (const sheetResult of inventoryResults.sheetResults) {
+    for (const item of sheetResult.items) {
+      allItems.push(item);
+    }
   }
 
   const candidateRows = normalizeRowsToColumnCount(
@@ -1585,11 +1611,11 @@ async function writeInventoryContentSheet(context, inventoryResults) {
 
   const metadataRows = normalizeRowsToColumnCount(
     [
-    ["Generated sheet", INVENTORY_CONTENT_SHEET_NAME],
-    ["Scanned sheets", inventoryResults.scannedSheets],
-    ["Candidate sheets", inventoryResults.sheetResults.length],
-    ["Detected candidates", totalCandidates],
-    ["Reminder", "Inventory is a candidate finder only. Use «Проверить таблицу» for interpretation."],
+      ["Generated sheet", INVENTORY_CONTENT_SHEET_NAME],
+      ["Scanned sheets", inventoryResults.scannedSheets],
+      ["Candidate sheets", inventoryResults.sheetResults.length],
+      ["Detected candidates", totalCandidates],
+      ["Reminder", "Inventory is a candidate finder only. Use «Проверить таблицу» for interpretation."],
     ],
     2
   );
@@ -1661,6 +1687,99 @@ async function writeInventoryContentSheet(context, inventoryResults) {
   });
 
   worksheet.getRange("A:K").format.verticalAlignment = "Top";
+
+  const RANGE_COL_INDEX = 3;
+  for (let i = 0; i < allItems.length; i++) {
+    const item = allItems[i];
+    const hyperlinkTarget = getContentTableHyperlinkTarget(item.sheetName, item.rangeAddress);
+    if (hyperlinkTarget) {
+      const cell = worksheet.getRangeByIndexes(headerRowIndex + i, RANGE_COL_INDEX, 1, 1);
+      cell.hyperlink = {
+        documentReference: hyperlinkTarget,
+        screenTip: `${item.sheetName}!${item.rangeAddress}`,
+      };
+    }
+  }
+}
+
+function writeClientFacingContent(worksheet, inventoryResults) {
+  const allItems = [];
+  for (const sheetResult of inventoryResults.sheetResults) {
+    for (const item of sheetResult.items) {
+      allItems.push(item);
+    }
+  }
+
+  const clientRows = buildClientContentRows(inventoryResults.sheetResults);
+  const colCount = INVENTORY_CLIENT_COLUMNS.length;
+
+  const titleRange = worksheet.getRangeByIndexes(0, 0, 1, colCount);
+  titleRange.values = normalizeRowsToColumnCount([["Инвентарь таблиц"]], colCount);
+  titleRange.merge();
+  titleRange.format.font.bold = true;
+  titleRange.format.font.size = 14;
+
+  const headerRowIndex = 2;
+  const headerRange = worksheet.getRangeByIndexes(headerRowIndex - 1, 0, 1, colCount);
+  headerRange.values = normalizeRowsToColumnCount([INVENTORY_CLIENT_COLUMNS], colCount);
+  headerRange.format.font.bold = true;
+
+  const dataRows = normalizeRowsToColumnCount(clientRows, colCount);
+  const dataRange = worksheet.getRangeByIndexes(headerRowIndex, 0, dataRows.length, colCount);
+  dataRange.values = dataRows;
+  dataRange.format.wrapText = false;
+
+  const tableRange = worksheet.getRangeByIndexes(headerRowIndex - 1, 0, dataRows.length + 1, colCount);
+  tableRange.format.borders.getItem("EdgeBottom").style = "Continuous";
+  tableRange.format.borders.getItem("EdgeTop").style = "Continuous";
+  tableRange.format.borders.getItem("EdgeLeft").style = "Continuous";
+  tableRange.format.borders.getItem("EdgeRight").style = "Continuous";
+  tableRange.format.borders.getItem("InsideHorizontal").style = "Continuous";
+  tableRange.format.borders.getItem("InsideVertical").style = "Continuous";
+
+  const columnWidths = [42, 260, 180, 120, 100];
+  columnWidths.forEach((width, index) => {
+    worksheet.getRangeByIndexes(0, index, 1, 1).format.columnWidth = width;
+  });
+
+  worksheet.getRangeByIndexes(0, 0, dataRows.length + headerRowIndex, colCount).format.verticalAlignment = "Top";
+
+  const LINK_COL_INDEX = 4;
+  for (let i = 0; i < allItems.length; i++) {
+    const item = allItems[i];
+    const hyperlinkTarget = getContentTableHyperlinkTarget(item.sheetName, item.rangeAddress);
+    if (hyperlinkTarget) {
+      const cell = worksheet.getRangeByIndexes(headerRowIndex + i, LINK_COL_INDEX, 1, 1);
+      cell.hyperlink = {
+        documentReference: hyperlinkTarget,
+        screenTip: `${item.sheetName}!${item.rangeAddress}`,
+      };
+    }
+  }
+}
+
+async function writeInventoryContentSheet(context, inventoryResults) {
+  const worksheet = await ensureInventoryContentWorksheet(context);
+  const existingUsedRange = worksheet.getUsedRangeOrNullObject();
+  existingUsedRange.load("isNullObject");
+
+  await context.sync();
+
+  if (!existingUsedRange.isNullObject) {
+    existingUsedRange.unmerge();
+    existingUsedRange.clear();
+  }
+
+  const mode = readContentOutputModeFromPanel();
+
+  if (mode === "client") {
+    writeClientFacingContent(worksheet, inventoryResults);
+  } else {
+    writeMinimalCheckContent(worksheet, inventoryResults);
+  }
+
+  worksheet.position = 0;
+
   await context.sync();
 }
 


### PR DESCRIPTION
## Summary

- **Content sheet placement**: `worksheet.position = 0` moves Content to the first worksheet position after every run. `ensureInventoryContentWorksheet` reuses the existing sheet by name, so re-running never creates duplicates.
- **Output mode control**: new dropdown in the action panel — *С минимальной проверкой* (default) / *Для клиента*.
- **Hyperlinks**: both modes add `range.hyperlink = { documentReference }` links to detected table ranges. Sheet names with spaces or special characters are safely single-quoted per Excel convention.

## Files changed

| File | Change |
|---|---|
| `src/taskpane/taskpane.js` | New helpers (`readContentOutputModeFromPanel`, `getContentTableHyperlinkTarget`, `buildClientContentRows`); refactored `writeInventoryContentSheet` into dispatcher + `writeMinimalCheckContent` + `writeClientFacingContent`; `worksheet.position = 0` in dispatcher |
| `src/taskpane/taskpane.html` | Added `<select id="content-output-mode">` below the Найти таблицы button |
| `src/taskpane/taskpane.css` | `.inventory-mode-row` / `.inventory-mode-select` minimal styles |

**Scanner/core logic: unchanged.** Only `taskpane.js`, `taskpane.html`, `taskpane.css` were modified.

## How Content is moved to first sheet

`worksheet.position = 0` is set inside `writeInventoryContentSheet` after writing content, then flushed in the single final `context.sync()`. No sheet-order assumptions are made — Office.js resolves position 0 to the first slot regardless of current order.

## How hyperlinks are implemented

After writing cell values, a loop iterates over detected items and calls:
```js
cell.hyperlink = {
  documentReference: getContentTableHyperlinkTarget(item.sheetName, item.rangeAddress),
  screenTip: "...",
};
```
`getContentTableHyperlinkTarget` wraps sheet names in single quotes when the name contains any character outside `[A-Za-z0-9_]`, and escapes embedded single quotes by doubling them. If `sheetName` or `rangeAddress` is empty/null, the hyperlink is skipped and the plain text value remains (non-fatal fallback).

Internal document references use the format `'Sheet Name'!A1:B10`.

## Validation results

```
npm.cmd test   → 124 pass, 0 fail
npm.cmd run build → compiled with 3 warnings (pre-existing bundle size warnings only)
git diff --check → clean
git status --short → 3 files modified, committed
```

## Manual smoke notes

_(For human owner to verify in Excel)_

1. Workbook with 2+ source sheets and several detected tables → run Найти таблицы → Content appears as first sheet; links in Range column navigate to table ranges.
2. Run again → no duplicate Content sheet; Content stays first; no runtime error.
3. Switch to Для клиента → compact 5-column sheet (#, Название таблицы, Подзаголовок, Лист, Ссылка); no technical diagnostics; links in Ссылка column navigate to ranges.
4. Switch back to С минимальной проверкой → existing 11-column output preserved.
5. Workbook with empty/skipped sheets → no fatal error; current skip behavior intact.
6. Source sheets not modified at any step.

## Explicit confirmations

- **Backlinks** (source tables → Content): NOT implemented. Source worksheets not touched.
- **Full Check** mode: NOT implemented.
- **Auto Check Table**: NOT triggered.
- **Auto Run significance**: NOT triggered.
- **Scanner heuristics**: NOT changed. `table-inventory-scanner.js` not modified.
- Subtitle column is blank (scanner does not detect subtitles; no heuristic added as instructed).

## Labels

`table-inventory` `ui` `feature`

Closes a slice of #147.