### PR TITLE
Fix Table Inventory candidate status for two-column row label tables (#153)

### DIFF
--- a/src/core/table-inventory-scanner.js
+++ b/src/core/table-inventory-scanner.js
@@ -357,7 +357,7 @@ function splitLabelData(values, band) {
     dataCols.push(dataRow);
   }
 
-  return { labelCols, dataCols, labelSplitConfidence };
+  return { labelCols, dataCols, labelSplitConfidence, labelColCount };
 }
 
 // ─── Title inference ──────────────────────────────────────────────────────────
@@ -451,8 +451,8 @@ function deriveCandidateStatus({ isLikelyTable, hasBlockingIssues, warningCount,
   return "available";
 }
 
-function buildTableInventoryItem({ band, model, titleInfo, rangeAddress, sheetName, labelSplitConfidence }) {
-  const { summary, qualitySummary, calculationBlocks } = model;
+function buildTableInventoryItem({ band, model, titleInfo, rangeAddress, sheetName, labelSplitConfidence, labelColCount }) {
+  const { summary, qualitySummary, calculationBlocks, dataQualityIssues } = model;
   const tableId = sheetName + "!" + rangeAddress;
 
   const isLikelyTable = summary.detectedMetricRows > 0;
@@ -498,6 +498,12 @@ function buildTableInventoryItem({ band, model, titleInfo, rangeAddress, sheetNa
 
   const columnCount = band.localTrimmedLastCol - band.localTrimmedFirstCol + 1;
 
+  // Flat list of issue codes for diagnostic inspection.
+  // Each entry: { code: string, severity: "warning"|"critical" }.
+  const qualityIssueCodes = isLikelyTable
+    ? (dataQualityIssues || []).map((i) => ({ code: i.code, severity: i.severity }))
+    : [];
+
   return {
     tableId,
     sheetName,
@@ -513,8 +519,10 @@ function buildTableInventoryItem({ band, model, titleInfo, rangeAddress, sheetNa
     candidateStatus,
     candidateNotes,
     labelSplitConfidence,
+    labelColCount: labelColCount ?? null,
     warningsCount: isLikelyTable ? qualitySummary.warningCount : 0,
     criticalCount: isLikelyTable ? qualitySummary.criticalCount : 0,
+    qualityIssueCodes,
   };
 }
 
@@ -558,7 +566,7 @@ export function scanWorksheetForTables({ values, usedRangeRowOffset, usedRangeCo
     // Pre-filter and label/data split operate on the body only.
     if (!hasNumericCell(values, bodyBand)) continue;
 
-    const { labelCols, dataCols, labelSplitConfidence } = splitLabelData(values, bodyBand);
+    const { labelCols, dataCols, labelSplitConfidence, labelColCount } = splitLabelData(values, bodyBand);
 
     if (!dataCols.length || !dataCols[0] || dataCols[0].length < 1) continue;
 
@@ -581,6 +589,7 @@ export function scanWorksheetForTables({ values, usedRangeRowOffset, usedRangeCo
       rangeAddress,
       sheetName,
       labelSplitConfidence,
+      labelColCount,
     });
     items.push(item);
   }

--- a/src/core/table-inventory-scanner.js
+++ b/src/core/table-inventory-scanner.js
@@ -357,6 +357,31 @@ function splitLabelData(values, band) {
     dataCols.push(dataRow);
   }
 
+  // Trim trailing data columns that are empty in all body rows.
+  // Body rows are rows where labelCols[row][0] is non-empty (the primary label is present).
+  // Banner/header rows (labelCols[row][0] empty) may add extra columns — e.g. a subgroup
+  // header that has no matching data in mean/variance/base — and those trailing all-empty-
+  // in-body-rows columns would otherwise produce spurious BASE_BLANK_VALUES quality warnings.
+  if (labelColCount > 0 && dataCols.length > 0 && dataCols[0] && dataCols[0].length > 1) {
+    const bodyRowIndexes = [];
+    for (let i = 0; i < labelCols.length; i++) {
+      if (!isCellEmpty(labelCols[i][0])) bodyRowIndexes.push(i);
+    }
+    if (bodyRowIndexes.length > 0) {
+      let trimmedWidth = dataCols[0].length;
+      while (trimmedWidth > 1) {
+        const colIdx = trimmedWidth - 1;
+        if (!bodyRowIndexes.every((ri) => isCellEmpty((dataCols[ri] || [])[colIdx]))) break;
+        trimmedWidth--;
+      }
+      if (trimmedWidth < dataCols[0].length) {
+        for (let i = 0; i < dataCols.length; i++) {
+          dataCols[i] = dataCols[i].slice(0, trimmedWidth);
+        }
+      }
+    }
+  }
+
   return { labelCols, dataCols, labelSplitConfidence, labelColCount };
 }
 

--- a/src/core/table-inventory-scanner.js
+++ b/src/core/table-inventory-scanner.js
@@ -232,12 +232,22 @@ function isLikelyRatingScaleLabelColumn(values, colIndex, startRow, endRow) {
   return textOnlyCount >= minText && ordinalScaleCount >= 3 && labelLikeFraction >= 0.8;
 }
 
-/** Returns true when every body cell in a column is empty. */
-function isColumnAllEmpty(values, colIndex, startRow, endRow) {
+/**
+ * Returns true when every body row has an empty gutter cell, where "body row" means
+ * a row whose col0 (labelCol0Index) is non-empty.  Banner/header rows above the body
+ * have an empty col0 and are intentionally ignored — they may carry numeric values
+ * (sample sizes, years, percentages) in the gutter column that must not disqualify it.
+ * Returns false if no body rows are found (conservative: do not promote to gutter).
+ */
+function isGutterColumnForBodyRows(values, gutterColIndex, labelCol0Index, startRow, endRow) {
+  let bodyRowSeen = false;
   for (let row = startRow; row <= endRow; row++) {
-    if (!isCellEmpty((values[row] || [])[colIndex])) return false;
+    const labelCell = (values[row] || [])[labelCol0Index];
+    if (isCellEmpty(labelCell)) continue;
+    bodyRowSeen = true;
+    if (!isCellEmpty((values[row] || [])[gutterColIndex])) return false;
   }
-  return true;
+  return bodyRowSeen;
 }
 
 function splitLabelData(values, band) {
@@ -246,12 +256,14 @@ function splitLabelData(values, band) {
 
   // Determine label column count by inspecting the character of the leftmost columns.
   // Rules:
-  //   col0 text + col1 text        → 2 label columns, confident
-  //   col0 text + col1 empty gutter → 2 label columns, twoColumn (skip the gutter)
-  //   col0 text + col1 numeric     → 1 label column, confident
-  //   col0 not text + col1 text    → 2 label columns, twoColumn (col0 is code/gutter)
-  //   col0 not text + col1 not text → 1 label column, uncertain
-  //   trimmedWidth < 2             → 0 label columns, uncertain
+  //   col0 text + col1 text                       → 2 label columns, confident
+  //   col0 text + col1 empty gutter (body rows)   → 2 label columns, twoColumn (skip the gutter)
+  //   col0 text + col1 numeric                    → 1 label column, confident
+  //   col0 not text + col1 text                   → 2 label columns, twoColumn (col0 is code/gutter)
+  //   col0 not text + col1 not text               → 1 label column, uncertain
+  //   trimmedWidth < 2                            → 0 label columns, uncertain
+  // "Empty gutter in body rows" means col1 is null in every row where col0 is non-empty.
+  // Banner/header rows above the body may have numeric values in col1 and are ignored.
   let labelColCount;
   let labelSplitConfidence;
 
@@ -311,9 +323,11 @@ function splitLabelData(values, band) {
         // Both col0 and col1 are text — 2 label columns.
         labelColCount = 2;
         labelSplitConfidence = "confident";
-      } else if (isColumnAllEmpty(values, localTrimmedFirstCol + 1, localStartRow, localEndRow)) {
-        // col0 is text labels and col1 is an empty visual gutter — skip the gutter so it
-        // does not land in the data matrix and trigger spurious quality warnings.
+      } else if (isGutterColumnForBodyRows(values, localTrimmedFirstCol + 1, localTrimmedFirstCol, localStartRow, localEndRow)) {
+        // col0 is text labels and col1 is an empty visual gutter in body rows — skip the
+        // gutter so it does not land in the data matrix and trigger spurious quality warnings.
+        // Banner rows above the body may have non-empty values in col1 (sample sizes, years,
+        // percents) — isGutterColumnForBodyRows ignores those rows.
         labelColCount = 2;
         labelSplitConfidence = "twoColumn";
       } else {

--- a/src/core/table-inventory-scanner.js
+++ b/src/core/table-inventory-scanner.js
@@ -224,8 +224,43 @@ function isLikelyRatingScaleLabelColumn(values, colIndex, startRow, endRow) {
   }
 
   const labelLikeFraction = (textOnlyCount + ordinalScaleCount) / totalNonEmpty;
+  // Allow a single text marker (e.g. "Base") alongside ordinal scale values when every
+  // non-empty cell is label-like (no out-of-range numeric data cells).
+  const allCellsAreLabelLike = textOnlyCount + ordinalScaleCount === totalNonEmpty;
+  const minText = allCellsAreLabelLike ? 1 : 2;
 
-  return textOnlyCount >= 2 && ordinalScaleCount >= 3 && labelLikeFraction >= 0.8;
+  return textOnlyCount >= minText && ordinalScaleCount >= 3 && labelLikeFraction >= 0.8;
+}
+
+/**
+ * Returns true when a column consists entirely of ordinal scale values (integers 0–10,
+ * as numbers or short digit strings) plus optional text cells — and has no out-of-range
+ * numeric cells.  Used to recognise question-code / scale-code label columns where the
+ * text fraction alone is too low to satisfy the main text-fraction threshold.
+ *
+ * Requires at least 3 ordinal values to avoid false positives on short numeric runs.
+ */
+function isMostlyOrdinalLabelColumn(values, colIndex, startRow, endRow) {
+  let totalNonEmpty = 0;
+  let ordinalCount = 0;
+  let textCount = 0;
+
+  for (let row = startRow; row <= endRow; row++) {
+    const cell = (values[row] || [])[colIndex];
+    if (isCellEmpty(cell)) continue;
+    totalNonEmpty++;
+    if (isLikelyOrdinalScaleLabelCell(cell)) {
+      ordinalCount++;
+    } else if (isTextOnlyCell(cell)) {
+      textCount++;
+    }
+    // any other cell (out-of-range numeric) disqualifies the column immediately
+    else {
+      return false;
+    }
+  }
+
+  return totalNonEmpty > 0 && ordinalCount >= 3;
 }
 
 function splitLabelData(values, band) {
@@ -257,9 +292,32 @@ function splitLabelData(values, band) {
       isLikelyRatingScaleLabelColumn(values, localTrimmedFirstCol, localStartRow, localEndRow);
 
     if (!col0IsText) {
-      // First column looks numeric — split is ambiguous.
-      labelColCount = 1;
-      labelSplitConfidence = "uncertain";
+      // First column looks numeric — check for ordinal-scale code + text-answer pattern
+      // before falling back to the generic uncertain case.
+      if (
+        trimmedWidth >= 3 &&
+        isMostlyOrdinalLabelColumn(values, localTrimmedFirstCol, localStartRow, localEndRow)
+      ) {
+        const col1Fraction = computeTextFraction(
+          values,
+          localTrimmedFirstCol + 1,
+          localTrimmedFirstCol + 1,
+          localStartRow,
+          localEndRow
+        );
+        if (col1Fraction >= LABEL_TEXT_FRACTION_THRESHOLD) {
+          // Both columns are row-label material: ordinal code + text answer label.
+          labelColCount = 2;
+          labelSplitConfidence = "twoColumn";
+        } else {
+          labelColCount = 1;
+          labelSplitConfidence = "uncertain";
+        }
+      } else {
+        // First column looks numeric — split is ambiguous.
+        labelColCount = 1;
+        labelSplitConfidence = "uncertain";
+      }
     } else if (trimmedWidth < 3) {
       // Only 2 columns and col0 is text — use 1 label column.
       labelColCount = 1;
@@ -384,6 +442,8 @@ function inferTitle(values, band) {
  *
  * "available"  — looks like a recognisable table with no blocking issues or
  *                uncertain boundaries; worth checking via Check Table.
+ *                Also returned when labelSplitConfidence is "twoColumn" (two-column
+ *                row labels with ordinal code + text answer are valid structures).
  * "uncertain"  — table-like but has blocking issues, quality warnings, or an
  *                ambiguous label/data boundary; Check Table may still work but
  *                results should be verified.
@@ -418,6 +478,9 @@ function buildTableInventoryItem({ band, model, titleInfo, rangeAddress, sheetNa
   }
   if (labelSplitConfidence === "uncertain") {
     candidateNotes.push("Граница лейблов/данных не определена");
+  }
+  if (labelSplitConfidence === "twoColumn") {
+    candidateNotes.push("Двухколоночные метки строк: порядковый код + текстовый ответ");
   }
   if (isLikelyTable && qualitySummary.warningCount > 0) {
     candidateNotes.push(`Предупреждений в превью: ${qualitySummary.warningCount}`);

--- a/src/core/table-inventory-scanner.js
+++ b/src/core/table-inventory-scanner.js
@@ -232,35 +232,12 @@ function isLikelyRatingScaleLabelColumn(values, colIndex, startRow, endRow) {
   return textOnlyCount >= minText && ordinalScaleCount >= 3 && labelLikeFraction >= 0.8;
 }
 
-/**
- * Returns true when a column consists entirely of ordinal scale values (integers 0–10,
- * as numbers or short digit strings) plus optional text cells — and has no out-of-range
- * numeric cells.  Used to recognise question-code / scale-code label columns where the
- * text fraction alone is too low to satisfy the main text-fraction threshold.
- *
- * Requires at least 3 ordinal values to avoid false positives on short numeric runs.
- */
-function isMostlyOrdinalLabelColumn(values, colIndex, startRow, endRow) {
-  let totalNonEmpty = 0;
-  let ordinalCount = 0;
-  let textCount = 0;
-
+/** Returns true when every body cell in a column is empty. */
+function isColumnAllEmpty(values, colIndex, startRow, endRow) {
   for (let row = startRow; row <= endRow; row++) {
-    const cell = (values[row] || [])[colIndex];
-    if (isCellEmpty(cell)) continue;
-    totalNonEmpty++;
-    if (isLikelyOrdinalScaleLabelCell(cell)) {
-      ordinalCount++;
-    } else if (isTextOnlyCell(cell)) {
-      textCount++;
-    }
-    // any other cell (out-of-range numeric) disqualifies the column immediately
-    else {
-      return false;
-    }
+    if (!isCellEmpty((values[row] || [])[colIndex])) return false;
   }
-
-  return totalNonEmpty > 0 && ordinalCount >= 3;
+  return true;
 }
 
 function splitLabelData(values, band) {
@@ -269,10 +246,12 @@ function splitLabelData(values, band) {
 
   // Determine label column count by inspecting the character of the leftmost columns.
   // Rules:
-  //   col0 text + col1 text  → 2 label columns, confident
-  //   col0 text + col1 numeric → 1 label column, confident (never consume a numeric column as label)
-  //   col0 not clearly text  → 1 label column, uncertain
-  //   trimmedWidth < 2       → 0 label columns, uncertain
+  //   col0 text + col1 text        → 2 label columns, confident
+  //   col0 text + col1 empty gutter → 2 label columns, twoColumn (skip the gutter)
+  //   col0 text + col1 numeric     → 1 label column, confident
+  //   col0 not text + col1 text    → 2 label columns, twoColumn (col0 is code/gutter)
+  //   col0 not text + col1 not text → 1 label column, uncertain
+  //   trimmedWidth < 2             → 0 label columns, uncertain
   let labelColCount;
   let labelSplitConfidence;
 
@@ -292,12 +271,9 @@ function splitLabelData(values, band) {
       isLikelyRatingScaleLabelColumn(values, localTrimmedFirstCol, localStartRow, localEndRow);
 
     if (!col0IsText) {
-      // First column looks numeric — check for ordinal-scale code + text-answer pattern
-      // before falling back to the generic uncertain case.
-      if (
-        trimmedWidth >= 3 &&
-        isMostlyOrdinalLabelColumn(values, localTrimmedFirstCol, localStartRow, localEndRow)
-      ) {
+      // col0 does not look like a text label column.  Check col1: if it is strongly text
+      // then col0 is a code/numeric identifier and col1 carries the real row labels.
+      if (trimmedWidth >= 3) {
         const col1Fraction = computeTextFraction(
           values,
           localTrimmedFirstCol + 1,
@@ -306,7 +282,6 @@ function splitLabelData(values, band) {
           localEndRow
         );
         if (col1Fraction >= LABEL_TEXT_FRACTION_THRESHOLD) {
-          // Both columns are row-label material: ordinal code + text answer label.
           labelColCount = 2;
           labelSplitConfidence = "twoColumn";
         } else {
@@ -314,7 +289,6 @@ function splitLabelData(values, band) {
           labelSplitConfidence = "uncertain";
         }
       } else {
-        // First column looks numeric — split is ambiguous.
         labelColCount = 1;
         labelSplitConfidence = "uncertain";
       }
@@ -323,7 +297,7 @@ function splitLabelData(values, band) {
       labelColCount = 1;
       labelSplitConfidence = "confident";
     } else {
-      // 3+ columns: inspect col1 to decide between 1 and 2 label columns.
+      // 3+ columns, col0 is text: inspect col1.
       const col1Fraction = computeTextFraction(
         values,
         localTrimmedFirstCol + 1,
@@ -334,11 +308,16 @@ function splitLabelData(values, band) {
       const col1IsText = col1Fraction >= LABEL_TEXT_FRACTION_THRESHOLD;
 
       if (col1IsText) {
-        // Both col0 and col1 are text — use 2 label columns.
+        // Both col0 and col1 are text — 2 label columns.
         labelColCount = 2;
         labelSplitConfidence = "confident";
+      } else if (isColumnAllEmpty(values, localTrimmedFirstCol + 1, localStartRow, localEndRow)) {
+        // col0 is text labels and col1 is an empty visual gutter — skip the gutter so it
+        // does not land in the data matrix and trigger spurious quality warnings.
+        labelColCount = 2;
+        labelSplitConfidence = "twoColumn";
       } else {
-        // col0 text, col1 numeric — 1 label column only.
+        // col0 text, col1 has numeric / mixed content — 1 label column.
         labelColCount = 1;
         labelSplitConfidence = "confident";
       }
@@ -480,7 +459,7 @@ function buildTableInventoryItem({ band, model, titleInfo, rangeAddress, sheetNa
     candidateNotes.push("Граница лейблов/данных не определена");
   }
   if (labelSplitConfidence === "twoColumn") {
-    candidateNotes.push("Двухколоночные метки строк: порядковый код + текстовый ответ");
+    candidateNotes.push("Двухколоночные метки строк");
   }
   if (isLikelyTable && qualitySummary.warningCount > 0) {
     candidateNotes.push(`Предупреждений в превью: ${qualitySummary.warningCount}`);

--- a/tests/core/table-inventory-scanner.test.mjs
+++ b/tests/core/table-inventory-scanner.test.mjs
@@ -288,4 +288,165 @@ describe("scanWorksheetForTables", () => {
       );
     }
   });
+
+  // ─── Issue #153: two-column row label tables ──────────────────────────────
+
+  it("non-NPS table with pure ordinal col0 + text answer col1 is available, not uncertain", () => {
+    // Pattern: [scale code] [answer label] [data...]
+    // col0 is integers 1-5 (ordinal scale codes, not text), col1 is text answer labels.
+    const values = [
+      [1, "Strongly agree", 40, 35, 42],
+      [2, "Agree", 30, 32, 28],
+      [3, "Neither agree nor disagree", 15, 17, 13],
+      [4, "Disagree", 10, 12, 10],
+      [5, "Strongly disagree", 5, 4, 7],
+      ["Base", "", 100, 100, 100],
+    ];
+    const items = scanWorksheetForTables({ values, ...OFFSET });
+    assert.ok(items.length >= 1, "expected at least one item");
+    const item = items[0];
+    // "twoColumn" when col0 fails the text test but is ordinal;
+    // "confident" when isLikelyRatingScaleLabelColumn already accepts the mixed col0.
+    assert.ok(
+      item.labelSplitConfidence === "twoColumn" || item.labelSplitConfidence === "confident",
+      `expected twoColumn or confident split; got ${item.labelSplitConfidence}`
+    );
+    assert.strictEqual(
+      item.candidateStatus,
+      "available",
+      `valid two-column label table must not be uncertain; got ${item.candidateStatus}`
+    );
+  });
+
+  it("non-NPS table with ordinal string col0 (\"1\"..\"5\") + text col1 is available", () => {
+    // Same pattern but col0 values are strings "1".."5" rather than integers.
+    const values = [
+      ["1", "Very satisfied", 44, 41, 45],
+      ["2", "Satisfied", 30, 32, 28],
+      ["3", "Neither", 15, 17, 13],
+      ["4", "Dissatisfied", 8, 7, 10],
+      ["5", "Very dissatisfied", 3, 3, 4],
+      ["Base", "", 500, 450, 550],
+    ];
+    const items = scanWorksheetForTables({ values, ...OFFSET });
+    assert.ok(items.length >= 1, "expected at least one item");
+    const item = items[0];
+    assert.ok(
+      item.labelSplitConfidence === "twoColumn" || item.labelSplitConfidence === "confident",
+      `expected twoColumn or confident split; got ${item.labelSplitConfidence}`
+    );
+    assert.strictEqual(
+      item.candidateStatus,
+      "available",
+      `two-column label table must not be uncertain; got ${item.candidateStatus}`
+    );
+  });
+
+  it("pure ordinal col0 with no text cell at all triggers twoColumn path when col1 is text", () => {
+    // col0 has only integers 1-5 (no "Base" or any text cell).
+    // isLikelyRatingScaleLabelColumn requires textOnlyCount >= 1, so it returns false here.
+    // The new isMostlyOrdinalLabelColumn + col1 text check should set twoColumn.
+    // A Base row is provided so the preview model can build a complete metric block.
+    // col0 of the Base row is null so col0 stays purely ordinal (no text cells).
+    const values = [
+      [1, "Strongly agree", 40, 35, 42],
+      [2, "Agree", 30, 32, 28],
+      [3, "Neither", 15, 17, 13],
+      [4, "Disagree", 10, 12, 10],
+      [5, "Strongly disagree", 5, 4, 7],
+      [null, "BASE", 100, 100, 100],
+    ];
+    const items = scanWorksheetForTables({ values, ...OFFSET });
+    assert.ok(items.length >= 1, "expected at least one item");
+    const item = items[0];
+    assert.strictEqual(
+      item.labelSplitConfidence,
+      "twoColumn",
+      `pure-ordinal col0 with text col1 should yield twoColumn; got ${item.labelSplitConfidence}`
+    );
+    assert.strictEqual(
+      item.candidateStatus,
+      "available",
+      `twoColumn split must not make the candidate uncertain; got ${item.candidateStatus}`
+    );
+    assert.ok(
+      item.candidateNotes.some((n) => n.includes("Двухколоночные метки")),
+      "candidateNotes must explain two-column labels for twoColumn split"
+    );
+  });
+
+  it("ordinal col0 + numeric col1 stays uncertain (col1 data, not a second label)", () => {
+    // col0 is ordinal 1-5 but col1 is numeric data — should not be classified as
+    // a two-column label table.
+    const values = [
+      [1, 40, 35, 42],
+      [2, 30, 32, 28],
+      [3, 15, 17, 13],
+      [4, 10, 12, 10],
+      [5, 5, 4, 7],
+    ];
+    const items = scanWorksheetForTables({ values, ...OFFSET });
+    if (items.length > 0) {
+      assert.notStrictEqual(
+        items[0].labelSplitConfidence,
+        "twoColumn",
+        "ordinal col0 with numeric col1 must not be classified as two-column label"
+      );
+    }
+  });
+
+  it("ordinal col0 + single Base text cell yields confident split (isLikelyRatingScaleLabelColumn fix)", () => {
+    // col0 has ordinal values 1-5 + one text cell "Base".
+    // isLikelyRatingScaleLabelColumn should now accept textOnlyCount=1 when all cells are label-like.
+    const values = [
+      ["1", "Very likely", 50, 48, 52],
+      ["2", "Likely", 25, 26, 24],
+      ["3", "Unlikely", 15, 16, 14],
+      ["4", "Very unlikely", 10, 10, 10],
+      ["Base", "", 1000, 950, 1050],
+    ];
+    const items = scanWorksheetForTables({ values, ...OFFSET });
+    assert.ok(items.length >= 1, "expected at least one item");
+    const item = items[0];
+    // With only 4 ordinal values in col0, isLikelyRatingScaleLabelColumn needs
+    // ordinalScaleCount >= 3 — should pass (4 ordinal + 1 text, all label-like).
+    assert.strictEqual(
+      item.candidateStatus,
+      "available",
+      `table with two-column labels and Base row must not be uncertain; got ${item.candidateStatus}`
+    );
+  });
+
+  it("extended NPS inventory behavior is preserved with two-column layout", () => {
+    // Extended NPS: col0 has scale values 0-10 + text bucket rows + NPS + Base.
+    // This previously worked; confirm it still does after the #153 changes.
+    const values = [
+      ["Score", "Total", "Male", "Female"],
+      ["1 - very unlikely", 5, 4, 6],
+      ["2", 6, 5, 7],
+      ["3", 7, 6, 8],
+      ["4", 8, 7, 9],
+      ["5", 9, 8, 10],
+      ["6", 10, 9, 11],
+      ["7", 11, 10, 12],
+      ["8", 12, 11, 13],
+      ["9", 13, 12, 14],
+      ["10 - very likely", 14, 13, 15],
+      ["Bottom-3", 18, 17, 19],
+      ["Top-3", 50, 53, 47],
+      ["Detractors", 20, 19, 18],
+      ["Promoters", 50, 52, 51],
+      ["NPS", 30, 33, 33],
+      ["BASE", 1000, 500, 500],
+    ];
+    const items = scanWorksheetForTables({ values, ...OFFSET });
+    assert.ok(items.length >= 1, "expected at least one item");
+    const item = items[0];
+    assert.strictEqual(item.labelSplitConfidence, "confident");
+    assert.strictEqual(item.candidateStatus, "available");
+    assert.ok(
+      !item.candidateNotes.includes("Граница лейблов/данных не определена"),
+      "extended NPS must not produce uncertain label/data boundary note"
+    );
+  });
 });

--- a/tests/core/table-inventory-scanner.test.mjs
+++ b/tests/core/table-inventory-scanner.test.mjs
@@ -559,6 +559,34 @@ describe("scanWorksheetForTables", () => {
       `${item.candidateStatus} split=${item.labelSplitConfidence} warn=${item.warningsCount} notes=${JSON.stringify(item.candidateNotes)}`);
   });
 
+  it("banner header rows wider than body data rows do not cause spurious BASE_BLANK_VALUES", () => {
+    // banner row spans 4 data columns (C-F), but mean/variance/base only have
+    // values in 3 data columns (C-E). Col F is present only in the banner header.
+    // Trailing empty data column must be trimmed before quality checks so that
+    // the base row does not get a spurious BASE_BLANK_VALUES warning.
+    const values = [
+      //  A               B      C         D           E           F (banner-only)
+      ["Title",       null,  null,     null,       null,       null],   // title row
+      ["Question?",   null,  null,     null,       null,       null],   // question title (unknownText)
+      [null,          null,  "Total",  "Group A",  "Group B",  "Extra"],// banner — F has header
+      [null,          null,  "Sub 1",  "Sub 2",    null,       null],   // banner row 2
+      ["Mean",        null,  50,       45,         55,         null],   // F is empty
+      ["Variance",    null,  100,      80,         120,        null],   // F is empty
+      ["Base",        null,  500,      200,        300,        null],   // F is empty → BASE_BLANK_VALUES
+    ];
+    const items = scanWorksheetForTables({ values, ...OFFSET });
+    assert.ok(items.length >= 1, "expected at least one item");
+    const item = items[0];
+    const hasBbv = item.qualityIssueCodes.some((e) => e.code === "BASE_BLANK_VALUES");
+    assert.strictEqual(hasBbv, false,
+      `should not produce BASE_BLANK_VALUES for a banner-extension trailing column; got codes=${JSON.stringify(item.qualityIssueCodes)}`);
+    assert.strictEqual(
+      item.candidateStatus,
+      "available",
+      `expected available; got ${item.candidateStatus} split=${item.labelSplitConfidence} warn=${item.warningsCount} codes=${JSON.stringify(item.qualityIssueCodes)}`
+    );
+  });
+
   it("extended NPS inventory behavior is preserved with two-column layout", () => {
     // Extended NPS: col0 has scale values 0-10 + text bucket rows + NPS + Base.
     // This previously worked; confirm it still does after the #153 changes.

--- a/tests/core/table-inventory-scanner.test.mjs
+++ b/tests/core/table-inventory-scanner.test.mjs
@@ -236,6 +236,29 @@ describe("scanWorksheetForTables", () => {
     assert.strictEqual(items[0].reasonsIfNotRunnable, undefined, "reasonsIfNotRunnable must not exist");
   });
 
+  it("item exposes labelColCount and qualityIssueCodes for diagnostics", () => {
+    // labelColCount must match the number of left label columns detected.
+    // qualityIssueCodes must be an array of {code, severity} objects — no raw issue objects.
+    const values = [
+      ["Label1", 10, 20, 30],
+      ["Label2", 40, 50, 60],
+      ["Base", 100, 100, 100],
+    ];
+    const items = scanWorksheetForTables({ values, ...OFFSET });
+    assert.ok(items.length >= 1, "expected at least one item");
+    const item = items[0];
+    assert.strictEqual(typeof item.labelColCount, "number", "labelColCount must be a number");
+    assert.ok(item.labelColCount >= 0, "labelColCount must be non-negative");
+    assert.ok(Array.isArray(item.qualityIssueCodes), "qualityIssueCodes must be an array");
+    for (const entry of item.qualityIssueCodes) {
+      assert.ok(typeof entry.code === "string", "each qualityIssueCodes entry must have a string code");
+      assert.ok(
+        entry.severity === "warning" || entry.severity === "critical",
+        `each qualityIssueCodes entry must have severity warning or critical; got ${entry.severity}`
+      );
+    }
+  });
+
   it("rating/NPS scale labels in the first column keep the label split confident", () => {
     const values = [
       ["Score", "Total", "Male", "Female"],

--- a/tests/core/table-inventory-scanner.test.mjs
+++ b/tests/core/table-inventory-scanner.test.mjs
@@ -462,6 +462,80 @@ describe("scanWorksheetForTables", () => {
     );
   });
 
+  it("metric table with text+sample banner rows in col1 and null gutter in body rows is available", () => {
+    // Real-world structure: title row, two banner rows (col0=null, col1=segment labels/sample sizes),
+    // then body rows with col0=metric label, col1=null gutter, col2+=data.
+    // col1 banner rows carry text values ("Total", "(n=500)") but col1 is null for all body rows.
+    // isGutterColumnForBodyRows must recognise col1 as a gutter (ignoring banner rows).
+    const values = [
+      ["Сколько (примерно) потратили?", null, null, null, null],
+      [null, "Total", "Male", "Female", "Other"],
+      [null, "(n=500)", "(n=250)", "(n=250)", "(n=100)"],
+      ["Среднее", null, 5000, 4500, 4800],
+      ["variance", null, 2500, 2300, 2400],
+      ["BASE", null, 500, 450, 100],
+    ];
+    const items = scanWorksheetForTables({ values, ...OFFSET });
+    assert.ok(items.length >= 1, "expected item");
+    const item = items[0];
+    assert.strictEqual(item.candidateStatus, "available",
+      `${item.candidateStatus} split=${item.labelSplitConfidence} warn=${item.warningsCount} notes=${JSON.stringify(item.candidateNotes)}`);
+  });
+
+  it("metric table with numeric year in banner col1 and null gutter in body rows is available", () => {
+    // col1 banner row carries a numeric year (2025) which is not a text value.
+    // isGutterColumnForBodyRows must ignore the banner row (col0=null) and only
+    // test body rows where col0 has content — those have col1=null → gutter detected.
+    const values = [
+      ["Сколько (примерно) потратили?", null, null, null, null],
+      [null, 2025, "Male", "Female", "Other"],
+      ["Среднее", null, 5000, 4500, 4800],
+      ["variance", null, 2500, 2300, 2700],
+      ["BASE", null, 500, 450, 100],
+    ];
+    const items = scanWorksheetForTables({ values, ...OFFSET });
+    assert.ok(items.length >= 1, "expected item");
+    const item = items[0];
+    assert.strictEqual(item.candidateStatus, "available",
+      `${item.candidateStatus} split=${item.labelSplitConfidence} warn=${item.warningsCount} notes=${JSON.stringify(item.candidateNotes)}`);
+  });
+
+  it("metric table with percent values in banner col1 and null gutter in body rows is available", () => {
+    // col1 banner row carries percent strings ("44%", "41%", "39%") — numeric-like but text.
+    // isGutterColumnForBodyRows must ignore that row and detect col1 as a gutter via body rows only.
+    const values = [
+      ["Сколько (примерно) потратили?", null, null, null],
+      [null, "44%", "41%", "39%"],
+      ["Среднее", null, 5000, 4500],
+      ["variance", null, 2500, 2300],
+      ["BASE", null, 500, 450],
+    ];
+    const items = scanWorksheetForTables({ values, ...OFFSET });
+    assert.ok(items.length >= 1, "expected item");
+    const item = items[0];
+    assert.strictEqual(item.candidateStatus, "available",
+      `${item.candidateStatus} split=${item.labelSplitConfidence} warn=${item.warningsCount} notes=${JSON.stringify(item.candidateNotes)}`);
+  });
+
+  it("metric table with two banner rows (text then numeric) in col1 and null gutter in body is available", () => {
+    // Two banner rows: first has text ("Total"/"Male"/...), second has numeric sample sizes (1000/500/...).
+    // Both have col0=null so isGutterColumnForBodyRows skips them.
+    // Body rows (col0 non-empty) have col1=null → gutter correctly detected → no BASE_BLANK_VALUES warning.
+    const values = [
+      ["Сколько (примерно) потратили?", null, null, null, null],
+      [null, "Total", "Male", "Female", "Other"],
+      [null, 1000, 500, 450, 50],
+      ["Среднее", null, 5000, 4500, 4800],
+      ["variance", null, 2500, 2300, 2400],
+      ["BASE", null, 500, 450, 50],
+    ];
+    const items = scanWorksheetForTables({ values, ...OFFSET });
+    assert.ok(items.length >= 1, "expected item");
+    const item = items[0];
+    assert.strictEqual(item.candidateStatus, "available",
+      `${item.candidateStatus} split=${item.labelSplitConfidence} warn=${item.warningsCount} notes=${JSON.stringify(item.candidateNotes)}`);
+  });
+
   it("extended NPS inventory behavior is preserved with two-column layout", () => {
     // Extended NPS: col0 has scale values 0-10 + text bucket rows + NPS + Base.
     // This previously worked; confirm it still does after the #153 changes.

--- a/tests/core/table-inventory-scanner.test.mjs
+++ b/tests/core/table-inventory-scanner.test.mjs
@@ -417,6 +417,51 @@ describe("scanWorksheetForTables", () => {
     );
   });
 
+  it("mean/variance/base table with empty gutter column is available, not uncertain", () => {
+    // Smoke-failing case from PR #154 review: metric labels in col0, col1 is an empty
+    // visual gutter, col2+ is numeric data.  The gutter must not land in the data matrix
+    // and cause quality warnings that flip the candidate to uncertain.
+    const values = [
+      ["Сколько (примерно) потратили?", null, null, null, null],  // title row
+      ["Среднее", null, 5000, 4500, 5500],
+      ["variance", null, 2500, 2300, 2700],
+      ["BASE", null, 500, 450, 550],
+    ];
+    const items = scanWorksheetForTables({ values, ...OFFSET });
+    assert.ok(items.length >= 1, "expected at least one item");
+    const item = items[0];
+    assert.strictEqual(
+      item.candidateStatus,
+      "available",
+      `mean/variance/base with gutter column must not be uncertain; got ${item.candidateStatus}`
+    );
+    assert.strictEqual(item.isLikelyTable, true);
+  });
+
+  it("mean/variance/base with non-ordinal code col0 + text metric col1 is available", () => {
+    // Variant: col0 carries a non-ordinal code (e.g. year/wave number > 10) that fails
+    // the text test, col1 has the metric labels.  The generalised twoColumn path must
+    // still classify this as available.
+    const values = [
+      [2025, "Среднее", 5000, 4500, 5500],
+      [2025, "variance", 2500, 2300, 2700],
+      [2025, "BASE", 500, 450, 550],
+    ];
+    const items = scanWorksheetForTables({ values, ...OFFSET });
+    assert.ok(items.length >= 1, "expected at least one item");
+    const item = items[0];
+    assert.strictEqual(
+      item.labelSplitConfidence,
+      "twoColumn",
+      `non-ordinal code col0 + text metric col1 must yield twoColumn; got ${item.labelSplitConfidence}`
+    );
+    assert.strictEqual(
+      item.candidateStatus,
+      "available",
+      `non-ordinal code col0 + text metric col1 must not be uncertain; got ${item.candidateStatus}`
+    );
+  });
+
   it("extended NPS inventory behavior is preserved with two-column layout", () => {
     // Extended NPS: col0 has scale values 0-10 + text bucket rows + NPS + Base.
     // This previously worked; confirm it still does after the #153 changes.


### PR DESCRIPTION
## Summary

Fixes #153 and related real-workbook Table Inventory smoke failures.

This PR improves Table Inventory classification for valid research tables that previously became `Кандидат неопределён` because of split/two-column row labels, generated Content backlinks, or structural blank gutter columns between labels and data.

## What changed

### 1. Two-column row label support

Valid two-column label layouts are now recognised more reliably, including:

- ordinal/code column + text answer label column;
- non-text/code column + text metric label column;
- rating-scale-like first label columns with limited text markers such as `Base`.

These structures are treated as valid candidates instead of uncertain solely because the label/data boundary is split.

### 2. Generated Content backlink rows are skipped for interpretation

Generated `← Оглавление` rows are no longer allowed to become the inferred table title or distort scanner interpretation.

Expected behavior:

- `item.title` recovers the real table title;
- generated backlink rows are treated as decoration/metadata, not as table content.

### 3. Blank structural gutter columns are excluded from the data window

Real research tables may contain a fully blank visual gutter column between row labels and data, similar to a horizontally merged label area:

```text
A: labels
B: blank gutter
C:N: data
```

The scanner now treats that gutter as part of the label side instead of the first data column. This prevents false `BASE_BLANK_VALUES` warnings when the BASE row is blank in the gutter but valid in the actual data columns.

Important: `BASE_BLANK_VALUES` is not weakened globally. Blank cells inside actual data columns should still warn.

### 4. Trailing banner-only data columns are trimmed for preview input

If banner/header rows are wider than the body rows, trailing columns that are empty across all body rows are removed from the preview data matrix. This avoids false BASE blank warnings caused by header-only columns.

### 5. Diagnostic metadata is kept on inventory items

The scanner now exposes compact diagnostic fields useful for future debugging:

- `labelColCount`
- `qualityIssueCodes`

Temporary taskpane debug output and `console.debug()` hooks were removed before merge.

## Changed files

- `src/core/table-inventory-scanner.js`
- `tests/core/table-inventory-scanner.test.mjs`

## Tests added / updated

Regression coverage now includes:

- ordinal/code + text two-column labels;
- ordinal-string + text labels;
- pure ordinal code column + text label column;
- ordinal/code + numeric data negative guard;
- rating-scale-like labels with a single `Base` text marker;
- extended NPS two-column layout regression;
- mean/variance/base with an empty gutter column;
- non-ordinal code column + text metric label column;
- banner/header rows in the gutter column;
- numeric/percent banner values above guttered body rows;
- banner-header rows wider than body data rows;
- generated `← Оглавление` backlink row above a real title/table.

## Validation

Manual smoke passed in Excel:

- the original mean/variance/BASE failing table no longer appears as `Кандидат неопределён`;
- no uncertain candidates remain in the tested workbook;
- generated backlink rows no longer appear as table titles;
- NPS inventory behavior still works;
- two-column label cases still work;
- ordinal/code + numeric data guard remains conservative.

Automated/local validation reported by the agent:

```text
npm.cmd test → passed
npm.cmd run build → passed
git diff --check → passed
```

## Scope / non-goals

No changes to:

- significance calculation;
- Excel writer;
- taskpane UI behavior;
- manifest files;
- Content sheet output behavior.

## Technical debt / follow-up

This PR keeps the scanner fix narrow. Further Table Inventory work should move toward fuller Check Table / diagnostics modes rather than adding ad hoc UI summary behavior.

Closes #153.