### PR TITLE
Add local manifest npm scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,9 +21,12 @@
     "signin": "office-addin-dev-settings m365-account login",
     "signout": "office-addin-dev-settings m365-account logout",
     "start": "office-addin-debugging start manifest.xml",
+    "start:local": "office-addin-debugging start manifest.local.xml",
     "stop": "office-addin-debugging stop manifest.xml",
+    "stop:local": "office-addin-debugging stop manifest.local.xml",
     "test": "node --no-warnings --loader ./tests/core/loader.mjs --test tests/core/*.test.mjs",
     "validate": "office-addin-manifest validate manifest.xml",
+    "validate:local": "office-addin-manifest validate manifest.local.xml",
     "watch": "webpack --mode development --watch"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary

Add npm scripts for working with the local Office Add-in manifest.

## Changes

- Add `start:local` for `manifest.local.xml`.
- Add `stop:local` for `manifest.local.xml`.
- Add `validate:local` for `manifest.local.xml`.
- Keep existing production/default manifest scripts unchanged.

## Scope

No runtime code changes.

## Validation

Reported local validation:

```text
npm.cmd run validate
npm.cmd run validate:local
git diff --check
```

Both manifest validation commands execute. They currently fail with the pre-existing manifest issue:

```text
Manifest Version Too Low: The manifest has unsupported version number less than 1.0.
```

That version issue affects both `manifest.xml` and `manifest.local.xml` and should be handled separately before release.