### PR TITLE
Add Full Check mode to workbook table discovery (#157)

### DIFF
--- a/src/core/table-inventory-scanner.js
+++ b/src/core/table-inventory-scanner.js
@@ -548,6 +548,11 @@ function buildTableInventoryItem({ band, model, titleInfo, rangeAddress, sheetNa
     warningsCount: isLikelyTable ? qualitySummary.warningCount : 0,
     criticalCount: isLikelyTable ? qualitySummary.criticalCount : 0,
     qualityIssueCodes,
+    detectedMetricRows: summary.detectedMetricRows ?? 0,
+    detectedBaseRows: summary.baseRows ?? 0,
+    detectedBlocks: summary.detectedBlocks ?? 0,
+    hasNps: summary.hasNps ?? false,
+    hasMeans: summary.hasMeans ?? false,
   };
 }
 

--- a/src/taskpane/taskpane.html
+++ b/src/taskpane/taskpane.html
@@ -60,6 +60,7 @@
           <select id="content-output-mode" class="inventory-mode-select">
             <option value="minimal-check">С минимальной проверкой</option>
             <option value="client">Для клиента</option>
+            <option value="full-check">С полной проверкой</option>
           </select>
         </div>
         <div class="inventory-backlink-row">

--- a/src/taskpane/taskpane.js
+++ b/src/taskpane/taskpane.js
@@ -70,6 +70,27 @@ const INVENTORY_CONTENT_COLUMNS = [
 
 const INVENTORY_CLIENT_COLUMNS = ["#", "Название таблицы", "Подзаголовок", "Лист"];
 
+const INVENTORY_FULL_CHECK_COLUMNS = [
+  "#",
+  "Sheet",
+  "Title",
+  "Range",
+  "Status",
+  "Summary",
+  "Rows",
+  "Columns",
+  "Metric rows",
+  "Base rows",
+  "Blocks",
+  "Metric types",
+  "Warnings",
+  "Critical",
+  "Issue codes",
+  "Notes",
+  "Label split",
+  "Label cols",
+];
+
 function formatBannerUserMessages(bannerStructure) {
   if (!bannerStructure || !bannerStructure.messages) {
     return "";
@@ -2105,6 +2126,133 @@ function writeClientFacingContent(worksheet, inventoryResults) {
   }
 }
 
+function buildFullCheckCandidateRows(sheetResults) {
+  const rows = [];
+  let candidateIndex = 1;
+
+  for (const sheetResult of sheetResults) {
+    for (const item of sheetResult.items) {
+      const metricTypes = [];
+      if (item.hasNps) metricTypes.push("NPS");
+      if (item.hasMeans) metricTypes.push("Средние");
+      if (item.isLikelyTable && !item.hasNps && !item.hasMeans) metricTypes.push("Пропорции");
+
+      rows.push([
+        candidateIndex,
+        sheetResult.sheetName,
+        item.resolvedTitle || (isGeneratedBacklinkRow(item.title) ? "" : (item.title || "")),
+        item.resolvedRangeAddress || item.rangeAddress || "",
+        getInventoryCandidateStatusLabel(item.candidateStatus),
+        item.previewSummary || "",
+        item.rowCount ?? "",
+        item.columnCount ?? "",
+        item.detectedMetricRows ?? "",
+        item.detectedBaseRows ?? "",
+        item.detectedBlocks ?? "",
+        metricTypes.join(", "),
+        item.warningsCount ?? 0,
+        item.criticalCount ?? 0,
+        (item.qualityIssueCodes || []).map((q) => q.code).join(", "),
+        item.candidateNotes && item.candidateNotes.length > 0 ? item.candidateNotes.join("; ") : "",
+        item.labelSplitConfidence || "",
+        item.labelColCount ?? "",
+      ]);
+      candidateIndex += 1;
+    }
+  }
+
+  if (rows.length === 0) {
+    const emptyRow = new Array(INVENTORY_FULL_CHECK_COLUMNS.length).fill("");
+    emptyRow[5] = "Нет кандидатов";
+    rows.push(emptyRow);
+  }
+
+  return rows;
+}
+
+function writeFullCheckContent(worksheet, inventoryResults) {
+  const allItems = [];
+  for (const sheetResult of inventoryResults.sheetResults) {
+    for (const item of sheetResult.items) {
+      allItems.push(item);
+    }
+  }
+
+  const colCount = INVENTORY_FULL_CHECK_COLUMNS.length;
+  const candidateRows = normalizeRowsToColumnCount(
+    buildFullCheckCandidateRows(inventoryResults.sheetResults),
+    colCount
+  );
+  const totalCandidates = inventoryResults.sheetResults.reduce(
+    (sum, sheetResult) => sum + sheetResult.items.length,
+    0
+  );
+
+  const titleRange = worksheet.getRangeByIndexes(0, 0, 1, colCount);
+  titleRange.values = normalizeRowsToColumnCount([["Table Full Check"]], colCount);
+  titleRange.merge();
+  titleRange.format.font.bold = true;
+  titleRange.format.font.size = 14;
+
+  const metadataRows = normalizeRowsToColumnCount(
+    [
+      ["Generated sheet", INVENTORY_CONTENT_SHEET_NAME],
+      ["Scanned sheets", inventoryResults.scannedSheets],
+      ["Candidate sheets", inventoryResults.sheetResults.length],
+      ["Detected candidates", totalCandidates],
+      ["Mode", "Full Check — expanded diagnostics for all detected candidates"],
+    ],
+    2
+  );
+
+  const metadataRange = worksheet.getRangeByIndexes(1, 0, metadataRows.length, 2);
+  metadataRange.values = metadataRows;
+  worksheet.getRange("A2:A6").format.font.bold = true;
+
+  const headerRowIndex = 7;
+  const headerRange = worksheet.getRangeByIndexes(headerRowIndex - 1, 0, 1, colCount);
+  headerRange.values = normalizeRowsToColumnCount([INVENTORY_FULL_CHECK_COLUMNS], colCount);
+  headerRange.format.font.bold = true;
+
+  const candidateRange = worksheet.getRangeByIndexes(headerRowIndex, 0, candidateRows.length, colCount);
+  candidateRange.values = candidateRows;
+  candidateRange.format.wrapText = true;
+
+  const tableRange = worksheet.getRangeByIndexes(
+    headerRowIndex - 1,
+    0,
+    candidateRows.length + 1,
+    colCount
+  );
+  tableRange.format.borders.getItem("EdgeBottom").style = "Continuous";
+  tableRange.format.borders.getItem("EdgeTop").style = "Continuous";
+  tableRange.format.borders.getItem("EdgeLeft").style = "Continuous";
+  tableRange.format.borders.getItem("EdgeRight").style = "Continuous";
+  tableRange.format.borders.getItem("InsideHorizontal").style = "Continuous";
+  tableRange.format.borders.getItem("InsideVertical").style = "Continuous";
+
+  const columnWidths = [42, 100, 160, 92, 200, 160, 50, 60, 72, 72, 50, 110, 72, 72, 200, 170, 85, 70];
+  columnWidths.forEach((width, index) => {
+    worksheet.getRangeByIndexes(0, index, 1, 1).format.columnWidth = width;
+  });
+
+  worksheet.getRangeByIndexes(0, 0, candidateRows.length + headerRowIndex, colCount).format.verticalAlignment = "Top";
+
+  const RANGE_COL_INDEX = 3;
+  for (let i = 0; i < allItems.length; i++) {
+    const item = allItems[i];
+    const effectiveRange = item.resolvedRangeAddress || item.rangeAddress;
+    const hyperlinkTarget = getContentTableHyperlinkTarget(item.sheetName, effectiveRange);
+    if (hyperlinkTarget) {
+      const cell = worksheet.getRangeByIndexes(headerRowIndex + i, RANGE_COL_INDEX, 1, 1);
+      cell.hyperlink = {
+        documentReference: hyperlinkTarget,
+        screenTip: `${item.sheetName}!${effectiveRange}`,
+      };
+    }
+  }
+}
+
 async function writeInventoryContentSheet(context, inventoryResults) {
   const worksheet = await ensureInventoryContentWorksheet(context);
   const existingUsedRange = worksheet.getUsedRangeOrNullObject();
@@ -2121,6 +2269,8 @@ async function writeInventoryContentSheet(context, inventoryResults) {
 
   if (mode === "client") {
     writeClientFacingContent(worksheet, inventoryResults);
+  } else if (mode === "full-check") {
+    writeFullCheckContent(worksheet, inventoryResults);
   } else {
     writeMinimalCheckContent(worksheet, inventoryResults);
   }

--- a/tests/core/table-inventory-scanner.test.mjs
+++ b/tests/core/table-inventory-scanner.test.mjs
@@ -619,4 +619,37 @@ describe("scanWorksheetForTables", () => {
       "extended NPS must not produce uncertain label/data boundary note"
     );
   });
+
+  it("item exposes detectedMetricRows, detectedBaseRows, detectedBlocks, hasNps, hasMeans for a proportion table", () => {
+    const values = [
+      ["Label1", 10, 20, 30],
+      ["Label2", 40, 50, 60],
+      ["Base", 100, 100, 100],
+    ];
+    const items = scanWorksheetForTables({ values, ...OFFSET });
+    assert.ok(items.length >= 1, "expected at least one item");
+    const item = items[0];
+    assert.ok(typeof item.detectedMetricRows === "number", "detectedMetricRows should be a number");
+    assert.ok(typeof item.detectedBaseRows === "number", "detectedBaseRows should be a number");
+    assert.ok(typeof item.detectedBlocks === "number", "detectedBlocks should be a number");
+    assert.strictEqual(typeof item.hasNps, "boolean", "hasNps should be a boolean");
+    assert.strictEqual(typeof item.hasMeans, "boolean", "hasMeans should be a boolean");
+    assert.ok(item.detectedMetricRows > 0, "proportion table should have metric rows");
+    assert.ok(item.detectedBaseRows > 0, "proportion table should have at least one base row");
+    assert.strictEqual(item.hasNps, false, "plain proportion table should not have NPS");
+    assert.strictEqual(item.hasMeans, false, "plain proportion table should not have means");
+  });
+
+  it("item exposes hasNps=true for an NPS table", () => {
+    const values = [
+      ["Promoters", 50, 52, 51],
+      ["Detractors", 20, 19, 18],
+      ["NPS", 30, 33, 33],
+      ["Base", 1000, 500, 500],
+    ];
+    const items = scanWorksheetForTables({ values, ...OFFSET });
+    assert.ok(items.length >= 1, "expected at least one item");
+    const item = items[0];
+    assert.strictEqual(item.hasNps, true, "NPS table should have hasNps=true");
+  });
 });


### PR DESCRIPTION
## Summary

- Adds `С полной проверкой` (`full-check`) as a third option in the `#content-output-mode` dropdown alongside the existing `С минимальной проверкой` and `Для клиента` modes.
- When `full-check` is selected and the user clicks `Найти таблицы`, the Content sheet is written with expanded read-only diagnostics for every detected candidate table (18 columns vs 11 for minimal-check).
- Exposes 5 new fields on `TableInventoryItem` (`detectedMetricRows`, `detectedBaseRows`, `detectedBlocks`, `hasNps`, `hasMeans`) so the writer can populate the extra diagnostic columns without re-running the preview model.

## Files changed

- `src/taskpane/taskpane.html` — adds `<option value="full-check">С полной проверкой</option>`
- `src/taskpane/taskpane.js` — adds `INVENTORY_FULL_CHECK_COLUMNS`, `buildFullCheckCandidateRows`, `writeFullCheckContent`; updates `writeInventoryContentSheet` to branch on `full-check`
- `src/core/table-inventory-scanner.js` — adds 5 new fields to `buildTableInventoryItem` return value
- `tests/core/table-inventory-scanner.test.mjs` — adds 2 tests for the new scanner item fields

## Technical notes

- Full Check uses the same 7-row metadata header layout as minimal-check (`firstDataRow = 8`), so `buildContentRowMap` required no change.
- `client` and `minimal-check` mode outputs are unchanged.
- Full Check is strictly read-only: it does not call `significance.js`, `excel-writer.js`, or write any significance markers.
- Backlink behavior (`Ставить обратные ссылки`) is unchanged and works with the new mode.
- Hyperlinks to detected tables are written on the Range column (col index 3).

## Affected table-structure matrix areas

Read-only output only — no changes to detection, calculation, or writing logic.

## Affected gold-standard cases

None — no significance calculation changes.

## Technical debt

No known technical debt introduced.

## Test plan

- [ ] `npm.cmd test` — 140/140 pass
- [ ] `npm.cmd run build` — builds without errors
- [ ] `git diff --check` — clean
- [ ] Smoke: run `Найти таблицы` in each mode and verify Content sheet output matches mode expectations
- [ ] Verify `Для клиента` and `С минимальной проверкой` outputs are unchanged
- [ ] Verify `С полной проверкой` writes 18-column diagnostic table with no significance markers in source sheets

🤖 Generated with [Claude Code](https://claude.com/claude-code)