### PR TITLE
Extract shared batch-candidate-filter helper (#170)

### DIFF
--- a/src/core/batch-candidate-filter.js
+++ b/src/core/batch-candidate-filter.js
@@ -1,0 +1,95 @@
+/**
+ * Pure helpers for scanner-driven batch actions.
+ *
+ * Filters workbook inventory results into eligible candidates and
+ * pre-execution skips, with stable reason codes for each skip.
+ *
+ * Office.js-free and side-effect-free. Reusable by Run, Clear, and Check.
+ */
+
+// ─── Batch skip reason codes ──────────────────────────────────────────────────
+
+/**
+ * Stable reason codes for candidates skipped before execution begins.
+ * Values must not change; callers map them to display text.
+ */
+export const BATCH_SKIP_REASONS = Object.freeze({
+  /** Candidate has no usable range address after backlink normalization. */
+  MISSING_RANGE: "missing_range",
+  /** Candidate status is "uncertain" — label/data boundary is ambiguous. */
+  CANDIDATE_UNCERTAIN: "candidate_uncertain",
+  /** Candidate status is "rejected" — not recognized as a research table. */
+  CANDIDATE_REJECTED: "candidate_rejected",
+  /** Candidate has an unrecognized or unsupported status. */
+  UNKNOWN_STATUS: "unknown_status",
+});
+
+// ─── Candidate filter ─────────────────────────────────────────────────────────
+
+/**
+ * Partitions workbook inventory results into eligible and skipped candidates.
+ *
+ * Eligible:  candidateStatus === "available" && canRunCheckTable && has usable range address
+ * Skipped:   uncertain, rejected, or missing-range candidates (with reason code)
+ * Ignored:   generated Content sheet — excluded entirely, not counted toward skipped
+ *
+ * @param {object} inventoryResults
+ * @param {Array<{ sheetName: string, items: Array }>} inventoryResults.sheetResults
+ * @param {object} [options]
+ * @param {string} [options.contentSheetName="Content"]  Sheet name to exclude entirely.
+ * @returns {{ eligible: Array, skipped: Array }}
+ *
+ * Each eligible entry: { sheetName, rangeAddress, title }
+ * Each skipped entry:  { sheetName, rangeAddress, reason, status }
+ */
+export function filterWorkbookCandidates(inventoryResults, { contentSheetName = "Content" } = {}) {
+  const eligible = [];
+  const skipped = [];
+
+  for (const sheetResult of inventoryResults.sheetResults) {
+    if (sheetResult.sheetName === contentSheetName) {
+      continue;
+    }
+    for (const item of sheetResult.items) {
+      const rangeAddr = item.resolvedRangeAddress || item.rangeAddress || null;
+
+      if (!rangeAddr) {
+        skipped.push({
+          sheetName: sheetResult.sheetName,
+          rangeAddress: item.rangeAddress || null,
+          reason: BATCH_SKIP_REASONS.MISSING_RANGE,
+          status: item.candidateStatus || null,
+        });
+      } else if (item.candidateStatus === "uncertain") {
+        skipped.push({
+          sheetName: sheetResult.sheetName,
+          rangeAddress: rangeAddr,
+          reason: BATCH_SKIP_REASONS.CANDIDATE_UNCERTAIN,
+          status: "uncertain",
+        });
+      } else if (item.candidateStatus === "rejected") {
+        skipped.push({
+          sheetName: sheetResult.sheetName,
+          rangeAddress: rangeAddr,
+          reason: BATCH_SKIP_REASONS.CANDIDATE_REJECTED,
+          status: "rejected",
+        });
+      } else if (item.candidateStatus === "available" && item.canRunCheckTable) {
+        eligible.push({
+          sheetName: sheetResult.sheetName,
+          rangeAddress: rangeAddr,
+          title: item.resolvedTitle || item.title || "",
+        });
+      } else {
+        skipped.push({
+          sheetName: sheetResult.sheetName,
+          rangeAddress: rangeAddr,
+          reason: BATCH_SKIP_REASONS.UNKNOWN_STATUS,
+          status: item.candidateStatus || null,
+        });
+      }
+    }
+  }
+
+  return { eligible, skipped };
+}

--- a/src/taskpane/taskpane.js
+++ b/src/taskpane/taskpane.js
@@ -36,6 +36,8 @@ import { detectBannerStructure, formatBannerDetectionDiagnostics } from "../core
 
 import { normalizeSelectedRange } from "../core/range-normalizer";
 
+import { filterWorkbookCandidates, BATCH_SKIP_REASONS } from "../core/batch-candidate-filter";
+
 import {
   interpretSelectedRange,
   loadLabelValuesForSelectedRange,
@@ -900,6 +902,26 @@ async function runSignificanceForRange(sheetName, rangeAddress, calculationSetti
 }
 
 /**
+ * Formats a pre-execution skipped candidate entry into a Russian-language
+ * detail line for the status panel. Used by runAutoSignificance and
+ * clearAutoSignificance when building their skipped-candidate summaries.
+ */
+function formatSkippedCandidateDetail({ sheetName, rangeAddress, reason, status }) {
+  const addr = rangeAddress || "?";
+  const label = `- ${sheetName} ${addr}`;
+  switch (reason) {
+    case BATCH_SKIP_REASONS.MISSING_RANGE:
+      return `${label}: пропущено — нет диапазона`;
+    case BATCH_SKIP_REASONS.CANDIDATE_UNCERTAIN:
+      return `${label}: пропущено — кандидат неопределён`;
+    case BATCH_SKIP_REASONS.CANDIDATE_REJECTED:
+      return `${label}: пропущено — не опознан как таблица ResearchSignal`;
+    default:
+      return `${label}: пропущено — статус «${status || "unknown"}»`;
+  }
+}
+
+/**
  * Auto-runner: processes all "available" inventory candidates in the workbook.
  *
  * Collects the workbook inventory, filters to candidates with
@@ -967,41 +989,12 @@ async function runAutoSignificance() {
   }
 
   // Partition candidates: eligible to process vs. pre-skipped due to status/range.
-  // The Content sheet is excluded entirely and does not count toward skipped.
-  const eligible = [];
-  let skipped = 0;
-  const detailLines = [];
-
-  for (const sheetResult of inventoryResults.sheetResults) {
-    if (sheetResult.sheetName === INVENTORY_CONTENT_SHEET_NAME) {
-      continue;
-    }
-    for (const item of sheetResult.items) {
-      const rangeAddr = item.resolvedRangeAddress || item.rangeAddress;
-      const label = `- ${sheetResult.sheetName} ${rangeAddr || item.rangeAddress || "?"}`;
-
-      if (!rangeAddr) {
-        skipped++;
-        detailLines.push(`${label}: пропущено — нет диапазона`);
-      } else if (item.candidateStatus === "uncertain") {
-        skipped++;
-        detailLines.push(`${label}: пропущено — кандидат неопределён`);
-      } else if (item.candidateStatus === "rejected") {
-        skipped++;
-        detailLines.push(`${label}: пропущено — не опознан как таблица ResearchSignal`);
-      } else if (item.candidateStatus === "available" && item.canRunCheckTable) {
-        eligible.push({
-          sheetName: sheetResult.sheetName,
-          rangeAddress: rangeAddr,
-          title: item.resolvedTitle || (item.title || ""),
-        });
-      } else {
-        // Catch-all for unknown future statuses.
-        skipped++;
-        detailLines.push(`${label}: пропущено — статус «${item.candidateStatus || "unknown"}»`);
-      }
-    }
-  }
+  // Content sheet is excluded entirely (not counted toward skipped).
+  const { eligible, skipped: preSkipped } = filterWorkbookCandidates(inventoryResults, {
+    contentSheetName: INVENTORY_CONTENT_SHEET_NAME,
+  });
+  let skipped = preSkipped.length;
+  const detailLines = preSkipped.map(formatSkippedCandidateDetail);
 
   if (eligible.length === 0) {
     const noEligibleLines = [
@@ -1205,35 +1198,11 @@ async function clearAutoSignificance() {
     return;
   }
 
-  const eligible = [];
-  let skipped = 0;
-  const detailLines = [];
-
-  for (const sheetResult of inventoryResults.sheetResults) {
-    if (sheetResult.sheetName === INVENTORY_CONTENT_SHEET_NAME) {
-      continue;
-    }
-    for (const item of sheetResult.items) {
-      const rangeAddr = item.resolvedRangeAddress || item.rangeAddress;
-      const label = `- ${sheetResult.sheetName} ${rangeAddr || item.rangeAddress || "?"}`;
-
-      if (!rangeAddr) {
-        skipped++;
-        detailLines.push(`${label}: пропущено — нет диапазона`);
-      } else if (item.candidateStatus === "uncertain") {
-        skipped++;
-        detailLines.push(`${label}: пропущено — кандидат неопределён`);
-      } else if (item.candidateStatus === "rejected") {
-        skipped++;
-        detailLines.push(`${label}: пропущено — не опознан как таблица ResearchSignal`);
-      } else if (item.candidateStatus === "available" && item.canRunCheckTable) {
-        eligible.push({ sheetName: sheetResult.sheetName, rangeAddress: rangeAddr });
-      } else {
-        skipped++;
-        detailLines.push(`${label}: пропущено — статус «${item.candidateStatus || "unknown"}»`);
-      }
-    }
-  }
+  const { eligible, skipped: preSkipped } = filterWorkbookCandidates(inventoryResults, {
+    contentSheetName: INVENTORY_CONTENT_SHEET_NAME,
+  });
+  let skipped = preSkipped.length;
+  const detailLines = preSkipped.map(formatSkippedCandidateDetail);
 
   if (eligible.length === 0) {
     const noEligibleLines = [

--- a/tests/core/batch-candidate-filter.test.mjs
+++ b/tests/core/batch-candidate-filter.test.mjs
@@ -1,0 +1,227 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  BATCH_SKIP_REASONS,
+  filterWorkbookCandidates,
+} from "../../src/core/batch-candidate-filter.js";
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function makeItem(overrides) {
+  return {
+    rangeAddress: "A1:D10",
+    resolvedRangeAddress: null,
+    candidateStatus: "available",
+    canRunCheckTable: true,
+    title: "",
+    resolvedTitle: null,
+    ...overrides,
+  };
+}
+
+function makeSheet(sheetName, items) {
+  return { sheetName, items };
+}
+
+function makeInventory(...sheetResults) {
+  return { sheetResults };
+}
+
+// ─── BATCH_SKIP_REASONS ───────────────────────────────────────────────────────
+
+describe("BATCH_SKIP_REASONS", () => {
+  it("is frozen", () => {
+    assert.ok(Object.isFrozen(BATCH_SKIP_REASONS));
+  });
+
+  it("has stable string values", () => {
+    assert.strictEqual(BATCH_SKIP_REASONS.MISSING_RANGE, "missing_range");
+    assert.strictEqual(BATCH_SKIP_REASONS.CANDIDATE_UNCERTAIN, "candidate_uncertain");
+    assert.strictEqual(BATCH_SKIP_REASONS.CANDIDATE_REJECTED, "candidate_rejected");
+    assert.strictEqual(BATCH_SKIP_REASONS.UNKNOWN_STATUS, "unknown_status");
+  });
+});
+
+// ─── filterWorkbookCandidates — eligible ──────────────────────────────────────
+
+describe("filterWorkbookCandidates — eligible candidates", () => {
+  it("includes available + canRunCheckTable + rangeAddress candidate", () => {
+    const item = makeItem({ candidateStatus: "available", canRunCheckTable: true, rangeAddress: "B2:E8" });
+    const { eligible, skipped } = filterWorkbookCandidates(makeInventory(makeSheet("Sheet1", [item])));
+    assert.strictEqual(eligible.length, 1);
+    assert.strictEqual(eligible[0].sheetName, "Sheet1");
+    assert.strictEqual(eligible[0].rangeAddress, "B2:E8");
+    assert.strictEqual(skipped.length, 0);
+  });
+
+  it("uses resolvedRangeAddress over rangeAddress when both present", () => {
+    const item = makeItem({
+      candidateStatus: "available",
+      canRunCheckTable: true,
+      rangeAddress: "A1:D10",
+      resolvedRangeAddress: "A2:D11",
+    });
+    const { eligible } = filterWorkbookCandidates(makeInventory(makeSheet("Sheet1", [item])));
+    assert.strictEqual(eligible[0].rangeAddress, "A2:D11");
+  });
+
+  it("includes title from resolvedTitle when present", () => {
+    const item = makeItem({
+      candidateStatus: "available",
+      canRunCheckTable: true,
+      title: "Raw",
+      resolvedTitle: "Resolved",
+    });
+    const { eligible } = filterWorkbookCandidates(makeInventory(makeSheet("Sheet1", [item])));
+    assert.strictEqual(eligible[0].title, "Resolved");
+  });
+
+  it("falls back to title when resolvedTitle is absent", () => {
+    const item = makeItem({ candidateStatus: "available", canRunCheckTable: true, title: "Raw", resolvedTitle: null });
+    const { eligible } = filterWorkbookCandidates(makeInventory(makeSheet("Sheet1", [item])));
+    assert.strictEqual(eligible[0].title, "Raw");
+  });
+
+  it("title is empty string when both title and resolvedTitle are absent", () => {
+    const item = makeItem({ candidateStatus: "available", canRunCheckTable: true, title: "", resolvedTitle: null });
+    const { eligible } = filterWorkbookCandidates(makeInventory(makeSheet("Sheet1", [item])));
+    assert.strictEqual(eligible[0].title, "");
+  });
+
+  it("does not include available candidate when canRunCheckTable is false", () => {
+    const item = makeItem({ candidateStatus: "available", canRunCheckTable: false });
+    const { eligible, skipped } = filterWorkbookCandidates(makeInventory(makeSheet("Sheet1", [item])));
+    assert.strictEqual(eligible.length, 0);
+    assert.strictEqual(skipped.length, 1);
+    assert.strictEqual(skipped[0].reason, BATCH_SKIP_REASONS.UNKNOWN_STATUS);
+  });
+});
+
+// ─── filterWorkbookCandidates — skipped ──────────────────────────────────────
+
+describe("filterWorkbookCandidates — skipped candidates", () => {
+  it("skips uncertain candidate with CANDIDATE_UNCERTAIN reason", () => {
+    const item = makeItem({ candidateStatus: "uncertain", rangeAddress: "A1:D10" });
+    const { eligible, skipped } = filterWorkbookCandidates(makeInventory(makeSheet("Sheet1", [item])));
+    assert.strictEqual(eligible.length, 0);
+    assert.strictEqual(skipped.length, 1);
+    assert.strictEqual(skipped[0].reason, BATCH_SKIP_REASONS.CANDIDATE_UNCERTAIN);
+    assert.strictEqual(skipped[0].status, "uncertain");
+    assert.strictEqual(skipped[0].sheetName, "Sheet1");
+    assert.strictEqual(skipped[0].rangeAddress, "A1:D10");
+  });
+
+  it("skips rejected candidate with CANDIDATE_REJECTED reason", () => {
+    const item = makeItem({ candidateStatus: "rejected", rangeAddress: "C3:F12" });
+    const { skipped } = filterWorkbookCandidates(makeInventory(makeSheet("Sheet2", [item])));
+    assert.strictEqual(skipped[0].reason, BATCH_SKIP_REASONS.CANDIDATE_REJECTED);
+    assert.strictEqual(skipped[0].status, "rejected");
+    assert.strictEqual(skipped[0].rangeAddress, "C3:F12");
+  });
+
+  it("skips candidate with no range address using MISSING_RANGE reason", () => {
+    const item = makeItem({ candidateStatus: "available", rangeAddress: null, resolvedRangeAddress: null });
+    const { skipped } = filterWorkbookCandidates(makeInventory(makeSheet("Sheet1", [item])));
+    assert.strictEqual(skipped[0].reason, BATCH_SKIP_REASONS.MISSING_RANGE);
+    assert.strictEqual(skipped[0].rangeAddress, null);
+  });
+
+  it("stores null rangeAddress when both resolvedRangeAddress and rangeAddress are absent", () => {
+    const item = makeItem({ candidateStatus: "available", rangeAddress: null, resolvedRangeAddress: null });
+    const { skipped } = filterWorkbookCandidates(makeInventory(makeSheet("Sheet1", [item])));
+    assert.strictEqual(skipped[0].reason, BATCH_SKIP_REASONS.MISSING_RANGE);
+    assert.strictEqual(skipped[0].rangeAddress, null);
+  });
+
+  it("skips unknown status with UNKNOWN_STATUS reason", () => {
+    const item = makeItem({ candidateStatus: "future_status", rangeAddress: "A1:D10" });
+    const { skipped } = filterWorkbookCandidates(makeInventory(makeSheet("Sheet1", [item])));
+    assert.strictEqual(skipped[0].reason, BATCH_SKIP_REASONS.UNKNOWN_STATUS);
+    assert.strictEqual(skipped[0].status, "future_status");
+  });
+
+  it("skips null candidateStatus with UNKNOWN_STATUS and null status field", () => {
+    const item = makeItem({ candidateStatus: null, rangeAddress: "A1:D10" });
+    const { skipped } = filterWorkbookCandidates(makeInventory(makeSheet("Sheet1", [item])));
+    assert.strictEqual(skipped[0].reason, BATCH_SKIP_REASONS.UNKNOWN_STATUS);
+    assert.strictEqual(skipped[0].status, null);
+  });
+});
+
+// ─── filterWorkbookCandidates — Content sheet ─────────────────────────────────
+
+describe("filterWorkbookCandidates — Content sheet exclusion", () => {
+  it("ignores the Content sheet entirely — items not counted toward skipped", () => {
+    const contentItem = makeItem({ candidateStatus: "available" });
+    const { eligible, skipped } = filterWorkbookCandidates(
+      makeInventory(makeSheet("Content", [contentItem]))
+    );
+    assert.strictEqual(eligible.length, 0);
+    assert.strictEqual(skipped.length, 0);
+  });
+
+  it("excludes Content sheet while processing other sheets normally", () => {
+    const contentItem = makeItem({ candidateStatus: "available", rangeAddress: "A1:D10" });
+    const normalItem = makeItem({ candidateStatus: "available", rangeAddress: "B2:E8" });
+    const { eligible, skipped } = filterWorkbookCandidates(
+      makeInventory(makeSheet("Content", [contentItem]), makeSheet("Data", [normalItem]))
+    );
+    assert.strictEqual(eligible.length, 1);
+    assert.strictEqual(eligible[0].sheetName, "Data");
+    assert.strictEqual(skipped.length, 0);
+  });
+
+  it("respects a custom contentSheetName option", () => {
+    const item = makeItem({ candidateStatus: "available", rangeAddress: "A1:D10" });
+    const { eligible, skipped } = filterWorkbookCandidates(
+      makeInventory(makeSheet("Содержание", [item])),
+      { contentSheetName: "Содержание" }
+    );
+    assert.strictEqual(eligible.length, 0);
+    assert.strictEqual(skipped.length, 0);
+  });
+
+  it("uses 'Content' as the default contentSheetName", () => {
+    const item = makeItem({ candidateStatus: "available", rangeAddress: "A1:D10" });
+    const { eligible } = filterWorkbookCandidates(makeInventory(makeSheet("Content", [item])));
+    assert.strictEqual(eligible.length, 0);
+  });
+});
+
+// ─── filterWorkbookCandidates — multi-sheet and mixed ────────────────────────
+
+describe("filterWorkbookCandidates — multi-sheet and mixed results", () => {
+  it("aggregates eligible and skipped across multiple sheets", () => {
+    const availableItem = makeItem({ candidateStatus: "available", rangeAddress: "A1:D10" });
+    const uncertainItem = makeItem({ candidateStatus: "uncertain", rangeAddress: "A1:D5" });
+    const rejectedItem = makeItem({ candidateStatus: "rejected", rangeAddress: "A1:D3" });
+    const inv = makeInventory(
+      makeSheet("Sheet1", [availableItem]),
+      makeSheet("Sheet2", [uncertainItem, rejectedItem])
+    );
+    const { eligible, skipped } = filterWorkbookCandidates(inv);
+    assert.strictEqual(eligible.length, 1);
+    assert.strictEqual(skipped.length, 2);
+  });
+
+  it("returns empty arrays for empty sheetResults", () => {
+    const { eligible, skipped } = filterWorkbookCandidates({ sheetResults: [] });
+    assert.strictEqual(eligible.length, 0);
+    assert.strictEqual(skipped.length, 0);
+  });
+
+  it("returns empty arrays for sheet with no items", () => {
+    const { eligible, skipped } = filterWorkbookCandidates(makeInventory(makeSheet("Sheet1", [])));
+    assert.strictEqual(eligible.length, 0);
+    assert.strictEqual(skipped.length, 0);
+  });
+
+  it("preserves order: eligible items appear in sheet/item traversal order", () => {
+    const a = makeItem({ candidateStatus: "available", rangeAddress: "A1:D5", title: "First" });
+    const b = makeItem({ candidateStatus: "available", rangeAddress: "A6:D10", title: "Second" });
+    const { eligible } = filterWorkbookCandidates(makeInventory(makeSheet("Sheet1", [a, b])));
+    assert.strictEqual(eligible[0].title, "First");
+    assert.strictEqual(eligible[1].title, "Second");
+  });
+});


### PR DESCRIPTION
## Summary

- Add `src/core/batch-candidate-filter.js` — pure Office.js-free module with `filterWorkbookCandidates()` and `BATCH_SKIP_REASONS` constants. Partitions workbook inventory results into `eligible` candidates and `skipped` entries with stable reason codes (missing_range, candidate_uncertain, candidate_rejected, unknown_status).
- Add `formatSkippedCandidateDetail()` private helper in `taskpane.js` to map reason codes to the existing Russian display strings.
- Wire both `runAutoSignificance` and `clearAutoSignificance` to use the shared helper, replacing ~36 duplicated lines in each with 3 lines.
- Add 19 focused unit tests in `tests/core/batch-candidate-filter.test.mjs`.

## Behavior

This is a pure behavior-preserving refactor. All status-panel display strings are identical to before. No eligibility semantics changed:
- `available + canRunCheckTable + usable range` → eligible
- `uncertain / rejected / missing-range` → skipped with reason code
- Content sheet → ignored, not counted toward skipped

## Files changed

| File | Change |
|------|--------|
| `src/core/batch-candidate-filter.js` | New — pure helper module |
| `tests/core/batch-candidate-filter.test.mjs` | New — 19 unit tests |
| `src/taskpane/taskpane.js` | Import helper; add formatter; replace two filtering loops |

## Validation

- `npm test`: 217 pass, 0 fail
- `npm run build`: compiled with 0 errors (3 pre-existing bundle-size warnings)
- `git diff --check`: clean

## Not changed

- `significance.js` — untouched
- `excel-writer.js` — untouched
- Manual selected-range Run/Clear/Check behavior — untouched
- Candidate eligibility semantics — unchanged
- UI / status panel output text — identical

## Tech debt

No new technical debt introduced. This resolves the duplication noted in the `runAutoSignificance` JSDoc comment ("A future refactor could unify them…").

🤖 Generated with [Claude Code](https://claude.com/claude-code)