### PR TITLE
Add current-sheet Run and Clear (#172)

### DIFF
--- a/src/taskpane/taskpane.html
+++ b/src/taskpane/taskpane.html
@@ -61,6 +61,10 @@
         <div class="check-buttons-row">
           <button id="clear-all-tables" class="check-action-button">Очистить по найденным таблицам</button>
         </div>
+        <div class="check-buttons-row">
+          <button id="run-sheet-tables" class="check-action-button">Лист: Запустить</button>
+          <button id="clear-sheet-tables" class="check-action-button">Лист: Очистить</button>
+        </div>
         <div class="inventory-mode-row">
           <label for="content-output-mode">Формат оглавления</label>
           <select id="content-output-mode" class="inventory-mode-select">

--- a/src/taskpane/taskpane.js
+++ b/src/taskpane/taskpane.js
@@ -398,6 +398,17 @@ Office.onReady((info) => {
   if (clearAllTablesButton) {
     clearAllTablesButton.addEventListener("click", clearAutoSignificance);
   }
+
+  const runSheetTablesButton = document.getElementById("run-sheet-tables");
+  const clearSheetTablesButton = document.getElementById("clear-sheet-tables");
+
+  if (runSheetTablesButton) {
+    runSheetTablesButton.addEventListener("click", runCurrentSheetSignificance);
+  }
+
+  if (clearSheetTablesButton) {
+    clearSheetTablesButton.addEventListener("click", clearCurrentSheetSignificance);
+  }
 });
 
 
@@ -1259,6 +1270,211 @@ async function clearAutoSignificance() {
 }
 
 /**
+ * Current-sheet run: processes all "available" inventory candidates on the
+ * active worksheet only.
+ *
+ * Mirrors runAutoSignificance() but scans only the active sheet via
+ * collectActiveSheetInventoryResults(). Content sheet is silently ignored.
+ * Settings validation is identical to runAutoSignificance().
+ */
+async function runCurrentSheetSignificance() {
+  const calculationSettings = readCalculationSettingsFromPanel();
+
+  if (calculationSettings.compareWithPreviousColumn && calculationSettings.compareOnlyWithTotal) {
+    setStatusMessage(
+      // eslint-disable-next-line quotes
+      'Режим "Сравнение с предыдущей колонкой" несовместим с режимом "Сравнивать только с Тотал".'
+    );
+    return;
+  }
+
+  if (
+    calculationSettings.excludeTotalFromComparisons &&
+    !calculationSettings.firstColumnIsTotal &&
+    !calculationSettings.respectBannerStructure
+  ) {
+    setStatusMessage(
+      'Для режима "Не сравнивать с Тотал" нужно указать расположение Тотала. Сейчас поддерживается вариант "Первая колонка — Тотал" или режим "Учитывать структуру баннера".'
+    );
+    return;
+  }
+
+  if (
+    calculationSettings.compareOnlyWithTotal &&
+    !calculationSettings.firstColumnIsTotal &&
+    !calculationSettings.respectBannerStructure
+  ) {
+    setStatusMessage(
+      'Для режима "Сравнивать только с Тотал" нужно указать расположение Тотала. Сейчас поддерживается вариант "Первая колонка — Тотал" или режим "Учитывать структуру баннера".'
+    );
+    return;
+  }
+
+  if (
+    calculationSettings.compareWithPreviousColumn &&
+    calculationSettings.fillOnlyTotalComparisons
+  ) {
+    setStatusMessage(
+      'Режим "Сравнение с предыдущей колонкой" несовместим с настройкой "Заливка только для Тотала".'
+    );
+    return;
+  }
+
+  let inventoryResults;
+  try {
+    await Excel.run(async (context) => {
+      inventoryResults = await collectActiveSheetInventoryResults(context, calculationSettings);
+      normalizeBacklinkItems(inventoryResults.sheetResults, false);
+    });
+  } catch (err) {
+    setStatusMessage(`Лист — запуск: ошибка при сканировании листа — ${err.message || err}`);
+    return;
+  }
+
+  const { eligible, skipped: preSkipped } = filterWorkbookCandidates(inventoryResults, {
+    contentSheetName: INVENTORY_CONTENT_SHEET_NAME,
+  });
+  let skipped = preSkipped.length;
+  const detailLines = preSkipped.map(formatSkippedCandidateDetail);
+
+  if (eligible.length === 0) {
+    const noEligibleLines = [
+      "Лист — запуск: доступных кандидатов не найдено.",
+      'Проверьте статусы таблиц через «Найти таблицы» / «С полной проверкой».',
+    ];
+    if (skipped > 0) {
+      noEligibleLines.push("", `Пропущено: ${skipped}.`, ...detailLines);
+    }
+    setStatusMessage(noEligibleLines.join("\n"));
+    return;
+  }
+
+  let processed = 0;
+  let errors = 0;
+
+  for (const candidate of eligible) {
+    try {
+      const result = await runSignificanceForRange(
+        candidate.sheetName,
+        candidate.rangeAddress,
+        calculationSettings
+      );
+
+      if (result.status === "processed") {
+        processed++;
+      } else if (result.status === "skipped" || result.status === "blocked") {
+        skipped++;
+        detailLines.push(
+          `- ${candidate.sheetName} ${candidate.rangeAddress}: пропущено — ${result.message}`
+        );
+      } else {
+        errors++;
+        detailLines.push(
+          `- ${candidate.sheetName} ${candidate.rangeAddress}: ошибка — ${result.message}`
+        );
+      }
+    } catch (err) {
+      errors++;
+      detailLines.push(
+        `- ${candidate.sheetName} ${candidate.rangeAddress}: ошибка — ${err.message || "неизвестная ошибка"}`
+      );
+    }
+  }
+
+  const summaryLines = [
+    "Лист — запуск завершён.",
+    `Обработано таблиц: ${processed}.`,
+    `Пропущено: ${skipped}.`,
+    `Ошибок: ${errors}.`,
+  ];
+
+  if (detailLines.length > 0) {
+    summaryLines.push("", ...detailLines);
+  }
+
+  setStatusMessage(summaryLines.join("\n"));
+}
+
+/**
+ * Current-sheet clear: removes significance markers from all "available"
+ * inventory candidates on the active worksheet only.
+ *
+ * Mirrors clearAutoSignificance() but scans only the active sheet via
+ * collectActiveSheetInventoryResults(). Content sheet is silently ignored.
+ */
+async function clearCurrentSheetSignificance() {
+  let inventoryResults;
+  try {
+    await Excel.run(async (context) => {
+      inventoryResults = await collectActiveSheetInventoryResults(context, readCalculationSettingsFromPanel());
+      normalizeBacklinkItems(inventoryResults.sheetResults, false);
+    });
+  } catch (err) {
+    setStatusMessage(`Лист — очистка: ошибка при сканировании листа — ${err.message || err}`);
+    return;
+  }
+
+  const { eligible, skipped: preSkipped } = filterWorkbookCandidates(inventoryResults, {
+    contentSheetName: INVENTORY_CONTENT_SHEET_NAME,
+  });
+  let skipped = preSkipped.length;
+  const detailLines = preSkipped.map(formatSkippedCandidateDetail);
+
+  if (eligible.length === 0) {
+    const noEligibleLines = [
+      "Лист — очистка: доступных кандидатов не найдено.",
+      'Проверьте статусы таблиц через «Найти таблицы» / «С полной проверкой».',
+    ];
+    if (skipped > 0) {
+      noEligibleLines.push("", `Пропущено: ${skipped}.`, ...detailLines);
+    }
+    setStatusMessage(noEligibleLines.join("\n"));
+    return;
+  }
+
+  let cleared = 0;
+  let errors = 0;
+
+  for (const candidate of eligible) {
+    try {
+      const result = await clearSignificanceForRange(candidate.sheetName, candidate.rangeAddress);
+
+      if (result.status === "cleared") {
+        cleared++;
+      } else if (result.status === "skipped") {
+        skipped++;
+        detailLines.push(
+          `- ${candidate.sheetName} ${candidate.rangeAddress}: пропущено — ${result.message}`
+        );
+      } else {
+        errors++;
+        detailLines.push(
+          `- ${candidate.sheetName} ${candidate.rangeAddress}: ошибка — ${result.message}`
+        );
+      }
+    } catch (err) {
+      errors++;
+      detailLines.push(
+        `- ${candidate.sheetName} ${candidate.rangeAddress}: ошибка — ${err.message || "неизвестная ошибка"}`
+      );
+    }
+  }
+
+  const summaryLines = [
+    "Лист — очистка завершена.",
+    `Очищено таблиц: ${cleared}.`,
+    `Пропущено: ${skipped}.`,
+    `Ошибок: ${errors}.`,
+  ];
+
+  if (detailLines.length > 0) {
+    summaryLines.push("", ...detailLines);
+  }
+
+  setStatusMessage(summaryLines.join("\n"));
+}
+
+/**
  * Calculates one detected metric block.
  *
  * PURPOSE:
@@ -2041,6 +2257,80 @@ async function collectWorkbookInventoryResults(context, settings) {
     sheetResults,
     skippedSheets,
   };
+}
+
+/**
+ * Collects inventory results for the active worksheet only.
+ *
+ * Mirrors collectWorkbookInventoryResults() but scans only the active sheet,
+ * returning the same { scannedSheets, sheetResults, skippedSheets } shape so
+ * that filterWorkbookCandidates() and normalizeBacklinkItems() work unchanged.
+ */
+async function collectActiveSheetInventoryResults(context, settings) {
+  const worksheet = context.workbook.worksheets.getActiveWorksheet();
+  worksheet.load("name");
+
+  await context.sync();
+
+  if (worksheet.name === INVENTORY_CONTENT_SHEET_NAME) {
+    return { scannedSheets: 0, sheetResults: [], skippedSheets: [] };
+  }
+
+  const usedRange = worksheet.getUsedRangeOrNullObject();
+  usedRange.load(["isNullObject", "rowIndex", "columnIndex", "rowCount", "columnCount"]);
+
+  await context.sync();
+
+  if (usedRange.isNullObject) {
+    return {
+      scannedSheets: 0,
+      sheetResults: [],
+      skippedSheets: [{ sheetName: worksheet.name, reason: "empty" }],
+    };
+  }
+
+  const cellCount = usedRange.rowCount * usedRange.columnCount;
+  if (cellCount > SCAN_CELL_LIMIT) {
+    return {
+      scannedSheets: 0,
+      sheetResults: [],
+      skippedSheets: [
+        {
+          sheetName: worksheet.name,
+          reason: "tooLarge",
+          rowCount: usedRange.rowCount,
+          columnCount: usedRange.columnCount,
+          cellCount,
+        },
+      ],
+    };
+  }
+
+  usedRange.load("values");
+
+  await context.sync();
+
+  const items = scanWorksheetForTables({
+    values: usedRange.values,
+    usedRangeRowOffset: usedRange.rowIndex,
+    usedRangeColOffset: usedRange.columnIndex,
+    sheetName: worksheet.name,
+    settings,
+  });
+
+  const sheetResults = items.length > 0
+    ? [
+        {
+          sheetName: worksheet.name,
+          usedRangeRowOffset: usedRange.rowIndex,
+          usedRangeColOffset: usedRange.columnIndex,
+          usedRangeValues: usedRange.values,
+          items,
+        },
+      ]
+    : [];
+
+  return { scannedSheets: 1, sheetResults, skippedSheets: [] };
 }
 
 function buildInventoryContentCandidateRows(sheetResults) {


### PR DESCRIPTION
## Summary

- Adds `collectActiveSheetInventoryResults(context, settings)` — mirrors `collectWorkbookInventoryResults` but scans only the active worksheet via `getActiveWorksheet()`. Returns the same `{ scannedSheets, sheetResults, skippedSheets }` shape so all downstream helpers are unchanged.
- Adds `runCurrentSheetSignificance()` — same settings validation and processing loop as `runAutoSignificance()`, using the active-sheet inventory.
- Adds `clearCurrentSheetSignificance()` — same loop as `clearAutoSignificance()`, using the active-sheet inventory.
- Wires both to new **"Лист: Запустить"** and **"Лист: Очистить"** buttons in `taskpane.html`.
- Content sheet is silently ignored (returns empty results immediately).
- Re-uses `filterWorkbookCandidates()`, `scanWorksheetForTables()`, `runSignificanceForRange()`, and `clearSignificanceForRange()` without modification.

## Affected files

| File | Change |
|---|---|
| `src/taskpane/taskpane.js` | +294 lines: new helper + two functions + button wiring |
| `src/taskpane/taskpane.html` | +4 lines: two new buttons |

## Validation

- `npm.cmd test` — 217/217 pass
- `npm.cmd run build` — compiled with warnings (pre-existing size warnings only)
- `git diff --check` — clean

## Smoke expectations coverage

1. Manual selected-range Run — unchanged (no existing code modified)
2. Manual selected-range Clear — unchanged
3. Whole-workbook auto-run — unchanged (`runAutoSignificance` untouched)
4. Whole-workbook auto-clear — unchanged (`clearAutoSignificance` untouched)
5. Current-sheet Run — processes only available candidates on the active sheet
6. Current-sheet Clear — clears only available candidates on the active sheet
7. Other sheets untouched — `collectActiveSheetInventoryResults` queries only `getActiveWorksheet()`
8. Content sheet ignored — early return when `worksheet.name === INVENTORY_CONTENT_SHEET_NAME`

## Assumptions / limitations

- Does not implement Check current-sheet (out of scope per issue).
- Does not implement active-cell / current-table resolver (out of scope).
- `normalizeBacklinkItems` is called with `backlinksEnabled=false` (same as whole-workbook path) — resolves `resolvedRangeAddress` without predicting row insertions.
- The two new buttons share the `check-action-button` CSS class (same as the workbook-level buttons) per the issue's "minimal UI" guidance.

## Technical debt

No known technical debt introduced. The active-sheet inventory helper is a focused single-sheet variant of the existing workbook collector and shares all its core paths.

Closes #172

🤖 Generated with [Claude Code](https://claude.com/claude-code)