### PR TITLE
Activate Content sheet after Find Tables generation (#147 slice 1)

### DIFF
--- a/src/taskpane/taskpane.js
+++ b/src/taskpane/taskpane.js
@@ -3836,6 +3836,8 @@ async function writeInventoryContentSheet(context, inventoryResults) {
   worksheet.position = 0;
 
   await context.sync();
+
+  return worksheet;
 }
 
 async function runTableInventory() {
@@ -3854,13 +3856,17 @@ async function runTableInventory() {
       : null;
 
     // Write Content first (hyperlinks use resolvedRangeAddress when available).
-    await writeInventoryContentSheet(context, inventoryResults);
+    const contentWorksheet = await writeInventoryContentSheet(context, inventoryResults);
 
     // Insert/update backlink rows after Content is written so the Content sheet
     // is not affected by row insertions in source sheets.
     if (addBacklinks && contentRowMap) {
       await ensureBacklinkRows(context, inventoryResults.sheetResults, contentRowMap);
     }
+
+    // Switch to the Content sheet after all writes are done.
+    contentWorksheet.activate();
+    await context.sync();
 
     setInventoryMessage(
       formatWorkbookInventoryMessage({


### PR DESCRIPTION
## Summary

- After `Find Tables` writes the Content sheet, Excel now activates (switches to) the Content sheet automatically.
- Content sheet is positioned first (`position = 0`) — this was already in place; activation is the new piece.
- Rerunning Find Tables reuses the existing Content sheet with no duplicates — also already in place via `getItemOrNullObject`.
- Content and Run report remain excluded from workbook scanning, current-sheet scanning, batch run/clear, and check actions via `GENERATED_SHEET_NAMES` — unchanged.

## What changed

**`src/taskpane/taskpane.js`** (7 insertions, 1 deletion)

1. `writeInventoryContentSheet` now returns the `worksheet` object after writing content and syncing.
2. `runTableInventory` captures the returned worksheet and calls `contentWorksheet.activate()` + `context.sync()` after all writes (content body + backlink rows) are complete.

## What was NOT changed (per issue scope)

- No taskpane redesign
- No new output modes
- No significance formulas / statistics
- `significance.js` untouched
- `excel-writer.js` untouched
- Run/Clear calculation behavior unchanged
- Run report behavior unchanged

## Validation

```
npm.cmd test   → 217/217 pass, 0 fail
npm.cmd run build  → 0 errors (3 pre-existing webpack size warnings)
git diff --check   → clean
```

## Smoke checklist (for human reviewer)

1. Find Tables / Content creates or updates Content sheet ✓ (pre-existing)
2. Excel switches to Content tab after generation ← **new**
3. Content is the first worksheet ✓ (pre-existing `position = 0`)
4. Rerun does not create duplicate Content sheets ✓ (pre-existing)
5. Find Tables does not scan Content as a source table ✓ (pre-existing `GENERATED_SHEET_NAMES`)
6. Auto-run / auto-clear / current-sheet actions ignore Content ✓ (pre-existing)
7. Run report still works and remains last ✓ (unchanged)

## Limitations / follow-ups

- `worksheet.position = 0` does not have a two-tier copy/delete/rename fallback (unlike the Run report). If position assignment silently fails on a specific Office.js build, a follow-up issue should add the same fallback pattern used for Run report.

## Technical debt

No new technical debt introduced. Patch is additive and minimal.