### PR TITLE
Restructure taskpane around action and scope shell

### DIFF
--- a/src/taskpane/taskpane.css
+++ b/src/taskpane/taskpane.css
@@ -525,3 +525,90 @@ b {
   font-size: 12px;
   color: var(--rs-color-muted);
 }
+
+/* ── Action + Scope shell (PR1 / issue #167) ─────────────────────────────── */
+
+.action-tabs {
+  display: flex;
+  gap: 2px;
+  margin-bottom: 8px;
+  padding: 3px;
+  background: var(--rs-color-bg-soft);
+  border: 1px solid var(--rs-color-border);
+  border-radius: var(--rs-radius-sm);
+}
+
+.action-tab {
+  flex: 1;
+  padding: 5px 4px;
+  border: none;
+  border-radius: 4px;
+  background: transparent;
+  color: var(--rs-color-muted);
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.action-tab:hover {
+  background: var(--rs-color-border);
+  color: var(--rs-color-text);
+}
+
+.action-tab.is-active {
+  background: var(--rs-color-primary);
+  color: #fff;
+}
+
+/* Check tab gets a blue active state to signal read-only */
+.action-tab--readonly.is-active {
+  background: #2563eb;
+  color: #fff;
+}
+
+.scope-selector {
+  display: flex;
+  gap: 3px;
+  margin-bottom: 8px;
+}
+
+.scope-btn {
+  flex: 1;
+  padding: 4px 2px;
+  border: 1px solid var(--rs-color-border);
+  border-radius: var(--rs-radius-sm);
+  background: var(--rs-color-bg);
+  color: var(--rs-color-muted);
+  font-size: 11px;
+  font-weight: 600;
+  cursor: pointer;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.scope-btn:hover:not(:disabled) {
+  background: var(--rs-color-bg-tint);
+  color: var(--rs-color-text);
+}
+
+.scope-btn.is-active {
+  border-color: var(--rs-color-primary);
+  background: var(--rs-color-bg-tint);
+  color: var(--rs-color-primary-dark);
+}
+
+.scope-btn:disabled {
+  opacity: 0.38;
+  cursor: not-allowed;
+}
+
+.action-workspace {
+  margin-top: 4px;
+}
+
+.scope-note {
+  margin: 6px 0 2px 0;
+  font-size: 12px;
+  color: var(--rs-color-muted);
+}

--- a/src/taskpane/taskpane.html
+++ b/src/taskpane/taskpane.html
@@ -40,51 +40,115 @@
       </section>
 
       <section class="action-panel action-panel-sticky">
-        <div class="action-panel-header">
-          <h3>Расчёт значимости</h3>
+        <!-- Action tabs: Run | Clear | Check | Content -->
+        <div class="action-tabs" role="tablist" id="action-tabs">
+          <button class="action-tab is-active" data-action="run" role="tab" aria-selected="true">Запуск</button>
+          <button class="action-tab" data-action="clear" role="tab" aria-selected="false">Очистка</button>
+          <button class="action-tab action-tab--readonly" data-action="check" role="tab" aria-selected="false">Проверка</button>
+          <button class="action-tab" data-action="content" role="tab" aria-selected="false">Оглавление</button>
         </div>
 
-        <div class="action-buttons-row">
-          <button id="calculate-significance" class="primary-action-button">Запустить</button>
-          <button id="clear-significance" class="secondary-action-button">
-            Очистить значимости
-          </button>
+        <!-- Scope selector: Current table | Current sheet | Whole workbook -->
+        <div class="scope-selector" role="group" aria-label="Область действия" id="scope-selector">
+          <button class="scope-btn is-active" data-scope="current_table">Текущая таблица</button>
+          <button class="scope-btn" data-scope="current_sheet">Текущий лист</button>
+          <button class="scope-btn" data-scope="whole_workbook">Вся книга</button>
         </div>
 
-        <div class="check-buttons-row">
-          <button id="check-table" class="check-action-button">Проверить таблицу</button>
-          <button id="find-tables" class="check-action-button">Найти таблицы</button>
+        <!-- Workspaces: one shown at a time based on action + scope -->
+
+        <div class="action-workspace" data-workspace="run-current_table">
+          <div class="action-buttons-row">
+            <button id="calculate-significance" class="primary-action-button">Запустить</button>
+          </div>
         </div>
-        <div class="check-buttons-row">
-          <button id="run-all-tables" class="check-action-button">Запустить по найденным таблицам</button>
+
+        <div class="action-workspace" data-workspace="run-current_sheet" style="display:none">
+          <div class="check-buttons-row">
+            <button id="run-sheet-tables" class="check-action-button">Запустить по листу</button>
+          </div>
         </div>
-        <div class="inventory-backlink-row">
+
+        <div class="action-workspace" data-workspace="run-whole_workbook" style="display:none">
+          <div class="check-buttons-row">
+            <button id="run-all-tables" class="check-action-button">Запустить по всей книге</button>
+          </div>
+        </div>
+
+        <div class="action-workspace" data-workspace="clear-current_table" style="display:none">
+          <div class="action-buttons-row">
+            <button id="clear-significance" class="secondary-action-button">Очистить значимости</button>
+          </div>
+        </div>
+
+        <div class="action-workspace" data-workspace="clear-current_sheet" style="display:none">
+          <div class="check-buttons-row">
+            <button id="clear-sheet-tables" class="check-action-button">Очистить по листу</button>
+          </div>
+        </div>
+
+        <div class="action-workspace" data-workspace="clear-whole_workbook" style="display:none">
+          <div class="check-buttons-row">
+            <button id="clear-all-tables" class="check-action-button">Очистить по книге</button>
+          </div>
+        </div>
+
+        <div class="action-workspace" data-workspace="check-current_table" style="display:none">
+          <div class="check-buttons-row">
+            <button id="check-table" class="check-action-button">Проверить таблицу</button>
+          </div>
+        </div>
+
+        <div class="action-workspace" data-workspace="check-current_sheet" style="display:none">
+          <div class="check-buttons-row">
+            <button id="check-sheet-tables" class="check-action-button">Проверить лист</button>
+          </div>
+        </div>
+
+        <div class="action-workspace" data-workspace="check-whole_workbook" style="display:none">
+          <div class="check-buttons-row">
+            <button id="find-tables" class="check-action-button">Найти таблицы</button>
+          </div>
+        </div>
+
+        <div class="action-workspace" data-workspace="content-current_table" style="display:none">
+          <p class="scope-note">Оглавление доступно только для всей книги.</p>
+        </div>
+
+        <div class="action-workspace" data-workspace="content-current_sheet" style="display:none">
+          <p class="scope-note">Оглавление доступно только для всей книги.</p>
+        </div>
+
+        <div class="action-workspace" data-workspace="content-whole_workbook" style="display:none">
+          <div class="check-buttons-row">
+            <button id="content-find-tables" class="check-action-button">Создать оглавление</button>
+          </div>
+        </div>
+
+        <!-- Shared run controls: shown for Run + current_sheet and Run + whole_workbook -->
+        <div id="run-report-control" class="inventory-backlink-row" style="display:none">
           <label class="inline-checkbox-label" for="run-add-report">
             <input type="checkbox" id="run-add-report" />
             <span>Добавить диагностический лист</span>
           </label>
         </div>
-        <div class="check-buttons-row">
-          <button id="clear-all-tables" class="check-action-button">Очистить по найденным таблицам</button>
-        </div>
-        <div class="check-buttons-row">
-          <button id="run-sheet-tables" class="check-action-button">Лист: Запустить</button>
-          <button id="clear-sheet-tables" class="check-action-button">Лист: Очистить</button>
-          <button id="check-sheet-tables" class="check-action-button">Лист: Проверить</button>
-        </div>
-        <div class="inventory-mode-row">
-          <label for="content-output-mode">Формат оглавления</label>
-          <select id="content-output-mode" class="inventory-mode-select">
-            <option value="minimal-check">С минимальной проверкой</option>
-            <option value="client">Для клиента</option>
-            <option value="full-check">С полной проверкой</option>
-          </select>
-        </div>
-        <div class="inventory-backlink-row">
-          <label class="inline-checkbox-label" for="content-add-backlinks">
-            <input type="checkbox" id="content-add-backlinks" />
-            <span>Ставить обратные ссылки</span>
-          </label>
+
+        <!-- Shared inventory controls: shown for Check/Content + whole_workbook -->
+        <div id="inventory-shared-controls" style="display:none">
+          <div class="inventory-mode-row">
+            <label for="content-output-mode">Формат оглавления</label>
+            <select id="content-output-mode" class="inventory-mode-select">
+              <option value="minimal-check">С минимальной проверкой</option>
+              <option value="client">Для клиента</option>
+              <option value="full-check">С полной проверкой</option>
+            </select>
+          </div>
+          <div class="inventory-backlink-row">
+            <label class="inline-checkbox-label" for="content-add-backlinks">
+              <input type="checkbox" id="content-add-backlinks" />
+              <span>Ставить обратные ссылки</span>
+            </label>
+          </div>
         </div>
       </section>
 

--- a/src/taskpane/taskpane.js
+++ b/src/taskpane/taskpane.js
@@ -440,23 +440,22 @@ function updateActionScopeShell(action, scope) {
     tab.setAttribute("aria-selected", active ? "true" : "false");
   });
 
-  // Content action is workbook-only: disable other scope buttons
+  // Content action is workbook-only: disable non-workbook scope buttons so the
+  // user can see they are unavailable, but do NOT coerce the selected scope —
+  // the content-current_table / content-current_sheet workspaces show an
+  // explanatory note for whichever scope the user currently has selected.
   const contentSelected = action === "content";
   document.querySelectorAll(".scope-btn").forEach((btn) => {
     btn.disabled = contentSelected && btn.dataset.scope !== "whole_workbook";
   });
 
-  // Force whole_workbook effective scope when content is selected
-  const effectiveScope =
-    contentSelected && scope !== "whole_workbook" ? "whole_workbook" : scope;
-
-  // Update scope button active states
+  // Update scope button active states using the actual scope (no coercion)
   document.querySelectorAll(".scope-btn").forEach((btn) => {
-    btn.classList.toggle("is-active", btn.dataset.scope === effectiveScope);
+    btn.classList.toggle("is-active", btn.dataset.scope === scope);
   });
 
   // Show the matching workspace, hide all others
-  const workspaceKey = `${action}-${effectiveScope}`;
+  const workspaceKey = `${action}-${scope}`;
   document.querySelectorAll(".action-workspace").forEach((ws) => {
     ws.style.display = ws.dataset.workspace === workspaceKey ? "" : "none";
   });
@@ -465,14 +464,14 @@ function updateActionScopeShell(action, scope) {
   const runReportControl = document.getElementById("run-report-control");
   if (runReportControl) {
     runReportControl.style.display =
-      action === "run" && effectiveScope !== "current_table" ? "" : "none";
+      action === "run" && scope !== "current_table" ? "" : "none";
   }
 
   // Show shared inventory controls for Check/Content + whole_workbook
   const inventoryControls = document.getElementById("inventory-shared-controls");
   if (inventoryControls) {
     inventoryControls.style.display =
-      (action === "check" || action === "content") && effectiveScope === "whole_workbook"
+      (action === "check" || action === "content") && scope === "whole_workbook"
         ? ""
         : "none";
   }
@@ -489,9 +488,6 @@ function initActionScopeShell() {
       const action = tab.dataset.action;
       if (action === _currentAction) return;
       _currentAction = action;
-      if (action === "content" && _currentScope !== "whole_workbook") {
-        _currentScope = "whole_workbook";
-      }
       updateActionScopeShell(_currentAction, _currentScope);
     });
   }

--- a/src/taskpane/taskpane.js
+++ b/src/taskpane/taskpane.js
@@ -417,9 +417,100 @@ Office.onReady((info) => {
   if (checkSheetTablesButton) {
     checkSheetTablesButton.addEventListener("click", runCurrentSheetCheck);
   }
+
+  const contentFindTablesButton = document.getElementById("content-find-tables");
+
+  if (contentFindTablesButton) {
+    contentFindTablesButton.addEventListener("click", runTableInventory);
+  }
+
+  initActionScopeShell();
 });
 
+// ─── Action + Scope shell (issue #167 PR1) ───────────────────────────────────
 
+let _currentAction = "run";
+let _currentScope = "current_table";
+
+function updateActionScopeShell(action, scope) {
+  // Update action tab active states
+  document.querySelectorAll(".action-tab").forEach((tab) => {
+    const active = tab.dataset.action === action;
+    tab.classList.toggle("is-active", active);
+    tab.setAttribute("aria-selected", active ? "true" : "false");
+  });
+
+  // Content action is workbook-only: disable other scope buttons
+  const contentSelected = action === "content";
+  document.querySelectorAll(".scope-btn").forEach((btn) => {
+    btn.disabled = contentSelected && btn.dataset.scope !== "whole_workbook";
+  });
+
+  // Force whole_workbook effective scope when content is selected
+  const effectiveScope =
+    contentSelected && scope !== "whole_workbook" ? "whole_workbook" : scope;
+
+  // Update scope button active states
+  document.querySelectorAll(".scope-btn").forEach((btn) => {
+    btn.classList.toggle("is-active", btn.dataset.scope === effectiveScope);
+  });
+
+  // Show the matching workspace, hide all others
+  const workspaceKey = `${action}-${effectiveScope}`;
+  document.querySelectorAll(".action-workspace").forEach((ws) => {
+    ws.style.display = ws.dataset.workspace === workspaceKey ? "" : "none";
+  });
+
+  // Show run-add-report for Run + current_sheet / whole_workbook
+  const runReportControl = document.getElementById("run-report-control");
+  if (runReportControl) {
+    runReportControl.style.display =
+      action === "run" && effectiveScope !== "current_table" ? "" : "none";
+  }
+
+  // Show shared inventory controls for Check/Content + whole_workbook
+  const inventoryControls = document.getElementById("inventory-shared-controls");
+  if (inventoryControls) {
+    inventoryControls.style.display =
+      (action === "check" || action === "content") && effectiveScope === "whole_workbook"
+        ? ""
+        : "none";
+  }
+}
+
+function initActionScopeShell() {
+  const tabsContainer = document.getElementById("action-tabs");
+  const scopeContainer = document.getElementById("scope-selector");
+
+  if (tabsContainer) {
+    tabsContainer.addEventListener("click", (e) => {
+      const tab = e.target.closest("[data-action]");
+      if (!tab) return;
+      const action = tab.dataset.action;
+      if (action === _currentAction) return;
+      _currentAction = action;
+      if (action === "content" && _currentScope !== "whole_workbook") {
+        _currentScope = "whole_workbook";
+      }
+      updateActionScopeShell(_currentAction, _currentScope);
+    });
+  }
+
+  if (scopeContainer) {
+    scopeContainer.addEventListener("click", (e) => {
+      const btn = e.target.closest("[data-scope]");
+      if (!btn || btn.disabled) return;
+      const scope = btn.dataset.scope;
+      if (scope === _currentScope) return;
+      _currentScope = scope;
+      updateActionScopeShell(_currentAction, _currentScope);
+    });
+  }
+
+  updateActionScopeShell(_currentAction, _currentScope);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
 
 /**
  * Reads selected Excel range, detects metric blocks, calculates pairwise significance,


### PR DESCRIPTION
## Summary

- Adds four top-level action tabs: **Run**, **Clear**, **Check**, **Content**
- Adds a shared three-way scope selector: **Текущая таблица / Текущий лист / Вся книга**
- Implements workspace switching: exactly one `data-workspace` div is shown at a time based on `action + scope`
- Wires all existing handlers into the new shell (no new behavior introduced)
- Content action is workbook-only for MVP: scope buttons for Текущая таблица and Текущий лист are visually disabled when Content is selected; switching to Content keeps the user's previously selected scope visible and shows an explanatory note in the workspace rather than silently coercing to Whole workbook
- Shared controls (`run-add-report`, `content-output-mode`, `content-add-backlinks`) are shown/hidden by the shell without moving them to separate elements — all existing `getElementById` reads in handlers continue to work unchanged

Part of #167 (PR1 of 5 per recommended implementation sequence).

## Files changed

| File | Change |
|------|--------|
| `src/taskpane/taskpane.html` | Replace flat button panel with action tabs + scope selector + 12 workspace divs + shared control groups |
| `src/taskpane/taskpane.css` | Add styles for `.action-tabs`, `.action-tab`, `.scope-selector`, `.scope-btn`, `.action-workspace`, `.scope-note` |
| `src/taskpane/taskpane.js` | Add `initActionScopeShell()` and `updateActionScopeShell()`, wire `content-find-tables` button to `runTableInventory`, call `initActionScopeShell()` from `Office.onReady` |

## Technical debt

- Content+whole_workbook re-uses the same `runTableInventory` function as Check+whole_workbook; both read `content-output-mode` and `content-add-backlinks` from the shared `inventory-shared-controls` div. A future PR can split these into action-specific controls.
- `clear-significance` retains its `secondary-action-button` style in the Clear workspace; visual polish is deferred to PR5.
- `_currentAction` and `_currentScope` are module-level variables (no persistence); tab state resets on taskpane close/reopen.

## Test / build result

- `npm test`: 217/217 pass, 0 fail
- `npm run build`: compiled with 3 pre-existing size warnings (no new warnings)
- `git diff --check`: clean

## Assumptions / limitations

- "Current table" preserves selected-range behavior as required (no active-cell resolver added).
- No behavior changes to Run, Clear, Check, or Content handlers.
- The Settings panel below the action panel is unchanged.
- No icon system integration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)