### PR TITLE
Split advanced controls into Settings and Design sections

### DIFF
--- a/src/taskpane/taskpane.html
+++ b/src/taskpane/taskpane.html
@@ -167,6 +167,7 @@
         <pre id="inventory-result"></pre>
       </section>
 
+      <!-- Settings section (statistical / processing / detection behavior) -->
       <section class="settings-panel">
         <button type="button" id="settings-toggle" class="settings-toggle">
           <span>Настройки</span>
@@ -204,12 +205,6 @@
             </select>
           </div>
 
-          <div class="settings-group">
-            <label>
-              <input type="checkbox" id="round-cell-values" />
-              Округлять значения в ячейках
-            </label>
-          </div>
           <div class="settings-group">
             <label>
               <input type="checkbox" id="compare-with-previous-column" />
@@ -282,20 +277,6 @@
           </div>
 
           <div class="settings-group">
-            <h4>Заливки</h4>
-            <label for="significant-fill-color">Обычная значимость</label>
-            <input type="color" id="significant-fill-color" value="#E2F0D9" />
-
-            <label for="lower-than-total-fill-color">Заливка &lt; Тотал</label>
-            <input type="color" id="lower-than-total-fill-color" value="#FCE4D6" />
-
-            <label
-              ><input type="checkbox" id="fill-only-total-comparisons" /> Заливка только для
-              Тотала</label
-            >
-          </div>
-
-          <div class="settings-group">
             <h4>Маленькие базы</h4>
             <label
               ><input type="checkbox" id="exclude-small-bases" /> Не сравнивать маленькие
@@ -306,9 +287,6 @@
               <label for="small-base-threshold">База &lt;</label>
               <input type="number" id="small-base-threshold" value="50" min="0" step="1" />
             </div>
-
-            <label for="small-base-fill-color">Заливка маленькой базы</label>
-            <input type="color" id="small-base-fill-color" value="#D0D0D0" />
           </div>
 
           <div class="settings-group">
@@ -330,6 +308,42 @@
             id="help-link"
             >Справка об использовании</a
           >
+        </div>
+      </section>
+
+      <!-- Design section (visual output / fills / presentation behavior) -->
+      <section class="settings-panel">
+        <button type="button" id="design-toggle" class="settings-toggle">
+          <span>Дизайн</span>
+          <span id="design-toggle-icon">▾</span>
+        </button>
+
+        <div id="design-content" class="settings-content">
+          <div class="settings-group">
+            <label>
+              <input type="checkbox" id="round-cell-values" />
+              Округлять значения в ячейках
+            </label>
+          </div>
+
+          <div class="settings-group">
+            <h4>Заливки</h4>
+            <label for="significant-fill-color">Обычная значимость</label>
+            <input type="color" id="significant-fill-color" value="#E2F0D9" />
+
+            <label for="lower-than-total-fill-color">Заливка &lt; Тотал</label>
+            <input type="color" id="lower-than-total-fill-color" value="#FCE4D6" />
+
+            <label
+              ><input type="checkbox" id="fill-only-total-comparisons" /> Заливка только для
+              Тотала</label
+            >
+          </div>
+
+          <div class="settings-group">
+            <label for="small-base-fill-color">Заливка маленькой базы</label>
+            <input type="color" id="small-base-fill-color" value="#D0D0D0" />
+          </div>
         </div>
       </section>
     </main>

--- a/src/taskpane/taskpane.js
+++ b/src/taskpane/taskpane.js
@@ -4448,6 +4448,7 @@ function initializeSettingsPanel() {
   initializePreviousColumnComparisonSettings();
   initializeSettingsResetButton();
   initializeSettingsToggle();
+  initializeDesignToggle();
   initializeBannerStructureSettings();
 
   const helpLink = document.getElementById("help-link");
@@ -4563,6 +4564,22 @@ function initializeSettingsToggle() {
     const isCollapsed = settingsContent.classList.toggle("collapsed");
 
     settingsToggleIcon.textContent = isCollapsed ? "▸" : "▾";
+  });
+}
+
+function initializeDesignToggle() {
+  const designToggle = document.getElementById("design-toggle");
+  const designContent = document.getElementById("design-content");
+  const designToggleIcon = document.getElementById("design-toggle-icon");
+
+  if (!designToggle || !designContent || !designToggleIcon) {
+    return;
+  }
+
+  designToggle.addEventListener("click", () => {
+    const isCollapsed = designContent.classList.toggle("collapsed");
+
+    designToggleIcon.textContent = isCollapsed ? "▸" : "▾";
   });
 }
 


### PR DESCRIPTION
## Summary

- Adds a second collapsible **Design** section below the existing **Settings** section in the taskpane
- Moves fill-related controls (`significant-fill-color`, `lower-than-total-fill-color`, `fill-only-total-comparisons`, `small-base-fill-color`) and `round-cell-values` into Design
- Settings retains all statistical / processing / detection / comparison controls, small-base threshold, and the storage/reset row
- Adds `initializeDesignToggle()` in `taskpane.js` (mirrors `initializeSettingsToggle()`), wired into `initializeSettingsPanel()`

## What is unchanged

- All control `id` attributes preserved — existing handlers require no changes
- Default values and `localStorage` persistence untouched
- Status-message logic untouched
- Action/scope shell untouched
- `excel-writer.js`, `significance.js`, and all core modules untouched

## Boundary controls

- `write-banner-letters` kept in Settings (Banner sub-group) — boundary, safest current location
- `compare-with-previous-column` + nested `apply-previous-column-fill` kept together in Settings — boundary, kept intact to avoid splitting a tightly coupled pair

## Test / build result

- `npm test`: 217/217 pass
- `npm run build`: compiled successfully (3 pre-existing bundle-size warnings, no new warnings or errors)
- `git diff --check`: clean

## Closes / relates to

Issue #167 — PR2 slice as described in the latest issue comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)