### PR TITLE
Consolidate Check into read-only workspace across scopes

### DIFF
--- a/src/taskpane/taskpane.css
+++ b/src/taskpane/taskpane.css
@@ -612,3 +612,10 @@ b {
   font-size: 12px;
   color: var(--rs-color-muted);
 }
+
+.check-workspace-hint {
+  margin: 4px 0 2px 0;
+  font-size: 11px;
+  color: var(--rs-color-muted);
+  line-height: 1.35;
+}

--- a/src/taskpane/taskpane.html
+++ b/src/taskpane/taskpane.html
@@ -97,18 +97,21 @@
           <div class="check-buttons-row">
             <button id="check-table" class="check-action-button">Проверить таблицу</button>
           </div>
+          <p class="check-workspace-hint">Только чтение · анализирует выделенный диапазон. В книгу ничего не записывается.</p>
         </div>
 
         <div class="action-workspace" data-workspace="check-current_sheet" style="display:none">
           <div class="check-buttons-row">
             <button id="check-sheet-tables" class="check-action-button">Проверить лист</button>
           </div>
+          <p class="check-workspace-hint">Только чтение · сканирует таблицы на текущем листе. В книгу ничего не записывается.</p>
         </div>
 
         <div class="action-workspace" data-workspace="check-whole_workbook" style="display:none">
           <div class="check-buttons-row">
             <button id="find-tables" class="check-action-button">Найти таблицы</button>
           </div>
+          <p class="check-workspace-hint">Сканирует все таблицы в книге. Создаёт лист «Content» — данные таблиц не изменяются.</p>
         </div>
 
         <div class="action-workspace" data-workspace="content-current_table" style="display:none">
@@ -158,7 +161,7 @@
       </section>
 
       <section id="check-panel" class="status-panel check-panel" style="display: none">
-        <h4>Проверка таблицы</h4>
+        <h4>Проверка</h4>
         <pre id="check-result"></pre>
       </section>
 


### PR DESCRIPTION
Part of #167 (PR3 slice).

## Summary

- Add per-scope helper text to each Check workspace explaining what it does and whether it writes to the workbook
- Generalize the `check-panel` heading from "Проверка таблицы" to "Проверка" — the panel is shared between table-level and sheet-level check handlers
- Add `.check-workspace-hint` CSS class for the hint text

## Scope mapping preserved

| Scope | Button | Handler |
|---|---|---|
| Current table | Проверить таблицу | `runCheckTable` |
| Current sheet | Проверить лист | `runCurrentSheetCheck` |
| Whole workbook | Найти таблицы | `runTableInventory` |

## Hint text per scope

- **Current table**: "Только чтение · анализирует выделенный диапазон. В книгу ничего не записывается."
- **Current sheet**: "Только чтение · сканирует таблицы на текущем листе. В книгу ничего не записывается."
- **Whole workbook**: "Сканирует все таблицы в книге. Создаёт лист «Content» — данные таблиц не изменяются."

The workbook-level hint is intentionally accurate: `runTableInventory` does create a Content sheet, so claiming "nothing written" would be misleading. It clarifies that table data is not changed.

## Files changed

- `src/taskpane/taskpane.html` — Check workspace helper text + panel heading
- `src/taskpane/taskpane.css` — `.check-workspace-hint` rule

## Not changed

- All Check/scan/check handlers
- Statistical formulas
- Run/Clear/Content behavior
- excel-writer.js, significance.js
- Action/scope switching logic
- Output modes / backlinks controls (#180)

## Test / build result

- `npm test`: 217/217 pass
- `npm run build`: compiled with 3 pre-existing size warnings (unchanged from main)
- `git diff --check`: clean

## Technical debt

No new debt. Output mode and backlink hardening for Check+workbook scope deferred to #180 per issue guidance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)