### PR TITLE
#167 PR4 — Move Content / Оглавление into its own workbook-level workspace

### DIFF
--- a/src/taskpane/taskpane.html
+++ b/src/taskpane/taskpane.html
@@ -115,29 +115,18 @@
         </div>
 
         <div class="action-workspace" data-workspace="content-current_table" style="display:none">
-          <p class="scope-note">Оглавление доступно только для всей книги.</p>
+          <p class="scope-note">Оглавление работает только на уровне всей книги. Переключитесь на «Вся книга».</p>
         </div>
 
         <div class="action-workspace" data-workspace="content-current_sheet" style="display:none">
-          <p class="scope-note">Оглавление доступно только для всей книги.</p>
+          <p class="scope-note">Оглавление работает только на уровне всей книги. Переключитесь на «Вся книга».</p>
         </div>
 
         <div class="action-workspace" data-workspace="content-whole_workbook" style="display:none">
           <div class="check-buttons-row">
             <button id="content-find-tables" class="check-action-button">Создать оглавление</button>
           </div>
-        </div>
-
-        <!-- Shared run controls: shown for Run + current_sheet and Run + whole_workbook -->
-        <div id="run-report-control" class="inventory-backlink-row" style="display:none">
-          <label class="inline-checkbox-label" for="run-add-report">
-            <input type="checkbox" id="run-add-report" />
-            <span>Добавить диагностический лист</span>
-          </label>
-        </div>
-
-        <!-- Shared inventory controls: shown for Check/Content + whole_workbook -->
-        <div id="inventory-shared-controls" style="display:none">
+          <p class="check-workspace-hint">Сканирует все листы книги и создаёт или обновляет лист «Content» со списком таблиц. Данные таблиц не изменяются.</p>
           <div class="inventory-mode-row">
             <label for="content-output-mode">Формат оглавления</label>
             <select id="content-output-mode" class="inventory-mode-select">
@@ -152,6 +141,14 @@
               <span>Ставить обратные ссылки</span>
             </label>
           </div>
+        </div>
+
+        <!-- Shared run controls: shown for Run + current_sheet and Run + whole_workbook -->
+        <div id="run-report-control" class="inventory-backlink-row" style="display:none">
+          <label class="inline-checkbox-label" for="run-add-report">
+            <input type="checkbox" id="run-add-report" />
+            <span>Добавить диагностический лист</span>
+          </label>
         </div>
       </section>
 

--- a/src/taskpane/taskpane.js
+++ b/src/taskpane/taskpane.js
@@ -467,14 +467,6 @@ function updateActionScopeShell(action, scope) {
       action === "run" && scope !== "current_table" ? "" : "none";
   }
 
-  // Show shared inventory controls for Check/Content + whole_workbook
-  const inventoryControls = document.getElementById("inventory-shared-controls");
-  if (inventoryControls) {
-    inventoryControls.style.display =
-      (action === "check" || action === "content") && scope === "whole_workbook"
-        ? ""
-        : "none";
-  }
 }
 
 function initActionScopeShell() {


### PR DESCRIPTION
## Summary

- Embeds output-mode and backlinks controls directly inside the `content-whole_workbook` workspace (previously rendered via a shared `inventory-shared-controls` div shown for both Check and Content whole-workbook actions).
- Removes the `inventory-shared-controls` div from the HTML and the corresponding visibility toggle from `updateActionScopeShell` in `taskpane.js`.
- Adds a `check-workspace-hint` to `content-whole_workbook` that describes the operation: scans all sheets, creates or updates the Content sheet, does not modify table data.
- Improves disabled-state text for `content-current_table` and `content-current_sheet` to make the workbook-level restriction explicit and guide the user toward switching to «Вся книга».

## Out of scope (deferred to #180)

- Generated-sheet wording.
- Output mode behavior changes.
- Backlink behavior / duplicate backlink prevention.
- Content placement fallback.
- Broader report/status wording.

## Preserved

- `runTableInventory` handler unchanged; `content-find-tables` still wires to it.
- Output mode and backlinks element IDs unchanged (`content-output-mode`, `content-add-backlinks`); `readContentOutputModeFromPanel` and `readBacklinkSettingFromPanel` read by ID and remain correct.
- `find-tables` (Check whole-workbook) still calls `runTableInventory` and reads settings from the same element IDs (controls remain in DOM inside the content workspace).
- Action/scope shell behavior, scope-button disabled states, and workspace switching logic unchanged.
- No changes to significance formulas, excel-writer, Check/Run/Clear handlers, or generated-sheet logic.

## Test / build result

- `npm test`: 217 pass, 0 fail
- `npm run build`: compiled with 3 pre-existing size warnings, no errors
- `git diff --check`: clean

## Files changed

| File | Change |
|---|---|
| `src/taskpane/taskpane.html` | Embed inventory controls in content-whole_workbook; improve disabled-state text; remove inventory-shared-controls div |
| `src/taskpane/taskpane.js` | Remove inventory-shared-controls visibility block from updateActionScopeShell |

## Assumptions / limitations

- The `find-tables` button (Check + whole_workbook) will continue reading output mode and backlink settings from the DOM even though those controls are now visually part of the Content workspace. This is intentional for this PR; any behavioral separation between Check and Content inventory runs belongs to #180.

🤖 Generated with [Claude Code](https://claude.com/claude-code)