### PR TITLE
Polish action/scope UI wording (#167 PR5)

### DIFF
--- a/src/taskpane/taskpane.html
+++ b/src/taskpane/taskpane.html
@@ -42,7 +42,7 @@
       <section class="action-panel action-panel-sticky">
         <!-- Action tabs: Run | Clear | Check | Content -->
         <div class="action-tabs" role="tablist" id="action-tabs">
-          <button class="action-tab is-active" data-action="run" role="tab" aria-selected="true">Запуск</button>
+          <button class="action-tab is-active" data-action="run" role="tab" aria-selected="true">Расчёт</button>
           <button class="action-tab" data-action="clear" role="tab" aria-selected="false">Очистка</button>
           <button class="action-tab action-tab--readonly" data-action="check" role="tab" aria-selected="false">Проверка</button>
           <button class="action-tab" data-action="content" role="tab" aria-selected="false">Оглавление</button>
@@ -59,19 +59,19 @@
 
         <div class="action-workspace" data-workspace="run-current_table">
           <div class="action-buttons-row">
-            <button id="calculate-significance" class="primary-action-button">Запустить</button>
+            <button id="calculate-significance" class="primary-action-button">Рассчитать</button>
           </div>
         </div>
 
         <div class="action-workspace" data-workspace="run-current_sheet" style="display:none">
           <div class="check-buttons-row">
-            <button id="run-sheet-tables" class="check-action-button">Запустить по листу</button>
+            <button id="run-sheet-tables" class="check-action-button">Рассчитать по листу</button>
           </div>
         </div>
 
         <div class="action-workspace" data-workspace="run-whole_workbook" style="display:none">
           <div class="check-buttons-row">
-            <button id="run-all-tables" class="check-action-button">Запустить по всей книге</button>
+            <button id="run-all-tables" class="check-action-button">Рассчитать по всей книге</button>
           </div>
         </div>
 
@@ -163,7 +163,7 @@
       </section>
 
       <section id="inventory-panel" class="status-panel check-panel" style="display: none">
-        <h4>Инвентарь таблиц</h4>
+        <h4>Оглавление</h4>
         <pre id="inventory-result"></pre>
       </section>
 

--- a/src/taskpane/taskpane.html
+++ b/src/taskpane/taskpane.html
@@ -109,9 +109,9 @@
 
         <div class="action-workspace" data-workspace="check-whole_workbook" style="display:none">
           <div class="check-buttons-row">
-            <button id="find-tables" class="check-action-button">Найти таблицы</button>
+            <button id="find-tables" class="check-action-button">Проверить книгу</button>
           </div>
-          <p class="check-workspace-hint">Сканирует все таблицы в книге. Создаёт лист «Content» — данные таблиц не изменяются.</p>
+          <p class="check-workspace-hint">Только чтение · сканирует таблицы по всей книге. В книгу ничего не записывается.</p>
         </div>
 
         <div class="action-workspace" data-workspace="content-current_table" style="display:none">
@@ -130,8 +130,8 @@
           <div class="inventory-mode-row">
             <label for="content-output-mode">Формат оглавления</label>
             <select id="content-output-mode" class="inventory-mode-select">
-              <option value="minimal-check">С минимальной проверкой</option>
               <option value="client">Для клиента</option>
+              <option value="minimal-check">С минимальной проверкой</option>
               <option value="full-check">С полной проверкой</option>
             </select>
           </div>

--- a/src/taskpane/taskpane.js
+++ b/src/taskpane/taskpane.js
@@ -390,7 +390,7 @@ Office.onReady((info) => {
   }
 
   if (findTablesButton) {
-    findTablesButton.addEventListener("click", runTableInventory);
+    findTablesButton.addEventListener("click", runWorkbookCheck);
   }
 
   if (runAllTablesButton) {
@@ -2230,6 +2230,94 @@ async function runCurrentSheetCheck() {
   summaryLines.push(...candidateLines);
   summaryLines.push("");
   summaryLines.push("Данные не изменены.");
+
+  setCheckMessage(summaryLines.join("\n"));
+}
+
+/**
+ * Workbook-wide check: scans all sheets and reports found table candidates.
+ *
+ * Read-only — does NOT write the Content sheet or any other Excel output.
+ * Reports the workbook scan summary to the check panel so the result is
+ * clearly a check/report rather than Content generation.
+ *
+ * Content / Оглавление remains the dedicated action for creating/updating
+ * the Content sheet.
+ */
+async function runWorkbookCheck() {
+  const calculationSettings = readCalculationSettingsFromPanel();
+
+  let inventoryResults;
+  try {
+    await Excel.run(async (context) => {
+      inventoryResults = await collectWorkbookInventoryResults(context, calculationSettings);
+      normalizeBacklinkItems(inventoryResults.sheetResults, false);
+    });
+  } catch (err) {
+    setCheckMessage(`Книга — проверка: ошибка при сканировании — ${err.message || err}`);
+    return;
+  }
+
+  const { scannedSheets, sheetResults, skippedSheets } = inventoryResults;
+  const totalCandidates = sheetResults.reduce((sum, s) => sum + s.items.length, 0);
+
+  const summaryLines = [
+    `Книга — проверка: просканировано листов: ${scannedSheets}.`,
+    `Кандидатов найдено: ${totalCandidates}.`,
+  ];
+
+  for (const sheetResult of sheetResults) {
+    summaryLines.push("");
+    summaryLines.push(`Лист: ${sheetResult.sheetName}`);
+
+    for (let i = 0; i < sheetResult.items.length; i++) {
+      const item = sheetResult.items[i];
+      const rangeAddr = item.resolvedRangeAddress || item.rangeAddress || null;
+      const displayTitle =
+        item.resolvedTitle ||
+        (item.title && !isGeneratedBacklinkRow(item.title) ? item.title : null);
+      const header = displayTitle
+        ? `  ${i + 1}. ${displayTitle} — ${rangeAddr || "?"}`
+        : `  ${i + 1}. ${rangeAddr || "?"}`;
+      summaryLines.push(header);
+
+      if (item.candidateStatus === "available") {
+        const warnParts = [];
+        if (item.criticalCount > 0) warnParts.push(`Критических: ${item.criticalCount}`);
+        if (item.warningsCount > 0) warnParts.push(`Предупреждений: ${item.warningsCount}`);
+        const warnStr = warnParts.length > 0 ? ` ${warnParts.join(". ")}.` : "";
+        summaryLines.push(`     Доступен.${warnStr}`);
+      } else if (item.candidateStatus === "uncertain") {
+        summaryLines.push("     Неопределён — граница данных неоднозначна.");
+      } else if (item.candidateStatus === "rejected") {
+        summaryLines.push("     Отклонён — не опознан как таблица ResearchSignal.");
+      } else {
+        summaryLines.push(`     Пропущено — статус «${item.candidateStatus || "unknown"}».`);
+      }
+
+      if (item.previewSummary) summaryLines.push(`     ${item.previewSummary}.`);
+      if (item.candidateNotes && item.candidateNotes.length > 0) {
+        summaryLines.push(`     [${item.candidateNotes.join("; ")}]`);
+      }
+    }
+  }
+
+  if (skippedSheets && skippedSheets.length > 0) {
+    summaryLines.push("");
+    summaryLines.push("Пропущенные листы:");
+    for (const sheet of skippedSheets) {
+      if (sheet.reason === "empty") {
+        summaryLines.push(`- ${sheet.sheetName}: пустой лист.`);
+      } else {
+        summaryLines.push(
+          `- ${sheet.sheetName}: слишком большой для сканирования (${sheet.rowCount} стр. × ${sheet.columnCount} кол.).`
+        );
+      }
+    }
+  }
+
+  summaryLines.push("");
+  summaryLines.push("Данные не изменены. Для детальной проверки используйте «Проверка → Текущий лист».");
 
   setCheckMessage(summaryLines.join("\n"));
 }


### PR DESCRIPTION
Part of #167. Does not close #167 — smoke testing still needed. #180 remains open for deeper Content hardening.

## Summary

**Commit 1 — wording polish**
- Rename Run action tab: **Запуск → Расчёт**
- Update all three Run workspace button labels: **Рассчитать** / **Рассчитать по листу** / **Рассчитать по всей книге**
- Rename inventory result panel heading: **Инвентарь таблиц → Оглавление**

Other tab labels (Очистка, Проверка, Оглавление) and scope selector labels (Текущая таблица, Текущий лист, Вся книга) were already correct.

**Commit 2 — Check vs Content separation**
- Add `runWorkbookCheck`: read-only workbook scan that writes to the check panel without creating the Content sheet; shows per-sheet/table candidate status and a "data not changed" footer
- Wire `find-tables` button to `runWorkbookCheck` instead of `runTableInventory`
- `check-whole_workbook` workspace: button "Найти таблицы" → "Проверить книгу"; hint updated to read-only (no Content-sheet mention)
- `content-whole_workbook` output mode order fixed: **Для клиента** is now first/default → С минимальной проверкой → С полной проверкой

Content + Whole workbook remains the only place that creates/updates the Content sheet.

## Files changed

- `src/taskpane/taskpane.html` — label and hint strings; output mode order
- `src/taskpane/taskpane.js` — new `runWorkbookCheck` function; button wiring

## Test / build

- `npm test` — 217/217 pass
- `npm run build` — clean (3 pre-existing bundle-size warnings, no errors)
- `git diff --check` — clean

## Assumptions / limitations

- `runWorkbookCheck` is a scan-only report (no per-table `checkTableForRange` calls) to keep it fast for large workbooks. The current-sheet Check path still runs the deep check per table. Users who need deep per-table diagnostics on a specific sheet can switch to Check + Текущий лист.
- No icon system integration.
- #180 (Content hardening: output modes, links/backlinks, duplicate backlink prevention, placement fallback) remains open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)