### PR TITLE
Harden Content links and backlinks on repeated generation (issue #180 PR2)

### DIFF
--- a/src/core/table-inventory-scanner.js
+++ b/src/core/table-inventory-scanner.js
@@ -641,13 +641,29 @@ export function scanWorksheetForTables({ values, usedRangeRowOffset, usedRangeCo
     const band = trimBandColumns(values, rawBand);
     if (!band) continue;
 
+    // If the first row of the band is a generated backlink marker, exclude it.
+    // Backlink rows are inserted by Content generation above detected tables and
+    // must not be treated as title rows or body rows of the candidate table.
+    // When settings.backlinkMarker is provided and matches the first content cell,
+    // the active band starts one row later so rangeAddress points to the real table.
+    // normalizeBacklinkItems detects the row above as "above-range" and updates
+    // the backlink in-place on repeated Content generation (no duplicate rows).
+    let activeBand = band;
+    if (settings?.backlinkMarker) {
+      const firstCell = (values[band.localStartRow] || [])[band.localTrimmedFirstCol];
+      if (String(firstCell ?? "").trim() === settings.backlinkMarker) {
+        activeBand = { ...band, localStartRow: band.localStartRow + 1 };
+        if (activeBand.localEndRow < activeBand.localStartRow) continue;
+      }
+    }
+
     // Detect a merged-like title in the first row of the band.
-    const firstRowTitleInfo = detectFirstRowTitle(values, band);
+    const firstRowTitleInfo = detectFirstRowTitle(values, activeBand);
 
     // bodyBand is what gets passed to the model: strip the title row if one was found.
     const bodyBand = firstRowTitleInfo
-      ? { ...band, localStartRow: band.localStartRow + 1 }
-      : band;
+      ? { ...activeBand, localStartRow: activeBand.localStartRow + 1 }
+      : activeBand;
 
     // If stripping the title row left nothing to interpret, skip.
     if (bodyBand.localEndRow < bodyBand.localStartRow) continue;
@@ -661,18 +677,18 @@ export function scanWorksheetForTables({ values, usedRangeRowOffset, usedRangeCo
 
     const model = buildTablePreviewModel({ values: dataCols, leftLabelValues: labelCols, settings });
 
-    // Range address always covers the full original band (title row included).
-    const absRowStart = band.localStartRow + usedRangeRowOffset;
-    const absRowEnd = band.localEndRow + usedRangeRowOffset;
-    const absColStart = band.localTrimmedFirstCol + usedRangeColOffset;
-    const absColEnd = band.localTrimmedLastCol + usedRangeColOffset;
+    // Range address covers the active band (backlink row excluded; title row included).
+    const absRowStart = activeBand.localStartRow + usedRangeRowOffset;
+    const absRowEnd = activeBand.localEndRow + usedRangeRowOffset;
+    const absColStart = activeBand.localTrimmedFirstCol + usedRangeColOffset;
+    const absColEnd = activeBand.localTrimmedLastCol + usedRangeColOffset;
     const rangeAddress = toA1Address(absRowStart, absRowEnd, absColStart, absColEnd);
 
     // Title: first-row detection takes priority; fall back to above-band lookback.
-    const titleInfo = firstRowTitleInfo || inferTitle(values, band);
+    const titleInfo = firstRowTitleInfo || inferTitle(values, activeBand);
 
     const item = buildTableInventoryItem({
-      band,
+      band: activeBand,
       model,
       titleInfo,
       rangeAddress,

--- a/src/taskpane/taskpane.js
+++ b/src/taskpane/taskpane.js
@@ -3095,7 +3095,7 @@ async function collectWorkbookInventoryResults(context, settings) {
         usedRangeRowOffset: usedRange.rowIndex,
         usedRangeColOffset: usedRange.columnIndex,
         sheetName: worksheet.name,
-        settings,
+        settings: { ...settings, backlinkMarker: BACKLINK_MARKER },
       }),
     }))
     .filter((sheetResult) => sheetResult.items.length > 0);
@@ -3163,7 +3163,7 @@ async function collectActiveSheetInventoryResults(context, settings) {
     usedRangeRowOffset: usedRange.rowIndex,
     usedRangeColOffset: usedRange.columnIndex,
     sheetName: worksheet.name,
-    settings,
+    settings: { ...settings, backlinkMarker: BACKLINK_MARKER },
   });
 
   const sheetResults = items.length > 0

--- a/tests/core/table-inventory-scanner.test.mjs
+++ b/tests/core/table-inventory-scanner.test.mjs
@@ -992,3 +992,137 @@ describe("scanWorksheetForTables — hasProportions / hasMeans / hasNps fields",
     assert.strictEqual(item.hasNps, false, "no NPS row present");
   });
 });
+
+// ─── Issue #180 PR2: backlink row handling ────────────────────────────────────
+//
+// Backlink rows ("← Оглавление") are inserted above detected tables by Content
+// generation. The scanner must exclude them from rangeAddress so that
+// normalizeBacklinkItems can detect the "above-range" state and update the
+// backlink in-place rather than inserting a duplicate on repeated generation.
+
+describe("scanWorksheetForTables — backlink row exclusion (issue #180 PR2)", () => {
+  const BACKLINK_MARKER = "← Оглавление";
+  const SCAN_SETTINGS = { backlinkMarker: BACKLINK_MARKER };
+
+  it("band starting with backlink marker excludes it from rangeAddress", () => {
+    // Simulates the state after first Content generation with backlinks ON.
+    // The backlink row was inserted above the table; on the next scan the scanner
+    // must start the rangeAddress at the first real table row (A2, not A1).
+    const values = [
+      [BACKLINK_MARKER, null, null, null],        // row 0 (A1) — backlink
+      ["Category", "Total", "Male", "Female"],    // row 1 (A2) — banner/header
+      ["Agree", 40, 60, 50],
+      ["Disagree", 60, 40, 50],
+      ["Base", 100, 100, 100],
+    ];
+    const items = scanWorksheetForTables({ values, ...OFFSET, settings: SCAN_SETTINGS });
+    assert.ok(items.length >= 1, "expected at least one item");
+    assert.ok(
+      !items[0].rangeAddress.startsWith("A1"),
+      `rangeAddress must not include the backlink row; got ${items[0].rangeAddress}`
+    );
+    assert.ok(
+      items[0].rangeAddress.startsWith("A2"),
+      `rangeAddress must start at A2 (first table row); got ${items[0].rangeAddress}`
+    );
+    assert.strictEqual(items[0].isLikelyTable, true);
+  });
+
+  it("backlink-only band (single row) produces no item", () => {
+    const values = [
+      [BACKLINK_MARKER, null, null],
+    ];
+    const items = scanWorksheetForTables({ values, ...OFFSET, settings: SCAN_SETTINGS });
+    assert.strictEqual(items.length, 0, "single backlink row must not produce an item");
+  });
+
+  it("backlink row + minimal 2-row table produces one item starting after the backlink", () => {
+    const values = [
+      [BACKLINK_MARKER, null, null],   // row 0 (A1)
+      ["Metric", 40, 60],              // row 1 (A2)
+      ["Base", 100, 100],              // row 2 (A3)
+    ];
+    const items = scanWorksheetForTables({ values, ...OFFSET, settings: SCAN_SETTINGS });
+    assert.ok(items.length >= 1, "expected at least one item");
+    assert.ok(
+      items[0].rangeAddress.startsWith("A2"),
+      `rangeAddress must start at A2; got ${items[0].rangeAddress}`
+    );
+  });
+
+  it("second scan (backlink above, table below): rangeAddress enables above-range detection", () => {
+    // After first Content generation a backlink was inserted at row 1 (A2).
+    // On the second scan the scanner sees: empty separator, backlink, table body.
+    // rangeAddress must start at A3 (table body) so normalizeBacklinkItems
+    // checks cell A2 for the backlink ("above-range") — no new row insertion.
+    const values = [
+      [null, null, null, null],                    // row 0 (A1) — empty separator
+      [BACKLINK_MARKER, null, null, null],          // row 1 (A2) — backlink
+      ["Category", "Total", "Male", "Female"],     // row 2 (A3) — table band start
+      ["Agree", 40, 60, 50],
+      ["Base", 100, 100, 100],
+    ];
+    const items = scanWorksheetForTables({ values, ...OFFSET, settings: SCAN_SETTINGS });
+    assert.ok(items.length >= 1, "expected at least one item");
+    assert.ok(
+      items[0].rangeAddress.startsWith("A3"),
+      `rangeAddress must start at A3; got ${items[0].rangeAddress}`
+    );
+    assert.strictEqual(items[0].isLikelyTable, true);
+  });
+
+  it("backlink row at start of band followed by in-band title — title is still detected", () => {
+    // If the original table had a title as its first row (firstRowOfBand), after
+    // backlink insertion the band is: [backlink, title, data...]. The scanner
+    // skips the backlink and detects the title from the next row.
+    const values = [
+      [BACKLINK_MARKER, null, null, null],          // row 0 — backlink
+      ["Survey Title", null, null, null],           // row 1 — in-band title
+      ["Category", "Total", "Male", "Female"],
+      ["Agree", 40, 60, 50],
+      ["Base", 100, 100, 100],
+    ];
+    const items = scanWorksheetForTables({ values, ...OFFSET, settings: SCAN_SETTINGS });
+    assert.ok(items.length >= 1, "expected at least one item");
+    const item = items[0];
+    assert.ok(
+      item.rangeAddress.startsWith("A2"),
+      `rangeAddress must start at A2 (skip backlink); got ${item.rangeAddress}`
+    );
+    assert.strictEqual(item.title, "Survey Title", "in-band title must still be detected");
+    assert.strictEqual(item.titleSource, "firstRowOfBand");
+  });
+
+  it("without backlinkMarker setting, backlink-like text in first row is treated as title (no regression)", () => {
+    // Regression guard: omitting settings.backlinkMarker must keep the original
+    // behavior — the first row is included in rangeAddress and treated as a title.
+    const values = [
+      [BACKLINK_MARKER, null, null, null],
+      ["Category", "Total", "Male", "Female"],
+      ["Agree", 40, 60, 50],
+      ["Base", 100, 100, 100],
+    ];
+    const items = scanWorksheetForTables({ values, ...OFFSET });
+    assert.ok(items.length >= 1, "expected at least one item");
+    assert.ok(
+      items[0].rangeAddress.startsWith("A1"),
+      `without backlinkMarker, rangeAddress must include row 1; got ${items[0].rangeAddress}`
+    );
+  });
+
+  it("non-backlink text in first row is not skipped even when backlinkMarker is set", () => {
+    // Safety: only exact matches must be skipped, not arbitrary text.
+    const values = [
+      ["Not a backlink", null, null, null],
+      ["Category", "Total", "Male", "Female"],
+      ["Agree", 40, 60, 50],
+      ["Base", 100, 100, 100],
+    ];
+    const items = scanWorksheetForTables({ values, ...OFFSET, settings: SCAN_SETTINGS });
+    assert.ok(items.length >= 1, "expected at least one item");
+    assert.ok(
+      items[0].rangeAddress.startsWith("A1"),
+      `non-backlink first row must not be skipped; got ${items[0].rangeAddress}`
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- **Scanner excludes backlink rows** from detected band ranges when `settings.backlinkMarker` is provided. Previously the `← Оглавление` row was treated as a table title; now it is skipped before title/body detection so `rangeAddress` always points to the real table body.
- **Both scan paths pass `backlinkMarker`**: `collectWorkbookInventoryResults` and `collectActiveSheetInventoryResults` now forward `BACKLINK_MARKER` to `scanWorksheetForTables`, activating the exclusion in all Content/Check/Run/Clear flows.
- **Duplicate backlink prevention preserved**: because `rangeAddress` no longer includes the backlink row, `normalizeBacklinkItems` detects the row above as `above-range` on the second run and calls `writeOrUpdateBacklink` in update-in-place mode — no new row is inserted.

## Mechanism

First Content generation (backlinks ON):
1. Scanner detects table at `A3:C5`; backlink state `will-insert`.
2. `ensureBacklinkRows` inserts a row at A3 and writes `← Оглавление` there.
3. Content hyperlink targets `A4:C6` (resolvedRangeAddress).

Second Content generation (backlinks ON):
1. Scanner sees `← Оглавление` at A3 → skips it → `rangeAddress = A4:C6`.
2. `normalizeBacklinkItems`: row above A4 (= A3) is the backlink → `above-range`.
3. `ensureBacklinkRows`: updates backlink at A3 in-place. No duplicate row.

## Files changed

| File | Change |
|---|---|
| `src/core/table-inventory-scanner.js` | Skip backlink row at top of band when `settings.backlinkMarker` matches |
| `src/taskpane/taskpane.js` | Pass `backlinkMarker: BACKLINK_MARKER` in both scan calls |
| `tests/core/table-inventory-scanner.test.mjs` | 7 new backlink-exclusion test cases |

## Test / build result

- `npm test`: **224 pass, 0 fail** (7 new cases in the new describe block)
- `npm run build`: compiled with 0 errors (3 pre-existing size warnings)
- `git diff --check`: clean

## Smoke expectations covered

- Content generation with backlinks ON → links point to correct table ranges ✓  
- Backlinks point back to correct Content rows ✓  
- Rerun with backlinks ON → no duplicate backlink rows (above-range in-place update) ✓  
- Rerun with backlinks OFF → no new backlinks inserted (normalizeBacklinkItems skips will-insert when backlinksEnabled=false) ✓  
- Existing backlink rows not treated as table titles or bodies ✓  

## Assumptions / limitations

- The fix uses an exact-string match (`=== settings.backlinkMarker`) at the trimmed first content cell of the band's first row. If a user manually types the marker text in a data cell at the top of a band, it will be skipped — this is intentional and matches the design of the feature.
- `resolvedTitle` in `normalizeBacklinkItems` looks at most 2 rows above the table start. Titles placed 3+ rows above (with 2 blank separators) remain unresolved; this is a pre-existing limitation, not introduced here.
- No changes to statistical formulas, Run/Clear/Check behavior, generated-sheet placement, `excel-writer.js`, or `significance.js`.

Part of #180 (PR2 slice).

🤖 Generated with [Claude Code](https://claude.com/claude-code)