### PR TITLE
Harden Content sheet reuse and placement behavior (#180 PR3)

### DIFF
--- a/src/core/batch-candidate-filter.js
+++ b/src/core/batch-candidate-filter.js
@@ -31,23 +31,30 @@ export const BATCH_SKIP_REASONS = Object.freeze({
  *
  * Eligible:  candidateStatus === "available" && canRunCheckTable && has usable range address
  * Skipped:   uncertain, rejected, or missing-range candidates (with reason code)
- * Ignored:   generated Content sheet — excluded entirely, not counted toward skipped
+ * Ignored:   generated sheets (Content, Run report, etc.) — excluded entirely, not counted toward skipped
  *
  * @param {object} inventoryResults
  * @param {Array<{ sheetName: string, items: Array }>} inventoryResults.sheetResults
  * @param {object} [options]
- * @param {string} [options.contentSheetName="Content"]  Sheet name to exclude entirely.
+ * @param {string} [options.contentSheetName="Content"]  Single sheet name to exclude (legacy; ignored when generatedSheetNames is provided).
+ * @param {Set<string>|string[]} [options.generatedSheetNames]  Set/array of all generated sheet names to exclude entirely.
  * @returns {{ eligible: Array, skipped: Array }}
  *
  * Each eligible entry: { sheetName, rangeAddress, title }
  * Each skipped entry:  { sheetName, rangeAddress, reason, status }
  */
-export function filterWorkbookCandidates(inventoryResults, { contentSheetName = "Content" } = {}) {
+export function filterWorkbookCandidates(
+  inventoryResults,
+  { contentSheetName = "Content", generatedSheetNames = null } = {}
+) {
+  const excluded =
+    generatedSheetNames != null ? new Set(generatedSheetNames) : new Set([contentSheetName]);
+
   const eligible = [];
   const skipped = [];
 
   for (const sheetResult of inventoryResults.sheetResults) {
-    if (sheetResult.sheetName === contentSheetName) {
+    if (excluded.has(sheetResult.sheetName)) {
       continue;
     }
     for (const item of sheetResult.items) {

--- a/src/taskpane/taskpane.js
+++ b/src/taskpane/taskpane.js
@@ -1368,9 +1368,9 @@ async function runAutoSignificance() {
   const itemMap = buildItemMetadataMap(inventoryResults);
 
   // Partition candidates: eligible to process vs. pre-skipped due to status/range.
-  // Content sheet is excluded entirely (not counted toward skipped).
+  // Generated sheets (Content, Run report) are excluded entirely (not counted toward skipped).
   const { eligible, skipped: preSkipped } = filterWorkbookCandidates(inventoryResults, {
-    contentSheetName: INVENTORY_CONTENT_SHEET_NAME,
+    generatedSheetNames: GENERATED_SHEET_NAMES,
   });
   let skipped = preSkipped.length;
   const detailLines = preSkipped.map(formatSkippedCandidateDetail);
@@ -1655,7 +1655,7 @@ async function clearAutoSignificance() {
   }
 
   const { eligible, skipped: preSkipped } = filterWorkbookCandidates(inventoryResults, {
-    contentSheetName: INVENTORY_CONTENT_SHEET_NAME,
+    generatedSheetNames: GENERATED_SHEET_NAMES,
   });
   let skipped = preSkipped.length;
   const detailLines = preSkipped.map(formatSkippedCandidateDetail);
@@ -1780,7 +1780,7 @@ async function runCurrentSheetSignificance() {
   const itemMap = buildItemMetadataMap(inventoryResults);
 
   const { eligible, skipped: preSkipped } = filterWorkbookCandidates(inventoryResults, {
-    contentSheetName: INVENTORY_CONTENT_SHEET_NAME,
+    generatedSheetNames: GENERATED_SHEET_NAMES,
   });
   let skipped = preSkipped.length;
   const detailLines = preSkipped.map(formatSkippedCandidateDetail);
@@ -1939,7 +1939,7 @@ async function clearCurrentSheetSignificance() {
   }
 
   const { eligible, skipped: preSkipped } = filterWorkbookCandidates(inventoryResults, {
-    contentSheetName: INVENTORY_CONTENT_SHEET_NAME,
+    generatedSheetNames: GENERATED_SHEET_NAMES,
   });
   let skipped = preSkipped.length;
   const detailLines = preSkipped.map(formatSkippedCandidateDetail);
@@ -3978,6 +3978,22 @@ function writeFullCheckContent(worksheet, inventoryResults) {
   }
 }
 
+/**
+ * Creates or updates the Content sheet, writes inventory content, moves the
+ * sheet to the first position (tab index 0), and returns the worksheet object.
+ *
+ * Placement uses the same two-tier strategy as writeRunReportSheet():
+ *
+ * Tier 1 — direct position assignment.
+ *   Content writes and position assignment are in separate sync batches.
+ *   A verification pass re-reads the actual server-side position. If the
+ *   sheet is already first, we return early.
+ *
+ * Tier 2 — copy / delete / rename fallback.
+ *   When Tier 1 verification shows the sheet is still not first, we fall
+ *   back to: find the first non-Content sheet, copy Content before it,
+ *   activate the copy, delete the original, rename the copy.
+ */
 async function writeInventoryContentSheet(context, inventoryResults) {
   const worksheet = await ensureInventoryContentWorksheet(context);
   const existingUsedRange = worksheet.getUsedRangeOrNullObject();
@@ -4000,11 +4016,59 @@ async function writeInventoryContentSheet(context, inventoryResults) {
     writeMinimalCheckContent(worksheet, inventoryResults);
   }
 
-  worksheet.position = 0;
-
+  // Tier 1 — flush content writes first, then attempt direct position assignment.
   await context.sync();
 
-  return worksheet;
+  const worksheets = context.workbook.worksheets;
+  worksheet.position = 0;
+  await context.sync();
+
+  // Verification: reload the sheet's actual position from the host.
+  worksheet.load("position");
+  await context.sync();
+
+  if (worksheet.position === 0) {
+    return worksheet; // Tier 1 succeeded — sheet is already first.
+  }
+
+  // Tier 2 — copy/delete/rename fallback.
+  // Direct position assignment did not take effect; use Worksheet.copy() to
+  // physically place the sheet at the start of the tab bar.
+
+  // Reload worksheet items in tab order to find the first non-Content sheet.
+  worksheets.load("items/name");
+  await context.sync();
+
+  const allSheets = worksheets.items;
+  let firstSheet = null;
+  for (let i = 0; i < allSheets.length; i++) {
+    if (allSheets[i].name !== INVENTORY_CONTENT_SHEET_NAME) {
+      firstSheet = allSheets[i];
+      break;
+    }
+  }
+
+  if (firstSheet === null) {
+    // Content is the only sheet — trivially at position 0.
+    return worksheet;
+  }
+
+  // Copy the sheet immediately before firstSheet (the true first position).
+  const copy = worksheet.copy("Before", firstSheet);
+
+  // Activate the copy before deleting the original to satisfy the host
+  // constraint that the active sheet cannot be deleted.
+  copy.activate();
+  await context.sync();
+
+  // Remove the original (now not-active) sheet and rename the copy.
+  worksheet.delete();
+  await context.sync();
+
+  copy.name = INVENTORY_CONTENT_SHEET_NAME;
+  await context.sync();
+
+  return copy;
 }
 
 async function runTableInventory() {

--- a/tests/core/batch-candidate-filter.test.mjs
+++ b/tests/core/batch-candidate-filter.test.mjs
@@ -189,6 +189,57 @@ describe("filterWorkbookCandidates — Content sheet exclusion", () => {
   });
 });
 
+// ─── filterWorkbookCandidates — generatedSheetNames option ───────────────────
+
+describe("filterWorkbookCandidates — generatedSheetNames option", () => {
+  it("excludes Run report sheet when passed in generatedSheetNames Set", () => {
+    const item = makeItem({ candidateStatus: "available", rangeAddress: "A1:D10" });
+    const { eligible, skipped } = filterWorkbookCandidates(
+      makeInventory(makeSheet("Run report", [item])),
+      { generatedSheetNames: new Set(["Content", "Run report"]) }
+    );
+    assert.strictEqual(eligible.length, 0);
+    assert.strictEqual(skipped.length, 0);
+  });
+
+  it("excludes all sheets listed in generatedSheetNames while processing others normally", () => {
+    const genItem = makeItem({ candidateStatus: "available", rangeAddress: "A1:D10" });
+    const dataItem = makeItem({ candidateStatus: "available", rangeAddress: "B2:E8" });
+    const { eligible, skipped } = filterWorkbookCandidates(
+      makeInventory(
+        makeSheet("Content", [genItem]),
+        makeSheet("Run report", [genItem]),
+        makeSheet("Data", [dataItem])
+      ),
+      { generatedSheetNames: new Set(["Content", "Run report"]) }
+    );
+    assert.strictEqual(eligible.length, 1);
+    assert.strictEqual(eligible[0].sheetName, "Data");
+    assert.strictEqual(skipped.length, 0);
+  });
+
+  it("accepts an array for generatedSheetNames", () => {
+    const item = makeItem({ candidateStatus: "available", rangeAddress: "A1:D10" });
+    const { eligible, skipped } = filterWorkbookCandidates(
+      makeInventory(makeSheet("Run report", [item])),
+      { generatedSheetNames: ["Content", "Run report"] }
+    );
+    assert.strictEqual(eligible.length, 0);
+    assert.strictEqual(skipped.length, 0);
+  });
+
+  it("generatedSheetNames overrides contentSheetName when both are provided", () => {
+    const item = makeItem({ candidateStatus: "available", rangeAddress: "A1:D10" });
+    // contentSheetName says exclude "Other" but generatedSheetNames does not include "Other"
+    const { eligible } = filterWorkbookCandidates(
+      makeInventory(makeSheet("Other", [item])),
+      { contentSheetName: "Other", generatedSheetNames: new Set(["Content"]) }
+    );
+    // "Other" is not in generatedSheetNames, so it should be included
+    assert.strictEqual(eligible.length, 1);
+  });
+});
+
 // ─── filterWorkbookCandidates — multi-sheet and mixed ────────────────────────
 
 describe("filterWorkbookCandidates — multi-sheet and mixed results", () => {


### PR DESCRIPTION
Part of #180 (PR3 slice).

## Summary

- **Content sheet placement fallback**: `writeInventoryContentSheet` now uses the same two-tier strategy as `writeRunReportSheet`. Tier 1 attempts `worksheet.position = 0` with a verification read-back; Tier 2 falls back to `copy("Before", firstSheet)` / activate / delete / rename when direct assignment is silently ignored by some Office.js host builds.
- **Generated-sheet exclusion hardening**: `filterWorkbookCandidates` gains a `generatedSheetNames` option (Set or Array) so callers can exclude all generated sheets in one pass. All four call sites (workbook run, workbook clear, sheet run, sheet clear) now pass `GENERATED_SHEET_NAMES` which includes both "Content" and "Run report". The previous `contentSheetName` option is preserved for backward compat.
- **Content reuse**: `ensureInventoryContentWorksheet` correctly reuses the sheet by name (`getItemOrNullObject` + `isNullObject` guard). No code change needed — verified and left intact.
- **Scan-level exclusion**: both `collectWorkbookInventoryResults` and `collectActiveSheetInventoryResults` already filter `GENERATED_SHEET_NAMES` before scanning. No change needed.

## Files changed

| File | Change |
|---|---|
| `src/core/batch-candidate-filter.js` | Add `generatedSheetNames` option; update JSDoc |
| `src/taskpane/taskpane.js` | Two-tier placement fallback in `writeInventoryContentSheet`; update 4 call sites |
| `tests/core/batch-candidate-filter.test.mjs` | 4 new tests for `generatedSheetNames` option |

## Test plan

- [ ] `npm test` — 228 tests, 0 failures
- [ ] `npm run build` — no errors (3 pre-existing bundle-size warnings)
- [ ] `git diff --check` — clean
- Manual smoke: repeated Content generation should reuse/update the existing Content sheet (no duplicates), Content sheet should appear at position 0, Content and Run report sheets should be ignored by Check/Run/Clear scans, links/backlinks from PR2 should remain intact.

## Affected GST / debt

No statistical logic changed. No formula or writer changes. Scanner exclusion was already in place at the scan layer; this PR adds defense-in-depth at the candidate-partition layer and hardens placement.

**Known limitation**: Tier 2 copy/delete/rename for Content placement activates the copy mid-operation; the caller's subsequent `.activate()` call on the returned worksheet is a no-op in that case (correct behavior, same as Run report).

🤖 Generated with [Claude Code](https://claude.com/claude-code)