### PR TITLE
feat(#190): warn when preferred base type is not found in table

### DIFF
--- a/src/core/table-inventory-scanner.js
+++ b/src/core/table-inventory-scanner.js
@@ -485,6 +485,10 @@ const ADVISORY_ISSUE_CODES = new Set([
   // in qualityIssueCodes / Check / Full Check but must not downgrade an
   // otherwise valid candidate to "uncertain".
   "BASE_BELOW_THRESHOLD",
+  // PREFERRED_BASE_NOT_FOUND fires when the user requested a specific base type
+  // that was absent from the table.  The calculation still ran with the best
+  // available base, so the table remains usable — the warning is informational.
+  "PREFERRED_BASE_NOT_FOUND",
 ]);
 
 /**

--- a/src/core/table-preview-model.js
+++ b/src/core/table-preview-model.js
@@ -141,6 +141,9 @@ export function buildTablePreviewModel(input) {
     ...checkBaseConsistency(safeValues, calculationBlocks, bannerStructure),
     ...checkNpsMismatch(safeValues, calculationBlocks),
     ...checkWeightedBaseFallback(calculationBlocks),
+    // Inspect rawBlocks so that the preferred-base check covers blocks whose
+    // base row was dropped by blockHasPreviewEvidence.
+    ...checkPreferredBaseNotFound(rawBlocks, safeSettings),
     // Inspect rawBlocks (pre-filter) so that blank/non-numeric base rows are
     // flagged even when blockHasPreviewEvidence later drops the block from
     // calculationBlocks.  Deduplication by base row index is done inside.
@@ -1180,6 +1183,61 @@ function checkWeightedBaseFallback(calculationBlocks) {
       relatedColumnIndexes: [],
       evidence: { baseRowIndex: block.baseRowIndex, baseSubtype: "weighted" },
     });
+  }
+
+  return issues;
+}
+
+/**
+ * Emits PREFERRED_BASE_NOT_FOUND when the user requested a specific base type
+ * (preferredBase !== "auto") but no matching base was found in the table, so
+ * the code fell back to auto-priority selection.
+ *
+ * Runs against rawBlocks (pre-filter) to cover blocks where the base row is
+ * present but has no usable numeric data (those blocks are dropped from
+ * calculationBlocks by blockHasPreviewEvidence but the fallback still occurred).
+ * Deduplicates by base row index.
+ */
+function checkPreferredBaseNotFound(rawBlocks, settings) {
+  const issues = [];
+  const preferredBase = settings?.preferredBase;
+
+  // Only relevant when the user has picked a specific type.
+  if (!preferredBase || preferredBase === "auto") return issues;
+
+  const seenBaseRows = new Set();
+
+  for (const block of rawBlocks || []) {
+    if (block.baseRowIndex == null) continue;
+    if (seenBaseRows.has(block.baseRowIndex)) continue;
+    seenBaseRows.add(block.baseRowIndex);
+
+    // Determine whether the auto-selected base matches the preference.
+    const subtype = block.baseSubtype; // undefined = plain Base
+    const matches =
+      preferredBase === "plain"
+        ? subtype === undefined || subtype === null
+        : subtype === preferredBase;
+
+    if (!matches) {
+      const actualLabel = subtype ? `${subtype} Base` : "plain Base";
+      issues.push({
+        code: "PREFERRED_BASE_NOT_FOUND",
+        severity: "warning",
+        message:
+          `Row ${block.baseRowIndex + 1}: preferred base type '${preferredBase}' not found — ` +
+          `using auto-selected base (${actualLabel}) instead.`,
+        rowIndex: block.baseRowIndex,
+        columnIndex: null,
+        relatedRowIndexes: [],
+        relatedColumnIndexes: [],
+        evidence: {
+          preferredBase,
+          actualBaseSubtype: subtype ?? null,
+          baseRowIndex: block.baseRowIndex,
+        },
+      });
+    }
   }
 
   return issues;

--- a/tests/core/base-subtype-preview.test.mjs
+++ b/tests/core/base-subtype-preview.test.mjs
@@ -527,3 +527,170 @@ describe("checkSelectedBaseValidity — normalizer integration (regression guard
       "non-base trailing footer must not produce BASE_NO_VALID_VALUES");
   });
 });
+
+// ─── checkPreferredBaseNotFound ───────────────────────────────────────────────
+
+describe("checkPreferredBaseNotFound — preferred base type missing warning", () => {
+  // Convenience wrapper that passes settings to makeModel.
+  function makeModelWithPref(labels, values, preferredBase) {
+    return makeModel(labels, values, { preferredBase });
+  }
+
+  // ── No warning when preference is satisfied ────────────────────────────────
+
+  it("preferredBase=effective, effective base present → no PREFERRED_BASE_NOT_FOUND", () => {
+    const model = makeModelWithPref(
+      ["Agree", "Disagree", "Base effective"],
+      [[0.4, 0.6], [0.6, 0.4], [100, 200]],
+      "effective"
+    );
+    assert.ok(
+      !warningCodes(model).includes("PREFERRED_BASE_NOT_FOUND"),
+      `unexpected PREFERRED_BASE_NOT_FOUND; got: ${JSON.stringify(warningCodes(model))}`
+    );
+  });
+
+  it("preferredBase=unweighted, unweighted base present → no PREFERRED_BASE_NOT_FOUND", () => {
+    const model = makeModelWithPref(
+      ["Agree", "Disagree", "Base unweighted"],
+      [[0.4, 0.6], [0.6, 0.4], [100, 200]],
+      "unweighted"
+    );
+    assert.ok(
+      !warningCodes(model).includes("PREFERRED_BASE_NOT_FOUND"),
+      `unexpected PREFERRED_BASE_NOT_FOUND; got: ${JSON.stringify(warningCodes(model))}`
+    );
+  });
+
+  it("preferredBase=weighted, weighted base present → no PREFERRED_BASE_NOT_FOUND", () => {
+    const model = makeModelWithPref(
+      ["Agree", "Disagree", "Base weighted"],
+      [[0.4, 0.6], [0.6, 0.4], [100, 200]],
+      "weighted"
+    );
+    assert.ok(
+      !warningCodes(model).includes("PREFERRED_BASE_NOT_FOUND"),
+      `unexpected PREFERRED_BASE_NOT_FOUND; got: ${JSON.stringify(warningCodes(model))}`
+    );
+  });
+
+  it("preferredBase=plain, plain Base present → no PREFERRED_BASE_NOT_FOUND", () => {
+    const model = makeModelWithPref(
+      ["Agree", "Disagree", "Base"],
+      [[0.4, 0.6], [0.6, 0.4], [100, 200]],
+      "plain"
+    );
+    assert.ok(
+      !warningCodes(model).includes("PREFERRED_BASE_NOT_FOUND"),
+      `unexpected PREFERRED_BASE_NOT_FOUND; got: ${JSON.stringify(warningCodes(model))}`
+    );
+  });
+
+  it("preferredBase=auto → no PREFERRED_BASE_NOT_FOUND regardless of base type", () => {
+    const model = makeModelWithPref(
+      ["Agree", "Disagree", "Base weighted"],
+      [[0.4, 0.6], [0.6, 0.4], [100, 200]],
+      "auto"
+    );
+    assert.ok(
+      !warningCodes(model).includes("PREFERRED_BASE_NOT_FOUND"),
+      `unexpected PREFERRED_BASE_NOT_FOUND in auto mode; got: ${JSON.stringify(warningCodes(model))}`
+    );
+  });
+
+  it("no preferredBase setting (omitted) → no PREFERRED_BASE_NOT_FOUND", () => {
+    const model = makeModel(
+      ["Agree", "Disagree", "Base weighted"],
+      [[0.4, 0.6], [0.6, 0.4], [100, 200]]
+    );
+    assert.ok(
+      !warningCodes(model).includes("PREFERRED_BASE_NOT_FOUND"),
+      `unexpected PREFERRED_BASE_NOT_FOUND when preferredBase omitted`
+    );
+  });
+
+  // ── Warning fires when preference cannot be satisfied ─────────────────────
+
+  it("preferredBase=effective, only plain Base available → PREFERRED_BASE_NOT_FOUND", () => {
+    const model = makeModelWithPref(
+      ["Agree", "Disagree", "Base"],
+      [[0.4, 0.6], [0.6, 0.4], [100, 200]],
+      "effective"
+    );
+    assert.ok(
+      warningCodes(model).includes("PREFERRED_BASE_NOT_FOUND"),
+      `expected PREFERRED_BASE_NOT_FOUND; got: ${JSON.stringify(warningCodes(model))}`
+    );
+    const issue = model.dataQualityIssues.find((i) => i.code === "PREFERRED_BASE_NOT_FOUND");
+    assert.strictEqual(issue.severity, "warning");
+    assert.strictEqual(issue.evidence.preferredBase, "effective");
+    assert.strictEqual(issue.evidence.actualBaseSubtype, null); // plain Base
+  });
+
+  it("preferredBase=unweighted, only weighted Base available → PREFERRED_BASE_NOT_FOUND", () => {
+    const model = makeModelWithPref(
+      ["Agree", "Disagree", "Base weighted"],
+      [[0.4, 0.6], [0.6, 0.4], [100, 200]],
+      "unweighted"
+    );
+    assert.ok(
+      warningCodes(model).includes("PREFERRED_BASE_NOT_FOUND"),
+      `expected PREFERRED_BASE_NOT_FOUND; got: ${JSON.stringify(warningCodes(model))}`
+    );
+    const issue = model.dataQualityIssues.find((i) => i.code === "PREFERRED_BASE_NOT_FOUND");
+    assert.strictEqual(issue.evidence.preferredBase, "unweighted");
+    assert.strictEqual(issue.evidence.actualBaseSubtype, "weighted");
+  });
+
+  it("preferredBase=effective, only weighted+unweighted available → PREFERRED_BASE_NOT_FOUND", () => {
+    // Auto fallback will pick unweighted (priority 1 > weighted 3).
+    const model = makeModelWithPref(
+      ["Agree", "Disagree", "Base weighted", "Base unweighted"],
+      [[0.4, 0.6], [0.6, 0.4], [200, 300], [180, 280]],
+      "effective"
+    );
+    assert.ok(
+      warningCodes(model).includes("PREFERRED_BASE_NOT_FOUND"),
+      `expected PREFERRED_BASE_NOT_FOUND; got: ${JSON.stringify(warningCodes(model))}`
+    );
+    const issue = model.dataQualityIssues.find((i) => i.code === "PREFERRED_BASE_NOT_FOUND");
+    assert.strictEqual(issue.evidence.preferredBase, "effective");
+    assert.strictEqual(issue.evidence.actualBaseSubtype, "unweighted");
+  });
+
+  it("preferredBase=weighted, only effective Base available → PREFERRED_BASE_NOT_FOUND", () => {
+    const model = makeModelWithPref(
+      ["Agree", "Disagree", "Base effective"],
+      [[0.4, 0.6], [0.6, 0.4], [100, 200]],
+      "weighted"
+    );
+    assert.ok(
+      warningCodes(model).includes("PREFERRED_BASE_NOT_FOUND"),
+      `expected PREFERRED_BASE_NOT_FOUND; got: ${JSON.stringify(warningCodes(model))}`
+    );
+  });
+
+  it("PREFERRED_BASE_NOT_FOUND is advisory — does not appear in critical count", () => {
+    const model = makeModelWithPref(
+      ["Agree", "Disagree", "Base"],
+      [[0.4, 0.6], [0.6, 0.4], [100, 200]],
+      "effective"
+    );
+    assert.ok(warningCodes(model).includes("PREFERRED_BASE_NOT_FOUND"));
+    assert.strictEqual(model.qualitySummary.criticalCount, 0, "must not count as critical");
+    assert.strictEqual(model.qualitySummary.warningCount, 1, "counts as one warning");
+  });
+
+  it("PREFERRED_BASE_NOT_FOUND deduplicates — shared base row produces one issue", () => {
+    // NPS-first: proportion + npsStructure blocks share the same base row.
+    const model = makeModelWithPref(
+      ["NPS", "Promoters", "Detractors", "Base"],
+      [[0.1, 0.2], [0.6, 0.5], [0.3, 0.3], [100, 200]],
+      "effective"
+    );
+    const notFoundIssues = model.dataQualityIssues.filter(
+      (i) => i.code === "PREFERRED_BASE_NOT_FOUND"
+    );
+    assert.strictEqual(notFoundIssues.length, 1, "shared base row must produce exactly one issue");
+  });
+});


### PR DESCRIPTION
## Summary

- The core `preferredBase` selection logic (in `metric-detector.js`, `taskpane.js`, and `table-preview-model.js`) was already fully wired up and working in all three Run paths. No changes were needed there.
- The only missing piece was a **fallback warning** for Check/Preview: when the user picks a specific base type that is absent from the table, the code silently auto-selected the best available base with no feedback.
- This PR adds `PREFERRED_BASE_NOT_FOUND` — a new advisory warning emitted by the Check layer whenever the preferred base type could not be matched and a fallback occurred.

## Files changed

| File | Change |
|---|---|
| `src/core/table-preview-model.js` | Add `checkPreferredBaseNotFound()` function and wire it into `dataQualityIssues` |
| `src/core/table-inventory-scanner.js` | Register `PREFERRED_BASE_NOT_FOUND` in `ADVISORY_ISSUE_CODES` so it never downgrades `candidateStatus` |
| `tests/core/base-subtype-preview.test.mjs` | 12 new tests: preference satisfied (no warning), preference missing (warning + evidence), advisory severity, shared-base deduplication |

## Behavior

- `preferredBase=auto` → no change, existing auto-priority (Effective → Unweighted → plain Base → Weighted) applies.
- `preferredBase=effective|unweighted|weighted|plain` and a matching base row is present → uses it, no new warning.
- `preferredBase=effective|unweighted|weighted|plain` and the requested type is **absent** → falls back to auto-priority (existing behavior), emits `PREFERRED_BASE_NOT_FOUND` warning in Check/Preview with `evidence.preferredBase` and `evidence.actualBaseSubtype`.
- `PREFERRED_BASE_NOT_FOUND` is advisory: it appears in `qualityIssueCodes` and `warnings` but does **not** downgrade `candidateStatus` or block Run.
- `WEIGHTED_BASE_FALLBACK` behavior is unchanged.

## What was already complete (no changes made)

- `selectBestFromConsecutiveBases` / `buildCalculationBlocks` in `metric-detector.js` — preference + fallback logic
- `#preferred-base` UI select in `taskpane.html` — options: auto / effective / unweighted / plain / weighted
- `preferredBase` read + default in `taskpane.js`, passed to `buildCalculationBlocks` in selected-range Run, current-sheet Run, and whole-workbook Run
- `buildTablePreviewModel` passing `preferredBase` to `buildCalculationBlocks`

## Test/build result

- `npm test`: 240/240 pass (228 pre-existing + 12 new)
- `npm run build`: webpack compiled with 3 pre-existing size warnings, no new warnings or errors
- `git diff --check`: clean

## Limitations / fallback behavior

- The warning only surfaces in the **Check/Preview** layer (`table-preview-model.js`). There is no status-bar message during Run itself for this fallback, consistent with how `WEIGHTED_BASE_FALLBACK` works.
- Weighted base explicitly chosen (`preferredBase=weighted`) still triggers `WEIGHTED_BASE_FALLBACK` (pre-existing behavior, tested). If that advisory warning is too noisy for the explicit-choice case, that is a separate follow-up.
- No UI changes were made (the `#preferred-base` select remains as-is with its 5 options).

## Closes

Resolves #190

🤖 Generated with [Claude Code](https://claude.com/claude-code)