### PR TITLE
UI polish: merge Clear into Расчёт, Content workbook-only scope (#195)

### DIFF
--- a/src/taskpane/taskpane.css
+++ b/src/taskpane/taskpane.css
@@ -636,17 +636,6 @@ b {
   color: var(--rs-color-muted);
 }
 
-.content-scope-label {
-  margin-bottom: 8px;
-  padding: 4px 8px;
-  font-size: 12px;
-  font-weight: 600;
-  color: var(--rs-color-muted);
-  background: var(--rs-color-bg-soft);
-  border: 1px solid var(--rs-color-border);
-  border-radius: var(--rs-radius-sm);
-}
-
 .check-workspace-hint {
   margin: 4px 0 2px 0;
   font-size: 11px;

--- a/src/taskpane/taskpane.css
+++ b/src/taskpane/taskpane.css
@@ -636,6 +636,17 @@ b {
   color: var(--rs-color-muted);
 }
 
+.content-scope-label {
+  margin-bottom: 8px;
+  padding: 4px 8px;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--rs-color-muted);
+  background: var(--rs-color-bg-soft);
+  border: 1px solid var(--rs-color-border);
+  border-radius: var(--rs-radius-sm);
+}
+
 .check-workspace-hint {
   margin: 4px 0 2px 0;
   font-size: 11px;

--- a/src/taskpane/taskpane.html
+++ b/src/taskpane/taskpane.html
@@ -54,9 +54,6 @@
           <button class="scope-btn" data-scope="whole_workbook">Вся книга</button>
         </div>
 
-        <!-- Static scope label shown when Content action is active -->
-        <div id="content-scope-label" class="content-scope-label" style="display:none">Область: вся книга</div>
-
         <!-- Workspaces: one shown at a time based on action + scope -->
 
         <div class="action-workspace" data-workspace="run-current_table">
@@ -67,16 +64,16 @@
         </div>
 
         <div class="action-workspace" data-workspace="run-current_sheet" style="display:none">
-          <div class="check-buttons-row">
-            <button id="run-sheet-tables" class="check-action-button">Рассчитать по листу</button>
-            <button id="clear-sheet-tables" class="check-action-button">Очистить по листу</button>
+          <div class="action-buttons-row">
+            <button id="run-sheet-tables" class="primary-action-button">Рассчитать</button>
+            <button id="clear-sheet-tables" class="secondary-action-button">Очистить значимости</button>
           </div>
         </div>
 
         <div class="action-workspace" data-workspace="run-whole_workbook" style="display:none">
-          <div class="check-buttons-row">
-            <button id="run-all-tables" class="check-action-button">Рассчитать по всей книге</button>
-            <button id="clear-all-tables" class="check-action-button">Очистить по книге</button>
+          <div class="action-buttons-row">
+            <button id="run-all-tables" class="primary-action-button">Рассчитать</button>
+            <button id="clear-all-tables" class="secondary-action-button">Очистить значимости</button>
           </div>
         </div>
 

--- a/src/taskpane/taskpane.html
+++ b/src/taskpane/taskpane.html
@@ -40,10 +40,9 @@
       </section>
 
       <section class="action-panel action-panel-sticky">
-        <!-- Action tabs: Run | Clear | Check | Content -->
+        <!-- Action tabs: Run | Check | Content -->
         <div class="action-tabs" role="tablist" id="action-tabs">
           <button class="action-tab is-active" data-action="run" role="tab" aria-selected="true">Расчёт</button>
-          <button class="action-tab" data-action="clear" role="tab" aria-selected="false">Очистка</button>
           <button class="action-tab action-tab--readonly" data-action="check" role="tab" aria-selected="false">Проверка</button>
           <button class="action-tab" data-action="content" role="tab" aria-selected="false">Оглавление</button>
         </div>
@@ -55,40 +54,28 @@
           <button class="scope-btn" data-scope="whole_workbook">Вся книга</button>
         </div>
 
+        <!-- Static scope label shown when Content action is active -->
+        <div id="content-scope-label" class="content-scope-label" style="display:none">Область: вся книга</div>
+
         <!-- Workspaces: one shown at a time based on action + scope -->
 
         <div class="action-workspace" data-workspace="run-current_table">
           <div class="action-buttons-row">
             <button id="calculate-significance" class="primary-action-button">Рассчитать</button>
+            <button id="clear-significance" class="secondary-action-button">Очистить значимости</button>
           </div>
         </div>
 
         <div class="action-workspace" data-workspace="run-current_sheet" style="display:none">
           <div class="check-buttons-row">
             <button id="run-sheet-tables" class="check-action-button">Рассчитать по листу</button>
+            <button id="clear-sheet-tables" class="check-action-button">Очистить по листу</button>
           </div>
         </div>
 
         <div class="action-workspace" data-workspace="run-whole_workbook" style="display:none">
           <div class="check-buttons-row">
             <button id="run-all-tables" class="check-action-button">Рассчитать по всей книге</button>
-          </div>
-        </div>
-
-        <div class="action-workspace" data-workspace="clear-current_table" style="display:none">
-          <div class="action-buttons-row">
-            <button id="clear-significance" class="secondary-action-button">Очистить значимости</button>
-          </div>
-        </div>
-
-        <div class="action-workspace" data-workspace="clear-current_sheet" style="display:none">
-          <div class="check-buttons-row">
-            <button id="clear-sheet-tables" class="check-action-button">Очистить по листу</button>
-          </div>
-        </div>
-
-        <div class="action-workspace" data-workspace="clear-whole_workbook" style="display:none">
-          <div class="check-buttons-row">
             <button id="clear-all-tables" class="check-action-button">Очистить по книге</button>
           </div>
         </div>
@@ -112,14 +99,6 @@
             <button id="find-tables" class="check-action-button">Проверить книгу</button>
           </div>
           <p class="check-workspace-hint">Только чтение · сканирует таблицы по всей книге. В книгу ничего не записывается.</p>
-        </div>
-
-        <div class="action-workspace" data-workspace="content-current_table" style="display:none">
-          <p class="scope-note">Оглавление работает только на уровне всей книги. Переключитесь на «Вся книга».</p>
-        </div>
-
-        <div class="action-workspace" data-workspace="content-current_sheet" style="display:none">
-          <p class="scope-note">Оглавление работает только на уровне всей книги. Переключитесь на «Вся книга».</p>
         </div>
 
         <div class="action-workspace" data-workspace="content-whole_workbook" style="display:none">

--- a/src/taskpane/taskpane.js
+++ b/src/taskpane/taskpane.js
@@ -450,12 +450,10 @@ function updateActionScopeShell(action, scope) {
     tab.setAttribute("aria-selected", active ? "true" : "false");
   });
 
-  // Content action is workbook-only: hide scope selector and show a static label.
+  // Content action is workbook-only: hide the scope selector.
   const contentSelected = action === "content";
   const scopeSelector = document.getElementById("scope-selector");
-  const contentScopeLabel = document.getElementById("content-scope-label");
   if (scopeSelector) scopeSelector.style.display = contentSelected ? "none" : "";
-  if (contentScopeLabel) contentScopeLabel.style.display = contentSelected ? "" : "none";
 
   // Update scope button active states (scope is preserved while selector is hidden)
   document.querySelectorAll(".scope-btn").forEach((btn) => {

--- a/src/taskpane/taskpane.js
+++ b/src/taskpane/taskpane.js
@@ -450,22 +450,21 @@ function updateActionScopeShell(action, scope) {
     tab.setAttribute("aria-selected", active ? "true" : "false");
   });
 
-  // Content action is workbook-only: disable non-workbook scope buttons so the
-  // user can see they are unavailable, but do NOT coerce the selected scope —
-  // the content-current_table / content-current_sheet workspaces show an
-  // explanatory note for whichever scope the user currently has selected.
+  // Content action is workbook-only: hide scope selector and show a static label.
   const contentSelected = action === "content";
-  document.querySelectorAll(".scope-btn").forEach((btn) => {
-    btn.disabled = contentSelected && btn.dataset.scope !== "whole_workbook";
-  });
+  const scopeSelector = document.getElementById("scope-selector");
+  const contentScopeLabel = document.getElementById("content-scope-label");
+  if (scopeSelector) scopeSelector.style.display = contentSelected ? "none" : "";
+  if (contentScopeLabel) contentScopeLabel.style.display = contentSelected ? "" : "none";
 
-  // Update scope button active states using the actual scope (no coercion)
+  // Update scope button active states (scope is preserved while selector is hidden)
   document.querySelectorAll(".scope-btn").forEach((btn) => {
     btn.classList.toggle("is-active", btn.dataset.scope === scope);
   });
 
-  // Show the matching workspace, hide all others
-  const workspaceKey = `${action}-${scope}`;
+  // Show the matching workspace: for content, always use whole_workbook
+  const effectiveScope = contentSelected ? "whole_workbook" : scope;
+  const workspaceKey = `${action}-${effectiveScope}`;
   document.querySelectorAll(".action-workspace").forEach((ws) => {
     ws.style.display = ws.dataset.workspace === workspaceKey ? "" : "none";
   });


### PR DESCRIPTION
## Summary

Closes #195. Part of #192.

- Removed the separate Clear / Очистка top-level action tab.
- Moved clear buttons into the matching Расчёт workspaces.
- Unified visible Run/Clear labels across scopes: `Рассчитать` and `Очистить значимости`.
- Kept existing handler IDs and behavior.
- Made Оглавление workbook-only in the UI by hiding the scope selector for Content.
- Removed non-workbook Content note workspaces.
- Replaced the previous static workbook-scope label with helper text explaining that Content scans all workbook sheets, creates or updates the Content sheet, and does not change table data.

## Files changed

- `src/taskpane/taskpane.html`
- `src/taskpane/taskpane.js`

## Test / build result

- `npm test`: 240 pass, 0 fail
- `npm run build`: clean, with 3 pre-existing bundle-size warnings
- `git diff --check`: clean

## Not changed

- no calculation behavior changes
- no clear handler changes
- no Content generation behavior changes
- no writer changes
- no Settings redesign
- no localization or icons
- no manual-vs-auto-runner split

## Follow-up

The later manual-vs-auto-runner split remains deferred to #192 PR7.