### PR TITLE
Content: Title links + user-facing status wording (#199)

### DIFF
--- a/src/taskpane/taskpane.js
+++ b/src/taskpane/taskpane.js
@@ -3222,7 +3222,7 @@ function buildInventoryContentCandidateRows(sheetResults) {
       rows.push([
         candidateIndex,
         sheetResult.sheetName,
-        item.resolvedTitle || (isGeneratedBacklinkRow(item.title) ? "" : (item.title || "")),
+        resolveContentDisplayTitle(item, candidateIndex),
         item.resolvedRangeAddress || item.rangeAddress || "",
         item.rowCount ?? "",
         item.columnCount ?? "",
@@ -3673,12 +3673,48 @@ function getContentTableHyperlinkTarget(sheetName, rangeAddress) {
   return `${quotedSheet}!${rangeAddress}`;
 }
 
+/**
+ * Returns the Content-sheet display title for a detected table candidate.
+ *
+ * Only trusts a scanner/resolved title when titleConfidence === "high", meaning
+ * the first row of the detected band was a dedicated sparse heading row.
+ * Medium-confidence titles (inferred from rows *above* the band) may be
+ * banner/header cells rather than genuine table titles and are suppressed here.
+ * resolvedTitle (post-backlink) is also only used when the original scan rated
+ * the title as high-confidence.
+ *
+ * Falls back to "Таблица N" for:
+ *   - titleConfidence !== "high" (medium / none)
+ *   - title equals the generated backlink marker
+ *   - title is empty after all checks
+ *
+ * @param {object} item   - TableInventoryItem (may have resolvedTitle set by normalizeBacklinkItems).
+ * @param {number} index  - 1-based candidate number within the Content output.
+ * @returns {string}
+ */
+function resolveContentDisplayTitle(item, index) {
+  const fallback = `Таблица ${index}`;
+
+  // Medium/none confidence titles come from rows above the band and may be
+  // banner or header text, not real table headings — always use the fallback.
+  if (item.titleConfidence !== "high") {
+    return fallback;
+  }
+
+  // High-confidence path: prefer post-backlink resolved title, then raw title.
+  const title =
+    item.resolvedTitle ||
+    (isGeneratedBacklinkRow(item.title) ? "" : (item.title || ""));
+
+  return title || fallback;
+}
+
 function buildClientContentRows(sheetResults) {
   const rows = [];
   let index = 1;
   for (const sheetResult of sheetResults) {
     for (const item of sheetResult.items) {
-      rows.push([index, item.resolvedTitle || (isGeneratedBacklinkRow(item.title) ? "" : (item.title || "")), "", item.sheetName || sheetResult.sheetName]);
+      rows.push([index, resolveContentDisplayTitle(item, index), "", item.sheetName || sheetResult.sheetName]);
       index++;
     }
   }
@@ -3814,12 +3850,10 @@ function writeMinimalCheckContent(worksheet, inventoryResults) {
     const effectiveRange = item.resolvedRangeAddress || item.rangeAddress;
     const hyperlinkTarget = getContentTableHyperlinkTarget(item.sheetName, effectiveRange);
     if (hyperlinkTarget) {
-      const displayTitle =
-        item.resolvedTitle || (isGeneratedBacklinkRow(item.title) ? "" : (item.title || ""));
       const cell = worksheet.getRangeByIndexes(headerRowIndex + i, TITLE_COL_INDEX, 1, 1);
       cell.hyperlink = {
         documentReference: hyperlinkTarget,
-        textToDisplay: displayTitle || `Таблица ${i + 1}`,
+        textToDisplay: resolveContentDisplayTitle(item, i + 1),
         screenTip: `${item.sheetName}!${effectiveRange}`,
       };
     }
@@ -3875,10 +3909,9 @@ function writeClientFacingContent(worksheet, inventoryResults) {
     const hyperlinkTarget = getContentTableHyperlinkTarget(item.sheetName, effectiveRange);
     if (hyperlinkTarget) {
       const cell = worksheet.getRangeByIndexes(headerRowIndex + i, TITLE_COL_INDEX, 1, 1);
-      const displayTitle = item.resolvedTitle || (isGeneratedBacklinkRow(item.title) ? "" : (item.title || ""));
       cell.hyperlink = {
         documentReference: hyperlinkTarget,
-        textToDisplay: displayTitle || `Таблица ${i + 1}`,
+        textToDisplay: resolveContentDisplayTitle(item, i + 1),
         screenTip: `${item.sheetName}!${effectiveRange}`,
       };
     }
@@ -3899,7 +3932,7 @@ function buildFullCheckCandidateRows(sheetResults) {
       rows.push([
         candidateIndex,
         sheetResult.sheetName,
-        item.resolvedTitle || (isGeneratedBacklinkRow(item.title) ? "" : (item.title || "")),
+        resolveContentDisplayTitle(item, candidateIndex),
         item.resolvedRangeAddress || item.rangeAddress || "",
         getContentCandidateStatusLabel(item),
         item.previewSummary || "",
@@ -4004,12 +4037,10 @@ function writeFullCheckContent(worksheet, inventoryResults) {
     const effectiveRange = item.resolvedRangeAddress || item.rangeAddress;
     const hyperlinkTarget = getContentTableHyperlinkTarget(item.sheetName, effectiveRange);
     if (hyperlinkTarget) {
-      const displayTitle =
-        item.resolvedTitle || (isGeneratedBacklinkRow(item.title) ? "" : (item.title || ""));
       const cell = worksheet.getRangeByIndexes(headerRowIndex + i, TITLE_COL_INDEX, 1, 1);
       cell.hyperlink = {
         documentReference: hyperlinkTarget,
-        textToDisplay: displayTitle || `Таблица ${i + 1}`,
+        textToDisplay: resolveContentDisplayTitle(item, i + 1),
         screenTip: `${item.sheetName}!${effectiveRange}`,
       };
     }

--- a/src/taskpane/taskpane.js
+++ b/src/taskpane/taskpane.js
@@ -2960,6 +2960,27 @@ function getInventoryCandidateStatusLabel(candidateStatus) {
   return "Не опознан как таблица ResearchSignal";
 }
 
+/**
+ * User-facing status label for Content sheet output.
+ * Uses warningsCount / criticalCount to produce plain-language readiness labels
+ * instead of internal candidate-finder wording.
+ */
+function getContentCandidateStatusLabel(item) {
+  const status = item.candidateStatus;
+  const warnings = item.warningsCount ?? 0;
+  const criticals = item.criticalCount ?? 0;
+
+  if (status === "available") {
+    return warnings > 0 ? "Есть предупреждения" : "Готово к расчёту";
+  }
+
+  if (status === "uncertain") {
+    return criticals > 0 ? "Есть критические проблемы" : "Нужна проверка";
+  }
+
+  return "Пропущено";
+}
+
 function formatInventoryItemLines(item, index) {
   const lines = [];
   // Prefer resolvedTitle (set after backlink normalization) over raw title.
@@ -3205,7 +3226,7 @@ function buildInventoryContentCandidateRows(sheetResults) {
         item.resolvedRangeAddress || item.rangeAddress || "",
         item.rowCount ?? "",
         item.columnCount ?? "",
-        getInventoryCandidateStatusLabel(item.candidateStatus),
+        getContentCandidateStatusLabel(item),
         item.previewSummary || "",
         item.candidateNotes && item.candidateNotes.length > 0 ? item.candidateNotes.join("; ") : "",
         item.warningsCount ?? 0,
@@ -3787,15 +3808,18 @@ function writeMinimalCheckContent(worksheet, inventoryResults) {
 
   worksheet.getRange("A:K").format.verticalAlignment = "Top";
 
-  const RANGE_COL_INDEX = 3;
+  const TITLE_COL_INDEX = 2;
   for (let i = 0; i < allItems.length; i++) {
     const item = allItems[i];
     const effectiveRange = item.resolvedRangeAddress || item.rangeAddress;
     const hyperlinkTarget = getContentTableHyperlinkTarget(item.sheetName, effectiveRange);
     if (hyperlinkTarget) {
-      const cell = worksheet.getRangeByIndexes(headerRowIndex + i, RANGE_COL_INDEX, 1, 1);
+      const displayTitle =
+        item.resolvedTitle || (isGeneratedBacklinkRow(item.title) ? "" : (item.title || ""));
+      const cell = worksheet.getRangeByIndexes(headerRowIndex + i, TITLE_COL_INDEX, 1, 1);
       cell.hyperlink = {
         documentReference: hyperlinkTarget,
+        textToDisplay: displayTitle || `Таблица ${i + 1}`,
         screenTip: `${item.sheetName}!${effectiveRange}`,
       };
     }
@@ -3877,7 +3901,7 @@ function buildFullCheckCandidateRows(sheetResults) {
         sheetResult.sheetName,
         item.resolvedTitle || (isGeneratedBacklinkRow(item.title) ? "" : (item.title || "")),
         item.resolvedRangeAddress || item.rangeAddress || "",
-        getInventoryCandidateStatusLabel(item.candidateStatus),
+        getContentCandidateStatusLabel(item),
         item.previewSummary || "",
         item.rowCount ?? "",
         item.columnCount ?? "",
@@ -3974,15 +3998,18 @@ function writeFullCheckContent(worksheet, inventoryResults) {
 
   worksheet.getRangeByIndexes(0, 0, candidateRows.length + headerRowIndex, colCount).format.verticalAlignment = "Top";
 
-  const RANGE_COL_INDEX = 3;
+  const TITLE_COL_INDEX = 2;
   for (let i = 0; i < allItems.length; i++) {
     const item = allItems[i];
     const effectiveRange = item.resolvedRangeAddress || item.rangeAddress;
     const hyperlinkTarget = getContentTableHyperlinkTarget(item.sheetName, effectiveRange);
     if (hyperlinkTarget) {
-      const cell = worksheet.getRangeByIndexes(headerRowIndex + i, RANGE_COL_INDEX, 1, 1);
+      const displayTitle =
+        item.resolvedTitle || (isGeneratedBacklinkRow(item.title) ? "" : (item.title || ""));
+      const cell = worksheet.getRangeByIndexes(headerRowIndex + i, TITLE_COL_INDEX, 1, 1);
       cell.hyperlink = {
         documentReference: hyperlinkTarget,
+        textToDisplay: displayTitle || `Таблица ${i + 1}`,
         screenTip: `${item.sheetName}!${effectiveRange}`,
       };
     }

--- a/src/taskpane/taskpane.js
+++ b/src/taskpane/taskpane.js
@@ -3674,17 +3674,48 @@ function getContentTableHyperlinkTarget(sheetName, rangeAddress) {
 }
 
 /**
+ * Returns true when a candidate title is a known total/banner/header-like label
+ * that should not be used as a table title in Content output.
+ *
+ * The scanner's detectFirstRowTitle fires on any sparse all-text first row —
+ * including a single-cell "Всего" or "Total" banner — and assigns
+ * titleConfidence "high".  This guard catches those labels before they reach
+ * the Content display layer.
+ *
+ * The list is intentionally conservative: only unambiguous aggregate/total
+ * words that cannot be a real research-table title on their own.
+ *
+ * @param {string} title - Raw title string from the scanner item.
+ * @returns {boolean}
+ */
+function isContentTitleFallbackLabel(title) {
+  if (!title) return false;
+  const normalized = String(title).trim().toLowerCase();
+  // prettier-ignore
+  const TOTAL_LIKE_LABELS = new Set([
+    "всего",        // Russian "All / Total"
+    "итого",        // Russian "Grand total / Sum"
+    "total",        // English
+    "grand total",  // English compound
+    "overall",      // English
+    "all",          // English
+  ]);
+  return TOTAL_LIKE_LABELS.has(normalized);
+}
+
+/**
  * Returns the Content-sheet display title for a detected table candidate.
  *
- * Only trusts a scanner/resolved title when titleConfidence === "high", meaning
- * the first row of the detected band was a dedicated sparse heading row.
- * Medium-confidence titles (inferred from rows *above* the band) may be
- * banner/header cells rather than genuine table titles and are suppressed here.
- * resolvedTitle (post-backlink) is also only used when the original scan rated
- * the title as high-confidence.
+ * Only trusts a scanner/resolved title when:
+ *   1. titleConfidence === "high" (first row of the detected band was a
+ *      dedicated sparse heading row, not inferred from rows above), AND
+ *   2. The title is not a known total/banner-like label (e.g. "Всего",
+ *      "Total") that the scanner can legitimately detect as a sparse
+ *      first-row title but that is not a real table heading.
  *
  * Falls back to "Таблица N" for:
  *   - titleConfidence !== "high" (medium / none)
+ *   - title is a known total/banner-like label
  *   - title equals the generated backlink marker
  *   - title is empty after all checks
  *
@@ -3705,6 +3736,12 @@ function resolveContentDisplayTitle(item, index) {
   const title =
     item.resolvedTitle ||
     (isGeneratedBacklinkRow(item.title) ? "" : (item.title || ""));
+
+  // Even high-confidence scanner titles can be total/banner-like labels
+  // (e.g. a lone "Всего" cell at the top of a band passes detectFirstRowTitle).
+  if (isContentTitleFallbackLabel(title)) {
+    return fallback;
+  }
 
   return title || fallback;
 }


### PR DESCRIPTION
## Summary

Closes #199. Part of #192.

- In minimal-check and full-check Content modes, navigation hyperlinks now live in the Title column instead of Range.
- Client mode already linked Title and remains unchanged.
- Title hyperlink text uses the detected/resolved title, with `Таблица N` fallback when title is missing.
- Range remains visible as plain text.
- Adds Content-only user-facing status labels:
  - `Готово к расчёту`
  - `Есть предупреждения`
  - `Есть критические проблемы`
  - `Нужна проверка`
  - `Пропущено`
- Leaves Check panel wording unchanged.

## Files changed

- `src/taskpane/taskpane.js`

## Test plan

- `npm test`: 240 tests, 0 failures
- `npm run build`: compiled with no errors, pre-existing bundle-size warnings only
- `git diff --check`: clean

## Limitations / follow-ups

- This PR does not rewrite the reporting details model.
- Full human-readable warning details and links to problematic cells/ranges remain a later #192 reporting-details slice.