### PR TITLE
Add Записать результат to Проверка (#201)

### DIFF
--- a/src/taskpane/taskpane.html
+++ b/src/taskpane/taskpane.html
@@ -80,22 +80,25 @@
         <div class="action-workspace" data-workspace="check-current_table" style="display:none">
           <div class="check-buttons-row">
             <button id="check-table" class="check-action-button">Проверить таблицу</button>
+            <button id="export-check-result-table" class="check-action-button">Записать результат</button>
           </div>
-          <p class="check-workspace-hint">Только чтение · анализирует выделенный диапазон. В книгу ничего не записывается.</p>
+          <p class="check-workspace-hint">Только чтение · анализирует выделенный диапазон. «Записать результат» записывает диагностику в «Run report».</p>
         </div>
 
         <div class="action-workspace" data-workspace="check-current_sheet" style="display:none">
           <div class="check-buttons-row">
             <button id="check-sheet-tables" class="check-action-button">Проверить лист</button>
+            <button id="export-check-result-sheet" class="check-action-button">Записать результат</button>
           </div>
-          <p class="check-workspace-hint">Только чтение · сканирует таблицы на текущем листе. В книгу ничего не записывается.</p>
+          <p class="check-workspace-hint">Только чтение · сканирует таблицы на текущем листе. «Записать результат» записывает диагностику в «Run report».</p>
         </div>
 
         <div class="action-workspace" data-workspace="check-whole_workbook" style="display:none">
           <div class="check-buttons-row">
             <button id="find-tables" class="check-action-button">Проверить книгу</button>
+            <button id="export-check-result-workbook" class="check-action-button">Записать результат</button>
           </div>
-          <p class="check-workspace-hint">Только чтение · сканирует таблицы по всей книге. В книгу ничего не записывается.</p>
+          <p class="check-workspace-hint">Только чтение · сканирует таблицы по всей книге. «Записать результат» записывает диагностику в «Run report».</p>
         </div>
 
         <div class="action-workspace" data-workspace="content-whole_workbook" style="display:none">

--- a/src/taskpane/taskpane.html
+++ b/src/taskpane/taskpane.html
@@ -80,25 +80,22 @@
         <div class="action-workspace" data-workspace="check-current_table" style="display:none">
           <div class="check-buttons-row">
             <button id="check-table" class="check-action-button">Проверить таблицу</button>
-            <button id="export-check-result-table" class="check-action-button">Записать результат</button>
           </div>
-          <p class="check-workspace-hint">Только чтение · анализирует выделенный диапазон. «Записать результат» записывает диагностику в «Run report».</p>
+          <p class="check-workspace-hint">Только чтение · анализирует выделенный диапазон.</p>
         </div>
 
         <div class="action-workspace" data-workspace="check-current_sheet" style="display:none">
           <div class="check-buttons-row">
             <button id="check-sheet-tables" class="check-action-button">Проверить лист</button>
-            <button id="export-check-result-sheet" class="check-action-button">Записать результат</button>
           </div>
-          <p class="check-workspace-hint">Только чтение · сканирует таблицы на текущем листе. «Записать результат» записывает диагностику в «Run report».</p>
+          <p class="check-workspace-hint">Только чтение · сканирует таблицы на текущем листе.</p>
         </div>
 
         <div class="action-workspace" data-workspace="check-whole_workbook" style="display:none">
           <div class="check-buttons-row">
             <button id="find-tables" class="check-action-button">Проверить книгу</button>
-            <button id="export-check-result-workbook" class="check-action-button">Записать результат</button>
           </div>
-          <p class="check-workspace-hint">Только чтение · сканирует таблицы по всей книге. «Записать результат» записывает диагностику в «Run report».</p>
+          <p class="check-workspace-hint">Только чтение · сканирует таблицы по всей книге.</p>
         </div>
 
         <div class="action-workspace" data-workspace="content-whole_workbook" style="display:none">
@@ -127,6 +124,14 @@
           <label class="inline-checkbox-label" for="run-add-report">
             <input type="checkbox" id="run-add-report" />
             <span>Добавить диагностический лист</span>
+          </label>
+        </div>
+
+        <!-- Shared check controls: shown for all Check scopes -->
+        <div id="check-report-control" class="inventory-backlink-row" style="display:none">
+          <label class="inline-checkbox-label" for="check-add-report">
+            <input type="checkbox" id="check-add-report" />
+            <span>Записать результат в «Run report»</span>
           </label>
         </div>
       </section>

--- a/src/taskpane/taskpane.html
+++ b/src/taskpane/taskpane.html
@@ -81,21 +81,21 @@
           <div class="check-buttons-row">
             <button id="check-table" class="check-action-button">Проверить таблицу</button>
           </div>
-          <p class="check-workspace-hint">Только чтение · анализирует выделенный диапазон.</p>
+          <p class="check-workspace-hint" data-hint-base="Проверяет выделенный диапазон."></p>
         </div>
 
         <div class="action-workspace" data-workspace="check-current_sheet" style="display:none">
           <div class="check-buttons-row">
             <button id="check-sheet-tables" class="check-action-button">Проверить лист</button>
           </div>
-          <p class="check-workspace-hint">Только чтение · сканирует таблицы на текущем листе.</p>
+          <p class="check-workspace-hint" data-hint-base="Проверяет таблицы на текущем листе."></p>
         </div>
 
         <div class="action-workspace" data-workspace="check-whole_workbook" style="display:none">
           <div class="check-buttons-row">
             <button id="find-tables" class="check-action-button">Проверить книгу</button>
           </div>
-          <p class="check-workspace-hint">Только чтение · сканирует таблицы по всей книге.</p>
+          <p class="check-workspace-hint" data-hint-base="Проверяет таблицы по всей книге."></p>
         </div>
 
         <div class="action-workspace" data-workspace="content-whole_workbook" style="display:none">

--- a/src/taskpane/taskpane.html
+++ b/src/taskpane/taskpane.html
@@ -131,7 +131,7 @@
         <div id="check-report-control" class="inventory-backlink-row" style="display:none">
           <label class="inline-checkbox-label" for="check-add-report">
             <input type="checkbox" id="check-add-report" />
-            <span>Записать результат в «Run report»</span>
+            <span>Записать результат</span>
           </label>
         </div>
       </section>

--- a/src/taskpane/taskpane.js
+++ b/src/taskpane/taskpane.js
@@ -424,6 +424,8 @@ Office.onReady((info) => {
     contentFindTablesButton.addEventListener("click", runTableInventory);
   }
 
+  document.getElementById("check-add-report")?.addEventListener("change", updateCheckHints);
+
   initActionScopeShell();
   initPanelDismiss();
 });
@@ -444,6 +446,13 @@ let _currentScope = "current_table";
 function isCheckReportEnabled() {
   const cb = document.getElementById("check-add-report");
   return cb ? cb.checked : false;
+}
+
+function updateCheckHints() {
+  const modeText = isCheckReportEnabled() ? " С записью на лист." : " Только чтение.";
+  document.querySelectorAll(".check-workspace-hint[data-hint-base]").forEach((el) => {
+    el.textContent = el.dataset.hintBase + modeText;
+  });
 }
 
 function updateActionScopeShell(action, scope) {
@@ -483,6 +492,8 @@ function updateActionScopeShell(action, scope) {
   if (checkReportControl) {
     checkReportControl.style.display = action === "check" ? "" : "none";
   }
+
+  updateCheckHints();
 
 }
 
@@ -2177,13 +2188,8 @@ async function runCurrentSheetCheck() {
   for (let i = 0; i < allItems.length; i++) {
     const item = allItems[i];
     const rangeAddr = item.resolvedRangeAddress || item.rangeAddress || null;
-    const displayTitle =
-      item.resolvedTitle ||
-      (item.title && !isGeneratedBacklinkRow(item.title) ? item.title : null);
     const reportTitle = resolveContentDisplayTitle(item, i + 1);
-    const header = displayTitle
-      ? `${i + 1}. ${displayTitle} — ${rangeAddr || "?"}`
-      : `${i + 1}. ${rangeAddr || "?"}`;
+    const header = `${i + 1}. ${reportTitle} — ${rangeAddr || "?"}`;
 
     candidateLines.push("");
     candidateLines.push(header);
@@ -2336,13 +2342,8 @@ async function runWorkbookCheck() {
       globalItemIndex++;
       const item = sheetResult.items[i];
       const rangeAddr = item.resolvedRangeAddress || item.rangeAddress || null;
-      const displayTitle =
-        item.resolvedTitle ||
-        (item.title && !isGeneratedBacklinkRow(item.title) ? item.title : null);
       const reportTitle = resolveContentDisplayTitle(item, globalItemIndex);
-      const header = displayTitle
-        ? `  ${i + 1}. ${displayTitle} — ${rangeAddr || "?"}`
-        : `  ${i + 1}. ${rangeAddr || "?"}`;
+      const header = `  ${i + 1}. ${reportTitle} — ${rangeAddr || "?"}`;
       summaryLines.push(header);
 
       if (item.candidateStatus === "available") {

--- a/src/taskpane/taskpane.js
+++ b/src/taskpane/taskpane.js
@@ -2180,6 +2180,7 @@ async function runCurrentSheetCheck() {
     const displayTitle =
       item.resolvedTitle ||
       (item.title && !isGeneratedBacklinkRow(item.title) ? item.title : null);
+    const reportTitle = resolveContentDisplayTitle(item, i + 1);
     const header = displayTitle
       ? `${i + 1}. ${displayTitle} — ${rangeAddr || "?"}`
       : `${i + 1}. ${rangeAddr || "?"}`;
@@ -2190,7 +2191,7 @@ async function runCurrentSheetCheck() {
     if (!rangeAddr) {
       missingCount++;
       candidateLines.push("   Пропущено — нет диапазона.");
-      checkReportRows.push({ sheetName: activeSheetName, title: displayTitle || "", rangeAddress: "", status: "skipped", message: "Нет диапазона", selectedBase: item.selectedBaseSubtypeLabel || "", metricTypes: runReportMetricTypes(item), warnings: item.warningsCount ?? "", critical: item.criticalCount ?? "", warningDetails: runReportWarningDetails(item), blocksProcessed: "" });
+      checkReportRows.push({ sheetName: activeSheetName, title: reportTitle, rangeAddress: "", status: "skipped", message: "Нет диапазона", selectedBase: item.selectedBaseSubtypeLabel || "", metricTypes: runReportMetricTypes(item), warnings: item.warningsCount ?? "", critical: item.criticalCount ?? "", warningDetails: runReportWarningDetails(item), blocksProcessed: "" });
       continue;
     }
 
@@ -2201,7 +2202,7 @@ async function runCurrentSheetCheck() {
       if (item.candidateNotes && item.candidateNotes.length > 0) {
         candidateLines.push(`   [${item.candidateNotes.join("; ")}]`);
       }
-      checkReportRows.push({ sheetName: activeSheetName, title: displayTitle || "", rangeAddress: rangeAddr, status: "skipped", message: "Не опознан как таблица", selectedBase: item.selectedBaseSubtypeLabel || "", metricTypes: runReportMetricTypes(item), warnings: item.warningsCount ?? "", critical: item.criticalCount ?? "", warningDetails: runReportWarningDetails(item), blocksProcessed: "" });
+      checkReportRows.push({ sheetName: activeSheetName, title: reportTitle, rangeAddress: rangeAddr, status: "skipped", message: "Не опознан как таблица", selectedBase: item.selectedBaseSubtypeLabel || "", metricTypes: runReportMetricTypes(item), warnings: item.warningsCount ?? "", critical: item.criticalCount ?? "", warningDetails: runReportWarningDetails(item), blocksProcessed: "" });
       continue;
     }
 
@@ -2212,7 +2213,7 @@ async function runCurrentSheetCheck() {
       if (item.candidateNotes && item.candidateNotes.length > 0) {
         candidateLines.push(`   [${item.candidateNotes.join("; ")}]`);
       }
-      checkReportRows.push({ sheetName: activeSheetName, title: displayTitle || "", rangeAddress: rangeAddr, status: "skipped", message: "Граница данных неоднозначна", selectedBase: item.selectedBaseSubtypeLabel || "", metricTypes: runReportMetricTypes(item), warnings: item.warningsCount ?? "", critical: item.criticalCount ?? "", warningDetails: runReportWarningDetails(item), blocksProcessed: "" });
+      checkReportRows.push({ sheetName: activeSheetName, title: reportTitle, rangeAddress: rangeAddr, status: "skipped", message: "Граница данных неоднозначна", selectedBase: item.selectedBaseSubtypeLabel || "", metricTypes: runReportMetricTypes(item), warnings: item.warningsCount ?? "", critical: item.criticalCount ?? "", warningDetails: runReportWarningDetails(item), blocksProcessed: "" });
       continue;
     }
 
@@ -2240,21 +2241,21 @@ async function runCurrentSheetCheck() {
             warnParts.push(`Предупреждений: ${qualitySummary.warningCount}`);
           if (warnParts.length > 0) candidateLines.push(`   ${warnParts.join(". ")}.`);
           const issueDetails = (userVisibleIssues || []).map((iss) => `[${iss.severity}] ${iss.message}`).join("; ");
-          checkReportRows.push({ sheetName: activeSheetName, title: displayTitle || "", rangeAddress: rangeAddr, status: "checked", message: `Строк: ${summary.rowCount}. Блоков: ${summary.detectedBlocks}. Баз: ${summary.baseRows}.`, selectedBase: item.selectedBaseSubtypeLabel || "", metricTypes: checkMetricTypesFromBlocks(calculationBlocks), warnings: qualitySummary.warningCount, critical: qualitySummary.criticalCount, warningDetails: issueDetails, blocksProcessed: summary.detectedBlocks });
+          checkReportRows.push({ sheetName: activeSheetName, title: reportTitle, rangeAddress: rangeAddr, status: "checked", message: `Строк: ${summary.rowCount}. Блоков: ${summary.detectedBlocks}. Баз: ${summary.baseRows}.`, selectedBase: item.selectedBaseSubtypeLabel || "", metricTypes: checkMetricTypesFromBlocks(calculationBlocks), warnings: qualitySummary.warningCount, critical: qualitySummary.criticalCount, warningDetails: issueDetails, blocksProcessed: summary.detectedBlocks });
         } else if (checkResult.status === "blocked") {
           candidateLines.push(`   Доступен — проверка заблокирована: ${checkResult.message}`);
-          checkReportRows.push({ sheetName: activeSheetName, title: displayTitle || "", rangeAddress: rangeAddr, status: "blocked", message: checkResult.message || "", selectedBase: item.selectedBaseSubtypeLabel || "", metricTypes: runReportMetricTypes(item), warnings: item.warningsCount ?? "", critical: item.criticalCount ?? "", warningDetails: runReportWarningDetails(item), blocksProcessed: 0 });
+          checkReportRows.push({ sheetName: activeSheetName, title: reportTitle, rangeAddress: rangeAddr, status: "blocked", message: checkResult.message || "", selectedBase: item.selectedBaseSubtypeLabel || "", metricTypes: runReportMetricTypes(item), warnings: item.warningsCount ?? "", critical: item.criticalCount ?? "", warningDetails: runReportWarningDetails(item), blocksProcessed: 0 });
         } else {
           candidateLines.push(
             `   Доступен — проверка пропущена: ${checkResult.message || "неизвестная причина"}`
           );
-          checkReportRows.push({ sheetName: activeSheetName, title: displayTitle || "", rangeAddress: rangeAddr, status: "skipped", message: checkResult.message || "Пропущено", selectedBase: item.selectedBaseSubtypeLabel || "", metricTypes: runReportMetricTypes(item), warnings: item.warningsCount ?? "", critical: item.criticalCount ?? "", warningDetails: runReportWarningDetails(item), blocksProcessed: "" });
+          checkReportRows.push({ sheetName: activeSheetName, title: reportTitle, rangeAddress: rangeAddr, status: "skipped", message: checkResult.message || "Пропущено", selectedBase: item.selectedBaseSubtypeLabel || "", metricTypes: runReportMetricTypes(item), warnings: item.warningsCount ?? "", critical: item.criticalCount ?? "", warningDetails: runReportWarningDetails(item), blocksProcessed: "" });
         }
       } catch (err) {
         candidateLines.push(
           `   Доступен — ошибка при проверке: ${err.message || "неизвестная ошибка"}`
         );
-        checkReportRows.push({ sheetName: activeSheetName, title: displayTitle || "", rangeAddress: rangeAddr, status: "error", message: err.message || "неизвестная ошибка", selectedBase: item.selectedBaseSubtypeLabel || "", metricTypes: runReportMetricTypes(item), warnings: item.warningsCount ?? "", critical: item.criticalCount ?? "", warningDetails: runReportWarningDetails(item), blocksProcessed: "" });
+        checkReportRows.push({ sheetName: activeSheetName, title: reportTitle, rangeAddress: rangeAddr, status: "error", message: err.message || "неизвестная ошибка", selectedBase: item.selectedBaseSubtypeLabel || "", metricTypes: runReportMetricTypes(item), warnings: item.warningsCount ?? "", critical: item.criticalCount ?? "", warningDetails: runReportWarningDetails(item), blocksProcessed: "" });
       }
 
       if (item.previewSummary) candidateLines.push(`   ${item.previewSummary}.`);
@@ -2265,7 +2266,7 @@ async function runCurrentSheetCheck() {
       // Unknown / future status — report without attempting check.
       missingCount++;
       candidateLines.push(`   Пропущено — статус «${item.candidateStatus || "unknown"}».`);
-      checkReportRows.push({ sheetName: activeSheetName, title: displayTitle || "", rangeAddress: rangeAddr, status: "skipped", message: `Статус «${item.candidateStatus || "unknown"}»`, selectedBase: item.selectedBaseSubtypeLabel || "", metricTypes: runReportMetricTypes(item), warnings: item.warningsCount ?? "", critical: item.criticalCount ?? "", warningDetails: runReportWarningDetails(item), blocksProcessed: "" });
+      checkReportRows.push({ sheetName: activeSheetName, title: reportTitle, rangeAddress: rangeAddr, status: "skipped", message: `Статус «${item.candidateStatus || "unknown"}»`, selectedBase: item.selectedBaseSubtypeLabel || "", metricTypes: runReportMetricTypes(item), warnings: item.warningsCount ?? "", critical: item.criticalCount ?? "", warningDetails: runReportWarningDetails(item), blocksProcessed: "" });
     }
   }
 
@@ -2325,17 +2326,20 @@ async function runWorkbookCheck() {
   ];
 
   const checkReportRows = [];
+  let globalItemIndex = 0;
 
   for (const sheetResult of sheetResults) {
     summaryLines.push("");
     summaryLines.push(`Лист: ${sheetResult.sheetName}`);
 
     for (let i = 0; i < sheetResult.items.length; i++) {
+      globalItemIndex++;
       const item = sheetResult.items[i];
       const rangeAddr = item.resolvedRangeAddress || item.rangeAddress || null;
       const displayTitle =
         item.resolvedTitle ||
         (item.title && !isGeneratedBacklinkRow(item.title) ? item.title : null);
+      const reportTitle = resolveContentDisplayTitle(item, globalItemIndex);
       const header = displayTitle
         ? `  ${i + 1}. ${displayTitle} — ${rangeAddr || "?"}`
         : `  ${i + 1}. ${rangeAddr || "?"}`;
@@ -2347,16 +2351,16 @@ async function runWorkbookCheck() {
         if (item.warningsCount > 0) warnParts.push(`Предупреждений: ${item.warningsCount}`);
         const warnStr = warnParts.length > 0 ? ` ${warnParts.join(". ")}.` : "";
         summaryLines.push(`     Доступен.${warnStr}`);
-        checkReportRows.push({ sheetName: sheetResult.sheetName, title: displayTitle || "", rangeAddress: rangeAddr || "", status: "checked", message: "Кандидат найден (сканирование книги).", selectedBase: item.selectedBaseSubtypeLabel || "", metricTypes: runReportMetricTypes(item), warnings: item.warningsCount ?? "", critical: item.criticalCount ?? "", warningDetails: runReportWarningDetails(item), blocksProcessed: "" });
+        checkReportRows.push({ sheetName: sheetResult.sheetName, title: reportTitle, rangeAddress: rangeAddr || "", status: "checked", message: "Кандидат найден (сканирование книги).", selectedBase: item.selectedBaseSubtypeLabel || "", metricTypes: runReportMetricTypes(item), warnings: item.warningsCount ?? "", critical: item.criticalCount ?? "", warningDetails: runReportWarningDetails(item), blocksProcessed: "" });
       } else if (item.candidateStatus === "uncertain") {
         summaryLines.push("     Неопределён — граница данных неоднозначна.");
-        checkReportRows.push({ sheetName: sheetResult.sheetName, title: displayTitle || "", rangeAddress: rangeAddr || "", status: "skipped", message: "Граница данных неоднозначна", selectedBase: item.selectedBaseSubtypeLabel || "", metricTypes: runReportMetricTypes(item), warnings: item.warningsCount ?? "", critical: item.criticalCount ?? "", warningDetails: runReportWarningDetails(item), blocksProcessed: "" });
+        checkReportRows.push({ sheetName: sheetResult.sheetName, title: reportTitle, rangeAddress: rangeAddr || "", status: "skipped", message: "Граница данных неоднозначна", selectedBase: item.selectedBaseSubtypeLabel || "", metricTypes: runReportMetricTypes(item), warnings: item.warningsCount ?? "", critical: item.criticalCount ?? "", warningDetails: runReportWarningDetails(item), blocksProcessed: "" });
       } else if (item.candidateStatus === "rejected") {
         summaryLines.push("     Отклонён — не опознан как таблица ResearchSignal.");
-        checkReportRows.push({ sheetName: sheetResult.sheetName, title: displayTitle || "", rangeAddress: rangeAddr || "", status: "skipped", message: "Не опознан как таблица", selectedBase: item.selectedBaseSubtypeLabel || "", metricTypes: runReportMetricTypes(item), warnings: item.warningsCount ?? "", critical: item.criticalCount ?? "", warningDetails: runReportWarningDetails(item), blocksProcessed: "" });
+        checkReportRows.push({ sheetName: sheetResult.sheetName, title: reportTitle, rangeAddress: rangeAddr || "", status: "skipped", message: "Не опознан как таблица", selectedBase: item.selectedBaseSubtypeLabel || "", metricTypes: runReportMetricTypes(item), warnings: item.warningsCount ?? "", critical: item.criticalCount ?? "", warningDetails: runReportWarningDetails(item), blocksProcessed: "" });
       } else {
         summaryLines.push(`     Пропущено — статус «${item.candidateStatus || "unknown"}».`);
-        checkReportRows.push({ sheetName: sheetResult.sheetName, title: displayTitle || "", rangeAddress: rangeAddr || "", status: "skipped", message: `Статус «${item.candidateStatus || "unknown"}»`, selectedBase: item.selectedBaseSubtypeLabel || "", metricTypes: runReportMetricTypes(item), warnings: item.warningsCount ?? "", critical: item.criticalCount ?? "", warningDetails: runReportWarningDetails(item), blocksProcessed: "" });
+        checkReportRows.push({ sheetName: sheetResult.sheetName, title: reportTitle, rangeAddress: rangeAddr || "", status: "skipped", message: `Статус «${item.candidateStatus || "unknown"}»`, selectedBase: item.selectedBaseSubtypeLabel || "", metricTypes: runReportMetricTypes(item), warnings: item.warningsCount ?? "", critical: item.criticalCount ?? "", warningDetails: runReportWarningDetails(item), blocksProcessed: "" });
       }
 
       if (item.previewSummary) summaryLines.push(`     ${item.previewSummary}.`);

--- a/src/taskpane/taskpane.js
+++ b/src/taskpane/taskpane.js
@@ -418,6 +418,10 @@ Office.onReady((info) => {
     checkSheetTablesButton.addEventListener("click", runCurrentSheetCheck);
   }
 
+  document.getElementById("export-check-result-table")?.addEventListener("click", runExportCheckResult);
+  document.getElementById("export-check-result-sheet")?.addEventListener("click", runExportCheckResult);
+  document.getElementById("export-check-result-workbook")?.addEventListener("click", runExportCheckResult);
+
   const contentFindTablesButton = document.getElementById("content-find-tables");
 
   if (contentFindTablesButton) {
@@ -441,6 +445,7 @@ function initPanelDismiss() {
 
 let _currentAction = "run";
 let _currentScope = "current_table";
+let _lastCheckRows = null; // { rows: [...], label: string } — populated by each Check action
 
 function updateActionScopeShell(action, scope) {
   // Update action tab active states
@@ -1065,6 +1070,7 @@ function runReportSkipReasonLabel(reason) {
 function runReportStatusLabel(status) {
   switch (status) {
     case "processed": return "Обработано";
+    case "checked":   return "Проверено";
     case "skipped":   return "Пропущено";
     case "blocked":   return "Пропущено";
     case "error":     return "Ошибка";
@@ -1096,6 +1102,21 @@ function runReportWarningDetails(item) {
     parts.push(...item.candidateNotes);
   }
   return parts.join("; ");
+}
+
+function checkMetricTypesFromBlocks(calculationBlocks) {
+  if (!calculationBlocks || calculationBlocks.length === 0) return "";
+  let hasProportions = false, hasMeans = false, hasNps = false;
+  for (const block of calculationBlocks) {
+    if (block.metricType === "proportion") hasProportions = true;
+    else if (block.metricType === "mean") hasMeans = true;
+    else if (block.metricType === "nps") hasNps = true;
+  }
+  const parts = [];
+  if (hasProportions) parts.push("Пропорции");
+  if (hasMeans) parts.push("Средние");
+  if (hasNps) parts.push("NPS");
+  return parts.join(", ");
 }
 
 const RUN_REPORT_COLUMNS = [
@@ -2088,6 +2109,7 @@ async function checkTableForRange(sheetName, rangeAddress, calculationSettings) 
  * the active sheet only.
  */
 async function runCurrentSheetCheck() {
+  _lastCheckRows = null;
   const calculationSettings = readCalculationSettingsFromPanel();
 
   let inventoryResults;
@@ -2146,6 +2168,7 @@ async function runCurrentSheetCheck() {
   let missingCount = 0;
 
   const candidateLines = [];
+  const checkReportRows = [];
 
   for (let i = 0; i < allItems.length; i++) {
     const item = allItems[i];
@@ -2163,6 +2186,7 @@ async function runCurrentSheetCheck() {
     if (!rangeAddr) {
       missingCount++;
       candidateLines.push("   Пропущено — нет диапазона.");
+      checkReportRows.push({ sheetName: activeSheetName, title: displayTitle || "", rangeAddress: "", status: "skipped", message: "Нет диапазона", selectedBase: item.selectedBaseSubtypeLabel || "", metricTypes: runReportMetricTypes(item), warnings: item.warningsCount ?? "", critical: item.criticalCount ?? "", warningDetails: runReportWarningDetails(item), blocksProcessed: "" });
       continue;
     }
 
@@ -2173,6 +2197,7 @@ async function runCurrentSheetCheck() {
       if (item.candidateNotes && item.candidateNotes.length > 0) {
         candidateLines.push(`   [${item.candidateNotes.join("; ")}]`);
       }
+      checkReportRows.push({ sheetName: activeSheetName, title: displayTitle || "", rangeAddress: rangeAddr, status: "skipped", message: "Не опознан как таблица", selectedBase: item.selectedBaseSubtypeLabel || "", metricTypes: runReportMetricTypes(item), warnings: item.warningsCount ?? "", critical: item.criticalCount ?? "", warningDetails: runReportWarningDetails(item), blocksProcessed: "" });
       continue;
     }
 
@@ -2183,6 +2208,7 @@ async function runCurrentSheetCheck() {
       if (item.candidateNotes && item.candidateNotes.length > 0) {
         candidateLines.push(`   [${item.candidateNotes.join("; ")}]`);
       }
+      checkReportRows.push({ sheetName: activeSheetName, title: displayTitle || "", rangeAddress: rangeAddr, status: "skipped", message: "Граница данных неоднозначна", selectedBase: item.selectedBaseSubtypeLabel || "", metricTypes: runReportMetricTypes(item), warnings: item.warningsCount ?? "", critical: item.criticalCount ?? "", warningDetails: runReportWarningDetails(item), blocksProcessed: "" });
       continue;
     }
 
@@ -2197,7 +2223,7 @@ async function runCurrentSheetCheck() {
         );
 
         if (checkResult.status === "checked") {
-          const { summary, qualitySummary } = checkResult.model;
+          const { summary, qualitySummary, userVisibleIssues, calculationBlocks } = checkResult.model;
           candidateLines.push("   Доступен.");
           candidateLines.push(
             `   ${item.rowCount ?? summary.rowCount} строк, ${item.columnCount ?? ""} колонок.` +
@@ -2209,17 +2235,22 @@ async function runCurrentSheetCheck() {
           if (qualitySummary.warningCount > 0)
             warnParts.push(`Предупреждений: ${qualitySummary.warningCount}`);
           if (warnParts.length > 0) candidateLines.push(`   ${warnParts.join(". ")}.`);
+          const issueDetails = (userVisibleIssues || []).map((iss) => `[${iss.severity}] ${iss.message}`).join("; ");
+          checkReportRows.push({ sheetName: activeSheetName, title: displayTitle || "", rangeAddress: rangeAddr, status: "checked", message: `Строк: ${summary.rowCount}. Блоков: ${summary.detectedBlocks}. Баз: ${summary.baseRows}.`, selectedBase: item.selectedBaseSubtypeLabel || "", metricTypes: checkMetricTypesFromBlocks(calculationBlocks), warnings: qualitySummary.warningCount, critical: qualitySummary.criticalCount, warningDetails: issueDetails, blocksProcessed: summary.detectedBlocks });
         } else if (checkResult.status === "blocked") {
           candidateLines.push(`   Доступен — проверка заблокирована: ${checkResult.message}`);
+          checkReportRows.push({ sheetName: activeSheetName, title: displayTitle || "", rangeAddress: rangeAddr, status: "blocked", message: checkResult.message || "", selectedBase: item.selectedBaseSubtypeLabel || "", metricTypes: runReportMetricTypes(item), warnings: item.warningsCount ?? "", critical: item.criticalCount ?? "", warningDetails: runReportWarningDetails(item), blocksProcessed: 0 });
         } else {
           candidateLines.push(
             `   Доступен — проверка пропущена: ${checkResult.message || "неизвестная причина"}`
           );
+          checkReportRows.push({ sheetName: activeSheetName, title: displayTitle || "", rangeAddress: rangeAddr, status: "skipped", message: checkResult.message || "Пропущено", selectedBase: item.selectedBaseSubtypeLabel || "", metricTypes: runReportMetricTypes(item), warnings: item.warningsCount ?? "", critical: item.criticalCount ?? "", warningDetails: runReportWarningDetails(item), blocksProcessed: "" });
         }
       } catch (err) {
         candidateLines.push(
           `   Доступен — ошибка при проверке: ${err.message || "неизвестная ошибка"}`
         );
+        checkReportRows.push({ sheetName: activeSheetName, title: displayTitle || "", rangeAddress: rangeAddr, status: "error", message: err.message || "неизвестная ошибка", selectedBase: item.selectedBaseSubtypeLabel || "", metricTypes: runReportMetricTypes(item), warnings: item.warningsCount ?? "", critical: item.criticalCount ?? "", warningDetails: runReportWarningDetails(item), blocksProcessed: "" });
       }
 
       if (item.previewSummary) candidateLines.push(`   ${item.previewSummary}.`);
@@ -2230,6 +2261,7 @@ async function runCurrentSheetCheck() {
       // Unknown / future status — report without attempting check.
       missingCount++;
       candidateLines.push(`   Пропущено — статус «${item.candidateStatus || "unknown"}».`);
+      checkReportRows.push({ sheetName: activeSheetName, title: displayTitle || "", rangeAddress: rangeAddr, status: "skipped", message: `Статус «${item.candidateStatus || "unknown"}»`, selectedBase: item.selectedBaseSubtypeLabel || "", metricTypes: runReportMetricTypes(item), warnings: item.warningsCount ?? "", critical: item.criticalCount ?? "", warningDetails: runReportWarningDetails(item), blocksProcessed: "" });
     }
   }
 
@@ -2243,6 +2275,11 @@ async function runCurrentSheetCheck() {
   summaryLines.push("Данные не изменены.");
 
   setCheckMessage(summaryLines.join("\n"));
+
+  _lastCheckRows = {
+    label: "Проверка — Текущий лист",
+    rows: checkReportRows,
+  };
 }
 
 /**
@@ -2256,6 +2293,7 @@ async function runCurrentSheetCheck() {
  * the Content sheet.
  */
 async function runWorkbookCheck() {
+  _lastCheckRows = null;
   const calculationSettings = readCalculationSettingsFromPanel();
 
   let inventoryResults;
@@ -2276,6 +2314,8 @@ async function runWorkbookCheck() {
     `Книга — проверка: просканировано листов: ${scannedSheets}.`,
     `Кандидатов найдено: ${totalCandidates}.`,
   ];
+
+  const checkReportRows = [];
 
   for (const sheetResult of sheetResults) {
     summaryLines.push("");
@@ -2298,12 +2338,16 @@ async function runWorkbookCheck() {
         if (item.warningsCount > 0) warnParts.push(`Предупреждений: ${item.warningsCount}`);
         const warnStr = warnParts.length > 0 ? ` ${warnParts.join(". ")}.` : "";
         summaryLines.push(`     Доступен.${warnStr}`);
+        checkReportRows.push({ sheetName: sheetResult.sheetName, title: displayTitle || "", rangeAddress: rangeAddr || "", status: "checked", message: "Кандидат найден (сканирование книги).", selectedBase: item.selectedBaseSubtypeLabel || "", metricTypes: runReportMetricTypes(item), warnings: item.warningsCount ?? "", critical: item.criticalCount ?? "", warningDetails: runReportWarningDetails(item), blocksProcessed: "" });
       } else if (item.candidateStatus === "uncertain") {
         summaryLines.push("     Неопределён — граница данных неоднозначна.");
+        checkReportRows.push({ sheetName: sheetResult.sheetName, title: displayTitle || "", rangeAddress: rangeAddr || "", status: "skipped", message: "Граница данных неоднозначна", selectedBase: item.selectedBaseSubtypeLabel || "", metricTypes: runReportMetricTypes(item), warnings: item.warningsCount ?? "", critical: item.criticalCount ?? "", warningDetails: runReportWarningDetails(item), blocksProcessed: "" });
       } else if (item.candidateStatus === "rejected") {
         summaryLines.push("     Отклонён — не опознан как таблица ResearchSignal.");
+        checkReportRows.push({ sheetName: sheetResult.sheetName, title: displayTitle || "", rangeAddress: rangeAddr || "", status: "skipped", message: "Не опознан как таблица", selectedBase: item.selectedBaseSubtypeLabel || "", metricTypes: runReportMetricTypes(item), warnings: item.warningsCount ?? "", critical: item.criticalCount ?? "", warningDetails: runReportWarningDetails(item), blocksProcessed: "" });
       } else {
         summaryLines.push(`     Пропущено — статус «${item.candidateStatus || "unknown"}».`);
+        checkReportRows.push({ sheetName: sheetResult.sheetName, title: displayTitle || "", rangeAddress: rangeAddr || "", status: "skipped", message: `Статус «${item.candidateStatus || "unknown"}»`, selectedBase: item.selectedBaseSubtypeLabel || "", metricTypes: runReportMetricTypes(item), warnings: item.warningsCount ?? "", critical: item.criticalCount ?? "", warningDetails: runReportWarningDetails(item), blocksProcessed: "" });
       }
 
       if (item.previewSummary) summaryLines.push(`     ${item.previewSummary}.`);
@@ -2331,6 +2375,11 @@ async function runWorkbookCheck() {
   summaryLines.push("Данные не изменены. Для детальной проверки используйте «Проверка → Текущий лист».");
 
   setCheckMessage(summaryLines.join("\n"));
+
+  _lastCheckRows = {
+    label: "Проверка — Вся книга",
+    rows: checkReportRows,
+  };
 }
 
 /**
@@ -2666,6 +2715,31 @@ async function runMetricDetectionDiagnostics() {
 }
 
 /**
+ * Exports the most recent Check result to the Run report sheet.
+ * Reads from _lastCheckRows (populated by each Check action) and calls
+ * writeRunReportSheet. Does not re-run significance or modify source data.
+ */
+async function runExportCheckResult() {
+  if (!_lastCheckRows || _lastCheckRows.rows.length === 0) {
+    setCheckMessage("Нет результатов проверки для записи. Сначала выполните проверку.");
+    return;
+  }
+  try {
+    await Excel.run(async (context) => {
+      await writeRunReportSheet(context, _lastCheckRows.rows, _lastCheckRows.label);
+    });
+    const checkResult = document.getElementById("check-result");
+    if (checkResult && checkResult.textContent) {
+      checkResult.textContent += "\n\nРезультат записан в лист «Run report».";
+    } else {
+      setCheckMessage("Результат записан в лист «Run report».");
+    }
+  } catch (err) {
+    setCheckMessage(`Ошибка при записи результата: ${err.message || err}`);
+  }
+}
+
+/**
  * Reads selected range and calls buildTablePreviewModel to display a short summary.
  *
  * Read-only: does not write to Excel, does not calculate significance.
@@ -2676,13 +2750,19 @@ async function runMetricDetectionDiagnostics() {
  *   3. blocked       — broad selection but decomposition failed; early return with message.
  */
 async function runCheckTable() {
+  _lastCheckRows = null;
   await Excel.run(async (context) => {
     const calculationSettings = readCalculationSettingsFromPanel();
     const selectedRange = context.workbook.getSelectedRange();
 
-    selectedRange.load(["values", "text", "rowIndex", "columnIndex", "rowCount", "columnCount"]);
+    selectedRange.load(["values", "text", "rowIndex", "columnIndex", "rowCount", "columnCount", "address"]);
+    selectedRange.worksheet.load("name");
 
     await context.sync();
+
+    const reportSheetName = selectedRange.worksheet.name;
+    const rawAddress = selectedRange.address;
+    const reportAddress = rawAddress.includes("!") ? rawAddress.split("!")[1] : rawAddress;
 
     const selectedValues = selectedRange.values;
     const selectedText = selectedRange.text;
@@ -2710,7 +2790,12 @@ async function runCheckTable() {
         interpretation.blockingReasons.length > 0
           ? ` [${interpretation.blockingReasons.join(", ")}]`
           : "";
-      setCheckMessage(`${interpretation.blockingMessage}${codes}`);
+      const msg = `${interpretation.blockingMessage}${codes}`;
+      setCheckMessage(msg);
+      _lastCheckRows = {
+        label: "Проверка — Текущая таблица",
+        rows: [{ sheetName: reportSheetName, title: "", rangeAddress: reportAddress, status: "blocked", message: msg, selectedBase: "", metricTypes: "", warnings: 0, critical: 0, warningDetails: "", blocksProcessed: 0 }],
+      };
       return;
     }
 
@@ -2783,6 +2868,26 @@ async function runCheckTable() {
     }
 
     setCheckMessage(lines.join("\n"));
+
+    const warningDetails = (userVisibleIssues || [])
+      .map((iss) => `[${iss.severity}] ${iss.message}`)
+      .join("; ");
+    _lastCheckRows = {
+      label: "Проверка — Текущая таблица",
+      rows: [{
+        sheetName: reportSheetName,
+        title: "",
+        rangeAddress: reportAddress,
+        status: "checked",
+        message: `Строк: ${summary.rowCount}. Блоков: ${summary.detectedBlocks}. Баз: ${summary.baseRows}.`,
+        selectedBase: "",
+        metricTypes: checkMetricTypesFromBlocks(calculationBlocks),
+        warnings: qualitySummary.warningCount,
+        critical: qualitySummary.criticalCount,
+        warningDetails,
+        blocksProcessed: summary.detectedBlocks,
+      }],
+    };
   });
 }
 

--- a/src/taskpane/taskpane.js
+++ b/src/taskpane/taskpane.js
@@ -445,7 +445,7 @@ function initPanelDismiss() {
 
 let _currentAction = "run";
 let _currentScope = "current_table";
-let _lastCheckRows = null; // { rows: [...], label: string } — populated by each Check action
+let _lastCheckRows = null; // { scope, rows, label } — populated by each Check action; scope guards against stale cross-scope export
 
 function updateActionScopeShell(action, scope) {
   // Update action tab active states
@@ -2277,6 +2277,7 @@ async function runCurrentSheetCheck() {
   setCheckMessage(summaryLines.join("\n"));
 
   _lastCheckRows = {
+    scope: "current_sheet",
     label: "Проверка — Текущий лист",
     rows: checkReportRows,
   };
@@ -2377,6 +2378,7 @@ async function runWorkbookCheck() {
   setCheckMessage(summaryLines.join("\n"));
 
   _lastCheckRows = {
+    scope: "whole_workbook",
     label: "Проверка — Вся книга",
     rows: checkReportRows,
   };
@@ -2720,7 +2722,11 @@ async function runMetricDetectionDiagnostics() {
  * writeRunReportSheet. Does not re-run significance or modify source data.
  */
 async function runExportCheckResult() {
-  if (!_lastCheckRows || _lastCheckRows.rows.length === 0) {
+  if (
+    !_lastCheckRows ||
+    _lastCheckRows.scope !== _currentScope ||
+    _lastCheckRows.rows.length === 0
+  ) {
     setCheckMessage("Нет результатов проверки для записи. Сначала выполните проверку.");
     return;
   }
@@ -2793,6 +2799,7 @@ async function runCheckTable() {
       const msg = `${interpretation.blockingMessage}${codes}`;
       setCheckMessage(msg);
       _lastCheckRows = {
+        scope: "current_table",
         label: "Проверка — Текущая таблица",
         rows: [{ sheetName: reportSheetName, title: "", rangeAddress: reportAddress, status: "blocked", message: msg, selectedBase: "", metricTypes: "", warnings: 0, critical: 0, warningDetails: "", blocksProcessed: 0 }],
       };
@@ -2873,6 +2880,7 @@ async function runCheckTable() {
       .map((iss) => `[${iss.severity}] ${iss.message}`)
       .join("; ");
     _lastCheckRows = {
+      scope: "current_table",
       label: "Проверка — Текущая таблица",
       rows: [{
         sheetName: reportSheetName,

--- a/src/taskpane/taskpane.js
+++ b/src/taskpane/taskpane.js
@@ -418,10 +418,6 @@ Office.onReady((info) => {
     checkSheetTablesButton.addEventListener("click", runCurrentSheetCheck);
   }
 
-  document.getElementById("export-check-result-table")?.addEventListener("click", runExportCheckResult);
-  document.getElementById("export-check-result-sheet")?.addEventListener("click", runExportCheckResult);
-  document.getElementById("export-check-result-workbook")?.addEventListener("click", runExportCheckResult);
-
   const contentFindTablesButton = document.getElementById("content-find-tables");
 
   if (contentFindTablesButton) {
@@ -445,7 +441,10 @@ function initPanelDismiss() {
 
 let _currentAction = "run";
 let _currentScope = "current_table";
-let _lastCheckRows = null; // { scope, rows, label } — populated by each Check action; scope guards against stale cross-scope export
+function isCheckReportEnabled() {
+  const cb = document.getElementById("check-add-report");
+  return cb ? cb.checked : false;
+}
 
 function updateActionScopeShell(action, scope) {
   // Update action tab active states
@@ -477,6 +476,12 @@ function updateActionScopeShell(action, scope) {
   if (runReportControl) {
     runReportControl.style.display =
       action === "run" && scope !== "current_table" ? "" : "none";
+  }
+
+  // Show check-add-report for all Check scopes
+  const checkReportControl = document.getElementById("check-report-control");
+  if (checkReportControl) {
+    checkReportControl.style.display = action === "check" ? "" : "none";
   }
 
 }
@@ -2109,7 +2114,6 @@ async function checkTableForRange(sheetName, rangeAddress, calculationSettings) 
  * the active sheet only.
  */
 async function runCurrentSheetCheck() {
-  _lastCheckRows = null;
   const calculationSettings = readCalculationSettingsFromPanel();
 
   let inventoryResults;
@@ -2276,11 +2280,16 @@ async function runCurrentSheetCheck() {
 
   setCheckMessage(summaryLines.join("\n"));
 
-  _lastCheckRows = {
-    scope: "current_sheet",
-    label: "Проверка — Текущий лист",
-    rows: checkReportRows,
-  };
+  if (isCheckReportEnabled() && checkReportRows.length > 0) {
+    try {
+      await Excel.run(async (context) => {
+        await writeRunReportSheet(context, checkReportRows, "Проверка — Текущий лист");
+      });
+    } catch (reportErr) {
+      const el = document.getElementById("check-result");
+      if (el) el.textContent += `\n\n[Run report: ошибка записи — ${reportErr.message || reportErr}]`;
+    }
+  }
 }
 
 /**
@@ -2294,7 +2303,6 @@ async function runCurrentSheetCheck() {
  * the Content sheet.
  */
 async function runWorkbookCheck() {
-  _lastCheckRows = null;
   const calculationSettings = readCalculationSettingsFromPanel();
 
   let inventoryResults;
@@ -2377,11 +2385,16 @@ async function runWorkbookCheck() {
 
   setCheckMessage(summaryLines.join("\n"));
 
-  _lastCheckRows = {
-    scope: "whole_workbook",
-    label: "Проверка — Вся книга",
-    rows: checkReportRows,
-  };
+  if (isCheckReportEnabled() && checkReportRows.length > 0) {
+    try {
+      await Excel.run(async (context) => {
+        await writeRunReportSheet(context, checkReportRows, "Проверка — Вся книга");
+      });
+    } catch (reportErr) {
+      const el = document.getElementById("check-result");
+      if (el) el.textContent += `\n\n[Run report: ошибка записи — ${reportErr.message || reportErr}]`;
+    }
+  }
 }
 
 /**
@@ -2717,35 +2730,6 @@ async function runMetricDetectionDiagnostics() {
 }
 
 /**
- * Exports the most recent Check result to the Run report sheet.
- * Reads from _lastCheckRows (populated by each Check action) and calls
- * writeRunReportSheet. Does not re-run significance or modify source data.
- */
-async function runExportCheckResult() {
-  if (
-    !_lastCheckRows ||
-    _lastCheckRows.scope !== _currentScope ||
-    _lastCheckRows.rows.length === 0
-  ) {
-    setCheckMessage("Нет результатов проверки для записи. Сначала выполните проверку.");
-    return;
-  }
-  try {
-    await Excel.run(async (context) => {
-      await writeRunReportSheet(context, _lastCheckRows.rows, _lastCheckRows.label);
-    });
-    const checkResult = document.getElementById("check-result");
-    if (checkResult && checkResult.textContent) {
-      checkResult.textContent += "\n\nРезультат записан в лист «Run report».";
-    } else {
-      setCheckMessage("Результат записан в лист «Run report».");
-    }
-  } catch (err) {
-    setCheckMessage(`Ошибка при записи результата: ${err.message || err}`);
-  }
-}
-
-/**
  * Reads selected range and calls buildTablePreviewModel to display a short summary.
  *
  * Read-only: does not write to Excel, does not calculate significance.
@@ -2756,7 +2740,6 @@ async function runExportCheckResult() {
  *   3. blocked       — broad selection but decomposition failed; early return with message.
  */
 async function runCheckTable() {
-  _lastCheckRows = null;
   await Excel.run(async (context) => {
     const calculationSettings = readCalculationSettingsFromPanel();
     const selectedRange = context.workbook.getSelectedRange();
@@ -2798,11 +2781,9 @@ async function runCheckTable() {
           : "";
       const msg = `${interpretation.blockingMessage}${codes}`;
       setCheckMessage(msg);
-      _lastCheckRows = {
-        scope: "current_table",
-        label: "Проверка — Текущая таблица",
-        rows: [{ sheetName: reportSheetName, title: "", rangeAddress: reportAddress, status: "blocked", message: msg, selectedBase: "", metricTypes: "", warnings: 0, critical: 0, warningDetails: "", blocksProcessed: 0 }],
-      };
+      if (isCheckReportEnabled()) {
+        await writeRunReportSheet(context, [{ sheetName: reportSheetName, title: "", rangeAddress: reportAddress, status: "blocked", message: msg, selectedBase: "", metricTypes: "", warnings: 0, critical: 0, warningDetails: "", blocksProcessed: 0 }], "Проверка — Текущая таблица");
+      }
       return;
     }
 
@@ -2876,13 +2857,11 @@ async function runCheckTable() {
 
     setCheckMessage(lines.join("\n"));
 
-    const warningDetails = (userVisibleIssues || [])
-      .map((iss) => `[${iss.severity}] ${iss.message}`)
-      .join("; ");
-    _lastCheckRows = {
-      scope: "current_table",
-      label: "Проверка — Текущая таблица",
-      rows: [{
+    if (isCheckReportEnabled()) {
+      const warningDetails = (userVisibleIssues || [])
+        .map((iss) => `[${iss.severity}] ${iss.message}`)
+        .join("; ");
+      await writeRunReportSheet(context, [{
         sheetName: reportSheetName,
         title: "",
         rangeAddress: reportAddress,
@@ -2894,8 +2873,8 @@ async function runCheckTable() {
         critical: qualitySummary.criticalCount,
         warningDetails,
         blocksProcessed: summary.detectedBlocks,
-      }],
-    };
+      }], "Проверка — Текущая таблица");
+    }
   });
 }
 


### PR DESCRIPTION
## Summary

Closes #201. Part of #192.

- Adds a shared Check option: `Записать результат`.
- The option is a checkbox shown for all Check scopes.
- Check hints update dynamically:
  - unchecked: `Только чтение`
  - checked: `С записью на лист`
- When unchecked, Check remains in-panel only.
- When checked, the same Check action also writes/updates `Run report`.
- Reuses existing Run report sheet creation/reuse behavior.
- Does not run significance and does not modify source data tables.
- Aligns Check panel and Check → Run report table-title fallback with Content: no-real-title and total/banner-like labels such as `Всего` use neutral `Таблица N` fallback.

## Files changed

- `src/taskpane/taskpane.html`
- `src/taskpane/taskpane.js`

## Test/build result

- `npm test`: 240/240 pass
- `npm run build`: success, pre-existing size warnings only
- `git diff --check`: clean

## Notes

- Current-table Check writes a deep Check result for the selected range when the checkbox is enabled. Its table title may remain blank because there is no safe inventory title lookup for the selected range in this PR.
- Current-sheet Check writes per-candidate Check results for the active sheet when enabled.
- Workbook-scope export uses inventory-level data only, not per-table deep Check.
- Reporting details enrichment remains a later #192 slice.