### PR TITLE
#203 Show human-readable issue details in Run report and Content check

### DIFF
--- a/src/core/table-inventory-scanner.js
+++ b/src/core/table-inventory-scanner.js
@@ -588,6 +588,19 @@ function buildTableInventoryItem({ band, model, titleInfo, rangeAddress, sheetNa
     ? (dataQualityIssues || []).map((i) => ({ code: i.code, severity: i.severity }))
     : [];
 
+  // Full issue objects (critical + warning) sorted by severity then rowIndex.
+  // Used for human-readable diagnostic details in Run report and Content check.
+  const userVisibleIssues = isLikelyTable
+    ? (dataQualityIssues || [])
+        .filter((i) => i.severity === "critical" || i.severity === "warning")
+        .sort((a, b) => {
+          const rank = { critical: 0, warning: 1 };
+          const sd = (rank[a.severity] ?? 99) - (rank[b.severity] ?? 99);
+          if (sd !== 0) return sd;
+          return (a.rowIndex ?? Number.MAX_SAFE_INTEGER) - (b.rowIndex ?? Number.MAX_SAFE_INTEGER);
+        })
+    : [];
+
   return {
     tableId,
     sheetName,
@@ -607,6 +620,7 @@ function buildTableInventoryItem({ band, model, titleInfo, rangeAddress, sheetNa
     warningsCount: isLikelyTable ? qualitySummary.warningCount : 0,
     criticalCount: isLikelyTable ? qualitySummary.criticalCount : 0,
     qualityIssueCodes,
+    userVisibleIssues,
     availabilityWarningCount,
     hasBlockingIssues: qualitySummary.hasBlockingIssues,
     detectedMetricRows: summary.detectedMetricRows ?? 0,

--- a/src/taskpane/taskpane.js
+++ b/src/taskpane/taskpane.js
@@ -1104,14 +1104,20 @@ function runReportMetricTypes(item) {
 }
 
 /**
- * Builds a compact warning-detail string from scanner-side item metadata.
- * Uses qualityIssueCodes (code identifiers) and candidateNotes (human-readable).
- * Returns an empty string when there is nothing to report.
+ * Builds a human-readable warning-detail string for the Run report Details column.
+ *
+ * Prefers userVisibleIssues (full issue objects with message and location) when
+ * available. Falls back to qualityIssueCodes (code-only) for older item shapes.
+ * candidateNotes (structural candidate diagnostics) are appended after issue lines.
  */
 function runReportWarningDetails(item) {
   if (!item) return "";
   const parts = [];
-  if (item.qualityIssueCodes && item.qualityIssueCodes.length > 0) {
+  if (item.userVisibleIssues && item.userVisibleIssues.length > 0) {
+    for (const iss of item.userVisibleIssues) {
+      parts.push(`[${iss.severity}] ${iss.message}`);
+    }
+  } else if (item.qualityIssueCodes && item.qualityIssueCodes.length > 0) {
     parts.push(item.qualityIssueCodes.map((q) => q.code).join(", "));
   }
   if (item.candidateNotes && item.candidateNotes.length > 0) {

--- a/src/taskpane/taskpane.js
+++ b/src/taskpane/taskpane.js
@@ -90,7 +90,7 @@ const INVENTORY_FULL_CHECK_COLUMNS = [
   "Metric types",
   "Warnings",
   "Critical",
-  "Issue codes",
+  "Issue details",
   "Notes",
   "Label split",
   "Label cols",
@@ -1104,22 +1104,36 @@ function runReportMetricTypes(item) {
 }
 
 /**
- * Builds a human-readable warning-detail string for the Run report Details column.
+ * Formats issue details from an inventory item into a human-readable string.
  *
  * Prefers userVisibleIssues (full issue objects with message and location) when
- * available. Falls back to qualityIssueCodes (code-only) for older item shapes.
- * candidateNotes (structural candidate diagnostics) are appended after issue lines.
+ * available. Falls back to qualityIssueCodes (code-only identifiers) for
+ * backward compatibility.
+ *
+ * Does NOT include candidateNotes — callers that need them append separately.
+ */
+function formatIssueDetailsForReport(item) {
+  if (!item) return "";
+  if (item.userVisibleIssues && item.userVisibleIssues.length > 0) {
+    return item.userVisibleIssues.map((iss) => `[${iss.severity}] ${iss.message}`).join("; ");
+  }
+  if (item.qualityIssueCodes && item.qualityIssueCodes.length > 0) {
+    return item.qualityIssueCodes.map((q) => q.code).join(", ");
+  }
+  return "";
+}
+
+/**
+ * Builds a human-readable warning-detail string for the Run report Details column.
+ *
+ * Uses formatIssueDetailsForReport() for issue messages, then appends
+ * candidateNotes (structural candidate diagnostics).
  */
 function runReportWarningDetails(item) {
   if (!item) return "";
   const parts = [];
-  if (item.userVisibleIssues && item.userVisibleIssues.length > 0) {
-    for (const iss of item.userVisibleIssues) {
-      parts.push(`[${iss.severity}] ${iss.message}`);
-    }
-  } else if (item.qualityIssueCodes && item.qualityIssueCodes.length > 0) {
-    parts.push(item.qualityIssueCodes.map((q) => q.code).join(", "));
-  }
+  const issueDetails = formatIssueDetailsForReport(item);
+  if (issueDetails) parts.push(issueDetails);
   if (item.candidateNotes && item.candidateNotes.length > 0) {
     parts.push(...item.candidateNotes);
   }
@@ -4085,7 +4099,7 @@ function buildFullCheckCandidateRows(sheetResults) {
         metricTypes.join(", "),
         item.warningsCount ?? 0,
         item.criticalCount ?? 0,
-        (item.qualityIssueCodes || []).map((q) => q.code).join(", "),
+        formatIssueDetailsForReport(item),
         item.candidateNotes && item.candidateNotes.length > 0 ? item.candidateNotes.join("; ") : "",
         item.labelSplitConfidence || "",
         item.labelColCount ?? "",


### PR DESCRIPTION
Closes #203

## Summary

- Run report **Details** column shows human-readable diagnostic messages instead of raw internal issue codes.
- Content **full-check** "Issue details" column (formerly "Issue codes") shows the same readable messages.
- A shared `formatIssueDetailsForReport(item)` helper drives both surfaces.

## What changed

### `src/core/table-inventory-scanner.js`

`buildTableInventoryItem()` builds and exposes `userVisibleIssues` on the inventory item — full issue objects (critical + warning) sorted by severity then `rowIndex`, sourced from `dataQualityIssues` on the preview model.

### `src/taskpane/taskpane.js`

**`formatIssueDetailsForReport(item)`** — new shared formatter:
- If `item.userVisibleIssues` is present and non-empty: formats each as `[severity] message`, joined with `"; "`.
- Falls back to joining `qualityIssueCodes` codes (backward compat) if `userVisibleIssues` is absent.
- Does not include `candidateNotes`.

**`runReportWarningDetails(item)`** — calls `formatIssueDetailsForReport(item)`, then appends `candidateNotes`.

**`buildFullCheckCandidateRows()`** — "Issue details" column uses `formatIssueDetailsForReport(item)` instead of raw code join.

**`INVENTORY_FULL_CHECK_COLUMNS`** — column header renamed from `"Issue codes"` to `"Issue details"`.

## Before / after

**Run report Details / Content full-check column:**

Before: `NUMERIC_LIKE_LABEL, BASE_BELOW_THRESHOLD`

After: `[warning] Row 3: label "Age" looks like a numeric range...; [warning] Row 5: ...`

## Test / build

- `npm test` — 240 pass, 0 fail
- `npm run build` — 0 errors
- `git diff --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)