### PR TITLE
Add Clear for Autorun current-table via active-cell resolver (#216)

### DIFF
--- a/src/taskpane/taskpane.html
+++ b/src/taskpane/taskpane.html
@@ -69,6 +69,7 @@
           <p class="run-scope-fixed">Область: активная ячейка → таблица</p>
           <div class="action-buttons-row">
             <button id="autorun-current-table" class="primary-action-button">Рассчитать</button>
+            <button id="clear-current-table" class="secondary-action-button">Очистить значимости</button>
           </div>
         </div>
 

--- a/src/taskpane/taskpane.js
+++ b/src/taskpane/taskpane.js
@@ -404,11 +404,16 @@ Office.onReady((info) => {
   }
 
   const autorunCurrentTableButton = document.getElementById("autorun-current-table");
+  const clearCurrentTableButton = document.getElementById("clear-current-table");
   const runSheetTablesButton = document.getElementById("run-sheet-tables");
   const clearSheetTablesButton = document.getElementById("clear-sheet-tables");
 
   if (autorunCurrentTableButton) {
     autorunCurrentTableButton.addEventListener("click", runAutoCurrentTableSignificance);
+  }
+
+  if (clearCurrentTableButton) {
+    clearCurrentTableButton.addEventListener("click", clearAutoCurrentTableSignificance);
   }
 
   if (runSheetTablesButton) {
@@ -1600,9 +1605,6 @@ async function runAutoSignificance() {
  * Uses the same pre-resolver selection guard as runCheckTable (#210) to block
  * broad multi-table selections before the active-cell resolver is called.
  * Delegates the significance pipeline to runSignificanceForRange.
- *
- * Clear is deferred for this scope — safely targeting only the resolved
- * active-cell table requires a separate implementation.
  */
 async function runAutoCurrentTableSignificance() {
   const calculationSettings = readCalculationSettingsFromPanel();
@@ -1777,6 +1779,76 @@ async function runAutoCurrentTableSignificance() {
     } catch (reportErr) {
       setStatusMessage(statusMsg + `\n[Отчёт: ошибка записи — ${reportErr.message || reportErr}]`);
     }
+  }
+}
+
+/**
+ * Autorun current-table Clear: resolves the table under the active cell and
+ * clears significance markers only from that resolved range.
+ *
+ * Applies the same pre-resolver selection guard as runAutoCurrentTableSignificance
+ * to block broad multi-table selections before the resolver runs. Does not touch
+ * the arbitrary selected range — the clear target is always the resolver result.
+ */
+async function clearAutoCurrentTableSignificance() {
+  let resolverResult = null;
+
+  try {
+    await Excel.run(async (context) => {
+      const selectionForGuard = context.workbook.getSelectedRange();
+      selectionForGuard.load(["values"]);
+      await context.sync();
+
+      if (selectionHasMultiTableGap(selectionForGuard.values)) {
+        resolverResult = {
+          status: "blocked",
+          sheetName: "",
+          message:
+            "Выделение содержит несколько таблиц или блоков данных, разделённых пустыми строками. " +
+            "Для «Текущей таблицы» поставьте курсор в одну таблицу или используйте «Автозапуск → Текущий лист».",
+        };
+        return;
+      }
+
+      resolverResult = await resolveCurrentTableFromActiveCell(context, readCalculationSettingsFromPanel());
+    });
+  } catch (err) {
+    setStatusMessage(
+      `Автозапуск — Текущая таблица: ошибка при определении таблицы — ${err.message || err}`
+    );
+    return;
+  }
+
+  if (!resolverResult) {
+    setStatusMessage("Автозапуск — Текущая таблица: не удалось определить таблицу.");
+    return;
+  }
+
+  if (resolverResult.status !== "ok") {
+    setStatusMessage(resolverResult.message || "Не удалось определить таблицу под активной ячейкой.");
+    return;
+  }
+
+  const { sheetName, rangeAddress } = resolverResult;
+
+  let result;
+  try {
+    result = await clearSignificanceForRange(sheetName, rangeAddress);
+  } catch (err) {
+    setStatusMessage(
+      `Автозапуск — Текущая таблица: ошибка очистки — ${err.message || err}`
+    );
+    return;
+  }
+
+  if (result.status === "cleared") {
+    setStatusMessage(
+      `Автозапуск — Текущая таблица: очищено. ${sheetName}!${rangeAddress}.`
+    );
+  } else {
+    setStatusMessage(
+      `Автозапуск — Текущая таблица: очистка пропущена — ${result.message || "нет данных"}.`
+    );
   }
 }
 


### PR DESCRIPTION
Closes #216.

## Summary

- Adds `Очистить значимости` button to the `autorun-current_table` workspace in `taskpane.html`, matching the Run/Clear pair style used in `autorun-current_sheet` and `autorun-whole_workbook`.
- Adds `clearAutoCurrentTableSignificance` handler in `taskpane.js` wired to the new button.
- Removes the "Clear is deferred" note from the `runAutoCurrentTableSignificance` JSDoc.

## How Clear resolves the active-cell table

1. Reads the current Excel selection and runs `selectionHasMultiTableGap` (the same pre-resolver guard used by Run #212 and Check #210). A selection spanning multiple table-like blocks separated by empty rows is blocked with a user-facing message before anything is written.
2. Calls `resolveCurrentTableFromActiveCell(context, settings)`. This is read-only — it scans the worksheet for tables and finds the one containing the active cell.
3. If the resolver returns `status: "ok"`, the handler calls the existing `clearSignificanceForRange(sheetName, rangeAddress)` with the resolved coordinates. Nothing in the selected range is touched.
4. If the resolver returns any non-ok status (`no-table`, `generated-sheet`, `ambiguous-boundary`, `blocked`, `error`), the user-facing message from the resolver is shown and nothing is cleared.

## Unchanged flows

- `Расчёт → Очистить значимости` — `clearSignificanceFromSelection` is untouched.
- `Автозапуск → Текущий лист → Очистить значимости` — `clearCurrentSheetSignificance` is untouched.
- `Автозапуск → Вся книга → Очистить значимости` — `clearAutoSignificance` is untouched.
- No changes to significance calculation, banner detection, Excel writer, or Check/Content.

## Affected files

| File | Change |
|------|--------|
| `src/taskpane/taskpane.html` | Added `<button id="clear-current-table">` to `autorun-current_table` workspace |
| `src/taskpane/taskpane.js` | Added `clearAutoCurrentTableSignificance` function; wired button; removed stale deferred-clear comment |

## Table structure matrix / GST

No new detection or calculation behavior — existing coverage is unchanged. The new handler reuses the same resolver and clear path already covered by the matrix.

## Technical debt

No known new technical debt. The handler is a straightforward parallel of `runAutoCurrentTableSignificance` using the existing `clearSignificanceForRange` helper.

## Test / build result

- `npm test`: 300/300 pass, 0 fail.
- `npm run build`: compiled with 3 pre-existing size warnings, no errors.
- `git diff --check`: clean.

## Manual smoke checklist

- [ ] `Автозапуск → Текущая таблица` shows both `Рассчитать` and `Очистить значимости`.
- [ ] After current-table Autorun writes markers, current-table Clear removes markers only from that resolved table.
- [ ] Selected range elsewhere does not affect current-table Clear when active cell is inside intended table.
- [ ] Broad selection spanning two tables blocks before clearing.
- [ ] Active cell outside any detected table shows no-table message.
- [ ] Active cell on `Content` or `Run report` shows generated-sheet message.
- [ ] Manual `Расчёт → Очистить значимости` still clears the selected range.
- [ ] Sheet/workbook Autorun Clear still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)