### PR TITLE
Fix stale banner markers in vertically merged cells on rerun (#218)

### DIFF
--- a/src/taskpane/taskpane.js
+++ b/src/taskpane/taskpane.js
@@ -813,6 +813,16 @@ async function runSignificanceFromSelection() {
         writeTargetRange.columnIndex
       );
 
+      // Pre-clear all existing banner markers above the write range before
+      // writing fresh ones.  Without this, stale markers survive in vertically
+      // merged banner cells: the write helpers only update cells they target on
+      // this run, so any cell targeted by a previous run (possibly in a higher
+      // banner row due to a vertical merge) that is not targeted this run keeps
+      // its old marker.  clearBannerMarkersAboveRange reads .text (which returns
+      // text from the top-left of each merge) and removes any trailing RIT marker
+      // from every banner row above the data range.
+      await clearBannerMarkersAboveRange(context, writeTargetRange);
+
       if (calculationSettings.respectBannerStructure && bannerStructure) {
         await writeBannerMarkersAboveSelectedRangeUsingBannerStructure(
           context,
@@ -1027,6 +1037,12 @@ async function runSignificanceForRange(sheetName, rangeAddress, calculationSetti
         writeTargetRange.rowIndex,
         writeTargetRange.columnIndex
       );
+
+      // Pre-clear all existing banner markers above the write range before
+      // writing fresh ones.  Same reason as in runSignificanceFromSelection:
+      // vertically merged banner cells retain stale markers when re-run with
+      // different banner/wave settings.
+      await clearBannerMarkersAboveRange(context, writeTargetRange);
 
       if (calculationSettings.respectBannerStructure && bannerStructure) {
         await writeBannerMarkersAboveSelectedRangeUsingBannerStructure(


### PR DESCRIPTION
## Summary

- Adds a `clearBannerMarkersAboveRange()` call before each banner write in `runSignificanceFromSelection` and `runSignificanceForRange`, so all existing RIT banner markers in the rows above the data range are removed before fresh markers are written.
- This covers both the manual selected-range Run flow and the Autorun/Autorun-current-table flows.

## Root cause of stale banner markers

The banner write helpers (`writeBannerMarkersAboveSelectedRangeUsingBannerStructure` and `writeBannerMarkersAboveSelectedRange`) use an "append-or-replace" strategy: they only update cells they target on the **current** run. When settings change between runs (e.g. wave detection enabled or disabled), the set of cells written changes. Any upper-banner-row cell that held a marker from a previous run but is not targeted in the current run is left with its old marker.

The specific gap for vertically merged banner cells: when a column's lower banner row cell is empty (because it is the non-top-left part of a vertical merge), the write helper only scans upward for that column if the column **has a new label to write**. If the column no longer needs a label this run, the condition `currentText === "" && labelMap.get(columnIndex)` is false, so the upward scan is skipped and the upper merged cell keeps its old marker.

## How vertically merged banner cells are cleaned

`clearBannerMarkersAboveRange` loads `.text` on the entire banner scan area (up to 5 rows above the data range). Excel's `.text` property returns the actual visible text only at the **top-left cell** of each merged region; other cells in the merge appear as empty strings. The function therefore correctly finds and removes the trailing RIT marker from the top-left cell of any vertically merged header cell. After the pre-clear pass, all write targets start from a clean state.

## Data-cell cleanup confirmation

Data-cell significance cleanup is not affected. The data body is still cleaned by the `writeTargetRange.values = valuesForCalculation` assignment (which resets all cell text to bare values) before `writeCellResultsToSelectedRange` writes fresh markers. No change to that path.

## Test / build result

- `npm test`: 300/300 pass
- `npm run build`: clean compile (pre-existing size warnings only)
- `git diff --check`: no whitespace issues

## Affected areas (TABLE_STRUCTURE_MATRIX)

- Banner letter placement — multi-row / vertically merged banners
- Autorun current-table flow (rerun stability)
- Manual selected-range Run flow (rerun stability)

## Smoke areas to verify manually

- Run with `Проставлять буквы в баннере` + `Учитывать структуру баннера`; rerun with the same settings + `Автоматически определять волны` — merged banner cells must not retain stale letters
- Fresh markers still written where expected on each run
- Data-cell marker cleanup still works (Run → Clear)
- Manual selected-range and Autorun current-table both behave correctly

## Assumptions / limitations

- The fix applies to all banner rows up to `BANNER_UPPER_SCAN_LIMIT` (5) rows above the data range, matching the existing scan limit used by the write helpers.
- The pre-clear is a per-cell write for banner cells only (same pattern already used by the write helpers and the explicit Clear path). The data-body batch write is unchanged.
- No Office.js unit test surface exists for `clearBannerMarkersAboveRange` (requires live Excel context); limitation documented per issue guidance.

## Technical debt

No new technical debt introduced. No follow-up issues identified.

Closes #218