### PR TITLE
Fill table title in Run report for current-table checks (#217)

### DIFF
--- a/src/taskpane/taskpane.js
+++ b/src/taskpane/taskpane.js
@@ -1734,6 +1734,7 @@ async function runAutoCurrentTableSignificance() {
   }
 
   const { sheetName, rangeAddress } = resolverResult;
+  const resolvedTableTitle = resolveContentDisplayTitle(resolverResult.candidateMeta, 1);
 
   let result;
   try {
@@ -1747,7 +1748,7 @@ async function runAutoCurrentTableSignificance() {
         await Excel.run(async (context) => {
           const sheet = await writeRunReportSheet(context, [{
             sheetName,
-            title: "",
+            title: resolvedTableTitle,
             rangeAddress,
             status: "error",
             message: errMsg,
@@ -1778,7 +1779,7 @@ async function runAutoCurrentTableSignificance() {
       await Excel.run(async (context) => {
         const sheet = await writeRunReportSheet(context, [{
           sheetName,
-          title: "",
+          title: resolvedTableTitle,
           rangeAddress,
           status: result.status,
           message: result.message || "",
@@ -3235,6 +3236,7 @@ async function runCheckTable() {
     }
 
     const { sheetName, rangeAddress } = resolverResult;
+    const resolvedTableTitle = resolveContentDisplayTitle(resolverResult.candidateMeta, 1);
 
     const checkResult = await checkSelectedRangePreview(
       context,
@@ -3254,7 +3256,7 @@ async function runCheckTable() {
       if (isCheckReportEnabled()) {
         await writeRunReportSheet(context, [{
           sheetName,
-          title: "",
+          title: resolvedTableTitle,
           rangeAddress,
           status: "blocked",
           message: msg,
@@ -3320,7 +3322,7 @@ async function runCheckTable() {
         .join("; ");
       await writeRunReportSheet(context, [{
         sheetName,
-        title: "",
+        title: resolvedTableTitle,
         rangeAddress,
         status: "checked",
         message: `Строк: ${summary.rowCount}. Блоков: ${summary.detectedBlocks}. Баз: ${summary.baseRows}.`,


### PR DESCRIPTION
## Summary

- Resolves empty `Таблица` column in Run report rows for `Проверка → Текущая таблица` and `Автозапуск → Текущая таблица` flows.
- After the active-cell resolver returns `ok`, `resolveContentDisplayTitle(candidateMeta, 1)` is called — the same function already used by Content/Inventory flows — and the result is passed to all `writeRunReportSheet` calls in the ok-path.
- Non-ok paths (pre-resolver guard block, resolver failure) keep `title: ""` because no `candidateMeta` is available.

## Files changed

- `src/taskpane/taskpane.js` — 6 insertions, 4 deletions

## How table title is resolved for current-table Check

1. `resolveCurrentTableFromActiveCell` returns `candidateMeta` (the full inventory item).
2. `resolveContentDisplayTitle(candidateMeta, 1)` applies the same two-tier logic used by Content/Inventory:
   - `titleConfidence === "high"` (first row of band was a sparse heading row) → use that title.
   - `titleConfidence` is `medium` or `none` (inferred from rows above the band) → use fallback `"Таблица 1"`.
3. Even for high-confidence titles, `isContentTitleFallbackLabel` suppresses known aggregate/banner-like labels (`"всего"`, `"итого"`, `"total"`, etc.) and falls back to `"Таблица 1"`.

## Fallback behavior

When no real title exists (confidence not high, or title is empty/backlink-generated), the fallback is `"Таблица 1"` — a stable single-table label consistent with the Content/Inventory numbering pattern.

## `Всего` from banner not used as title

`isContentTitleFallbackLabel` (already in production) lists `"всего"` as a total-like label. A lone `Всего` cell detected as the first-row sparse heading gets `titleConfidence: "high"` by the scanner, but `resolveContentDisplayTitle` then rejects it via `isContentTitleFallbackLabel` and falls back to `"Таблица 1"`. This is not a new guard — it was already protecting Content. This PR reuses it for current-table Run report rows.

## Sheet/workbook Run report behavior unchanged

Only `runCheckTable` and `runAutoCurrentTableSignificance` are modified. Sheet-level (`runCurrentSheetSignificance`) and workbook-level (`runAutoSignificance`) paths are untouched.

## Validation

- `npm test` — 300/300 pass, 0 fail
- `npm run build` — compiled with 3 pre-existing bundle-size warnings, 0 errors
- `git diff --check` — clean

## Affected areas

- TABLE_STRUCTURE_MATRIX: no structural change — title metadata only
- GOLD_STANDARD_TEST_SUITE: no calculation or detection change
- No known technical debt introduced

Closes #217

🤖 Generated with [Claude Code](https://claude.com/claude-code)