### PR TITLE
Fix taskpane language switcher flag rendering

### DIFF
--- a/src/taskpane/taskpane.css
+++ b/src/taskpane/taskpane.css
@@ -131,25 +131,84 @@ b {
 }
 
 .lang-btn {
-  background: none;
+  position: relative;
+  width: 28px;
+  height: 20px;
+  background: rgba(255, 255, 255, 0.72);
   border: 1px solid transparent;
   border-radius: var(--rs-radius-sm);
   cursor: pointer;
-  font-size: 18px;
-  line-height: 1;
-  padding: 2px 4px;
-  opacity: 0.45;
-  transition: opacity 0.15s;
+  font-size: 0;
+  line-height: 0;
+  padding: 0;
+  color: transparent;
+  opacity: 0.72;
+  overflow: hidden;
+  box-shadow: inset 0 0 0 1px rgba(17, 24, 39, 0.05);
+  transition:
+    opacity 0.15s,
+    border-color 0.15s,
+    background-color 0.15s,
+    box-shadow 0.15s,
+    transform 0.15s;
+}
+
+.lang-btn::before {
+  content: "";
+  position: absolute;
+  top: 3px;
+  left: 3px;
+  width: 20px;
+  height: 14px;
+  border-radius: 3px;
+  box-shadow:
+    inset 0 0 0 1px rgba(17, 24, 39, 0.08),
+    0 0 0 1px rgba(255, 255, 255, 0.4);
+}
+
+.lang-btn[data-lang="ru"]::before {
+  background:
+    linear-gradient(
+      to bottom,
+      #ffffff 0,
+      #ffffff 33.33%,
+      #0f5bd3 33.33%,
+      #0f5bd3 66.66%,
+      #d52b1e 66.66%,
+      #d52b1e 100%
+    );
+}
+
+.lang-btn[data-lang="en"]::before {
+  background:
+    linear-gradient(33deg, transparent 42%, #ffffff 42%, #ffffff 49%, transparent 49%),
+    linear-gradient(-33deg, transparent 42%, #ffffff 42%, #ffffff 49%, transparent 49%),
+    linear-gradient(33deg, transparent 46%, #c8102e 46%, #c8102e 49%, transparent 49%),
+    linear-gradient(-33deg, transparent 46%, #c8102e 46%, #c8102e 49%, transparent 49%),
+    linear-gradient(to right, transparent 38%, #ffffff 38%, #ffffff 62%, transparent 62%),
+    linear-gradient(to bottom, transparent 35%, #ffffff 35%, #ffffff 65%, transparent 65%),
+    linear-gradient(to right, transparent 44%, #c8102e 44%, #c8102e 56%, transparent 56%),
+    linear-gradient(to bottom, transparent 41%, #c8102e 41%, #c8102e 59%, transparent 59%),
+    #012169;
 }
 
 .lang-btn:hover {
-  opacity: 0.85;
+  opacity: 0.92;
+  transform: translateY(-1px);
 }
 
 .lang-btn.is-active {
   border-color: var(--rs-color-border);
   opacity: 1;
   background: var(--rs-color-bg);
+  box-shadow:
+    inset 0 0 0 1px rgba(22, 163, 74, 0.12),
+    0 0 0 2px rgba(34, 197, 94, 0.12);
+}
+
+.lang-btn:focus-visible {
+  outline: 2px solid rgba(22, 163, 74, 0.35);
+  outline-offset: 2px;
 }
 
 .settings-panel {

--- a/tests/core/loader.mjs
+++ b/tests/core/loader.mjs
@@ -37,9 +37,14 @@ export async function resolve(specifier, context, nextResolve) {
 
 export async function load(url, context, nextLoad) {
   // Force ESM format for project source files.
-  // src/core/*.js files use export/import syntax but the package has no
-  // "type":"module", so Node would otherwise parse them as CommonJS.
-  if (url.includes("/src/core/") && !url.includes("/node_modules/") && url.endsWith(".js")) {
+  // src/core/*.js and src/taskpane/*.js files use export/import syntax but
+  // the package has no "type":"module", so Node would otherwise parse them
+  // as CommonJS.
+  if (
+    (url.includes("/src/core/") || url.includes("/src/taskpane/")) &&
+    !url.includes("/node_modules/") &&
+    url.endsWith(".js")
+  ) {
     const result = await nextLoad(url, context);
     return { ...result, format: "module" };
   }

--- a/tests/core/localization.test.mjs
+++ b/tests/core/localization.test.mjs
@@ -1,0 +1,106 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+function createLocalStorage(initial = {}) {
+  const store = new Map(Object.entries(initial));
+  return {
+    getItem(key) {
+      return store.has(key) ? store.get(key) : null;
+    },
+    setItem(key, value) {
+      store.set(key, String(value));
+    },
+  };
+}
+
+function createLeaf(i18nKey) {
+  return {
+    dataset: { i18n: i18nKey },
+    children: [],
+    textContent: "",
+  };
+}
+
+function createHint(hintI18nKey) {
+  return {
+    dataset: { hintI18n: hintI18nKey, hintBase: "" },
+  };
+}
+
+function createButton(lang, isActive = false) {
+  const classes = new Set(isActive ? ["lang-btn", "is-active"] : ["lang-btn"]);
+  return {
+    dataset: { lang },
+    classList: {
+      toggle(name, force) {
+        if (force) classes.add(name);
+        else classes.delete(name);
+      },
+      contains(name) {
+        return classes.has(name);
+      },
+    },
+  };
+}
+
+function createDocument(elementsBySelector) {
+  return {
+    querySelectorAll(selector) {
+      return elementsBySelector[selector] || [];
+    },
+  };
+}
+
+async function importLocalizationModule() {
+  return import(new URL(`../../src/taskpane/localization.js?test=${Date.now()}-${Math.random()}`, import.meta.url));
+}
+
+describe("taskpane localization", () => {
+  it("switches to English, updates translated content, and toggles the active button state", async () => {
+    const ruButton = createButton("ru", true);
+    const enButton = createButton("en");
+    const label = createLeaf("tabs.run");
+    const hint = createHint("hint.runCurrentTable");
+
+    globalThis.localStorage = createLocalStorage();
+    globalThis.document = createDocument({
+      "[data-i18n]": [label],
+      "[data-hint-i18n]": [hint],
+      ".lang-btn[data-lang]": [ruButton, enButton],
+    });
+
+    const { getLanguage, setLanguage } = await importLocalizationModule();
+
+    setLanguage("en");
+
+    assert.strictEqual(getLanguage(), "en");
+    assert.strictEqual(globalThis.localStorage.getItem("rit.ui.lang"), "en");
+    assert.strictEqual(label.textContent, "Run");
+    assert.strictEqual(hint.dataset.hintBase, "Scope: selected range");
+    assert.equal(ruButton.classList.contains("is-active"), false);
+    assert.equal(enButton.classList.contains("is-active"), true);
+  });
+
+  it("loads the saved language on a fresh module import and reapplies the active state", async () => {
+    const ruButton = createButton("ru", true);
+    const enButton = createButton("en");
+    const label = createLeaf("tabs.content");
+
+    globalThis.localStorage = createLocalStorage({ "rit.ui.lang": "en" });
+    globalThis.document = createDocument({
+      "[data-i18n]": [label],
+      "[data-hint-i18n]": [],
+      ".lang-btn[data-lang]": [ruButton, enButton],
+    });
+
+    const { applyI18n, getLanguage, loadSavedLanguage } = await importLocalizationModule();
+
+    loadSavedLanguage();
+    applyI18n();
+
+    assert.strictEqual(getLanguage(), "en");
+    assert.strictEqual(label.textContent, "Contents");
+    assert.equal(ruButton.classList.contains("is-active"), false);
+    assert.equal(enButton.classList.contains("is-active"), true);
+  });
+});


### PR DESCRIPTION
## Summary
- replace emoji-dependent language switcher visuals with compact CSS-drawn flag badges
- preserve the existing ru/en switching, active-state toggling, and saved-language persistence behavior
- add focused localization tests for switch state and saved-language reload behavior

## Validation
- npm.cmd test
- npm.cmd run build
- git diff --check

Closes #231