### PR TITLE
Fix call-sync-before-read: sync before selectedRange.worksheet in runCheckSelectedRange

### DIFF
--- a/src/taskpane/taskpane.js
+++ b/src/taskpane/taskpane.js
@@ -3403,6 +3403,7 @@ async function runCheckSelectedRange() {
     try {
       const selectedRange = context.workbook.getSelectedRange();
       selectedRange.load(["address"]);
+      await context.sync();
       const worksheet = selectedRange.worksheet;
       worksheet.load(["name"]);
       await context.sync();


### PR DESCRIPTION
## Summary

- Inserts `await context.sync()` between `selectedRange.load(["address"])` and `const worksheet = selectedRange.worksheet` in `runCheckSelectedRange` (taskpane.js:3406).
- Resolves the `office-addins/call-sync-before-read` lint error documented in `docs/PRE_1_0_AUDIT.md` Issue A.
- `selectedRange.worksheet` is a navigation property; without a prior sync after the load call, the worksheet proxy may be stale or undefined on some Office hosts.

## Files changed

- `src/taskpane/taskpane.js` — 1 line inserted (`await context.sync()`)

## Lint result

- `call-sync-before-read` error at line 3406: **gone**
- Total: 410 problems (398 errors, 12 warnings) — down from 411 (399 errors) baseline
- All remaining issues are pre-existing and outside scope

## Test / build result

- `npm test`: 302/302 pass
- `npm run build`: exit 0, 3 pre-existing performance warnings only
- `git diff --check`: clean

## Technical debt

No new debt introduced. Fix is a single sync insertion within the existing try/catch block. No calculation behavior, no sheet-name generation, no writer/run/clear paths touched.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)