### PR TITLE
Fix action tab row overflow at narrow taskpane widths (#242)

### DIFF
--- a/src/taskpane/localization.js
+++ b/src/taskpane/localization.js
@@ -382,6 +382,12 @@ export function applyI18n() {
     }
   });
 
+  // Update title attributes for elements that declare data-i18n-title
+  // (e.g. action tabs that may be ellipsized at narrow widths).
+  document.querySelectorAll("[data-i18n-title]").forEach((el) => {
+    el.title = t(el.dataset.i18nTitle);
+  });
+
   // Update the data-hint-base attribute for check workspace hints so that
   // updateCheckHints() (in taskpane.js) can append the correct mode suffix.
   document.querySelectorAll("[data-hint-i18n]").forEach((el) => {

--- a/src/taskpane/taskpane.css
+++ b/src/taskpane/taskpane.css
@@ -705,10 +705,14 @@ b {
   background: var(--rs-color-bg-soft);
   border: 1px solid var(--rs-color-border);
   border-radius: var(--rs-radius-sm);
+  min-width: 0;
+  overflow: hidden;
+  box-sizing: border-box;
 }
 
 .action-tab {
-  flex: 1;
+  flex: 1 1 0;
+  min-width: 0;
   padding: 5px 4px;
   border: none;
   border-radius: 4px;
@@ -717,6 +721,10 @@ b {
   font-size: 12px;
   font-weight: 600;
   cursor: pointer;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  text-align: center;
 }
 
 .action-tab:hover {

--- a/src/taskpane/taskpane.html
+++ b/src/taskpane/taskpane.html
@@ -68,10 +68,10 @@
       <section class="action-panel action-panel-sticky">
         <!-- Action tabs: Расчёт | Автозапуск | Проверка | Оглавление -->
         <div class="action-tabs" role="tablist" id="action-tabs">
-          <button class="action-tab is-active" data-action="run" role="tab" aria-selected="true" data-i18n="tabs.run">Расчёт</button>
-          <button class="action-tab" data-action="autorun" role="tab" aria-selected="false" data-i18n="tabs.autorun">Автозапуск</button>
-          <button class="action-tab action-tab--readonly" data-action="check" role="tab" aria-selected="false" data-i18n="tabs.check">Проверка</button>
-          <button class="action-tab" data-action="content" role="tab" aria-selected="false" data-i18n="tabs.content">Оглавление</button>
+          <button class="action-tab is-active" data-action="run" role="tab" aria-selected="true" data-i18n="tabs.run" data-i18n-title="tabs.run" title="Расчёт">Расчёт</button>
+          <button class="action-tab" data-action="autorun" role="tab" aria-selected="false" data-i18n="tabs.autorun" data-i18n-title="tabs.autorun" title="Автозапуск">Автозапуск</button>
+          <button class="action-tab action-tab--readonly" data-action="check" role="tab" aria-selected="false" data-i18n="tabs.check" data-i18n-title="tabs.check" title="Проверка">Проверка</button>
+          <button class="action-tab" data-action="content" role="tab" aria-selected="false" data-i18n="tabs.content" data-i18n-title="tabs.content" title="Оглавление">Оглавление</button>
         </div>
 
         <!-- Scope selector: Current table | Current sheet | Whole workbook -->


### PR DESCRIPTION
## Summary

- **CSS-first fix** for the action tab row (`Расчёт / Автозапуск / Проверка / Оглавление`) spilling outside its container at narrow Excel taskpane widths.
- No behavior changes — Run, Clear, Autorun, Check, Contents all work identically.

## Files changed

| File | Change |
|---|---|
| `src/taskpane/taskpane.css` | Core fix: constrain `.action-tabs` and `.action-tab` |
| `src/taskpane/taskpane.html` | Add `title`/`data-i18n-title` to action tab buttons |
| `src/taskpane/localization.js` | Extend `applyI18n()` to sync `title` on language switch |

## CSS approach

**`.action-tabs`** — added `min-width: 0`, `overflow: hidden`, `box-sizing: border-box`.  
The container now clips any content that would otherwise push past the card edge.

**`.action-tab`** — changed to `flex: 1 1 0` (explicit shrink + zero basis), added `min-width: 0` (overrides the default `min-width: auto` that prevents shrinking below content width), plus `white-space: nowrap; overflow: hidden; text-overflow: ellipsis; text-align: center`.  
At narrow widths all four tabs shrink equally; long labels like `Автозапуск` and `Оглавление` become ellipsized rather than spilling.

**Accessibility** — each tab button now carries a `title` attribute (static initial value) and `data-i18n-title` key so `applyI18n()` keeps the tooltip correct when the user switches RU ↔ EN.

## Before / after at narrow width

| | Before | After |
|---|---|---|
| Narrow taskpane | Active tab can extend outside the card | All tabs stay inside the container; long labels ellipsized |
| Active tab | May spill past card edge | Fully contained, active state still clearly visible |
| Wider taskpane | Normal | Unchanged — tabs expand to fill available width |

## Test / build result

- `npm test`: **302/302 pass**
- `npm run build`: **compiled with 3 warnings** (pre-existing bundle-size warnings, not introduced here)
- `git diff --check`: clean

## Assumptions / limitations

- No compact labels were needed; ellipsis alone keeps labels understandable in both RU and EN at reasonable taskpane widths.
- The `title` tooltip covers the truncated-label accessibility case.
- No changes to calculation, writer, detection, or worksheet-name logic.

## Technical debt

No new technical debt introduced. This is a targeted CSS containment fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)