### PR TITLE
Remove dead applyTotalComparisonMarkerToFullMarkerMatrix and prependTotalMarker

### DIFF
--- a/src/core/significance.js
+++ b/src/core/significance.js
@@ -1500,48 +1500,6 @@ function applyTotalComparisonMarkerToFullCellResultMatrix(
     totalMarker
   );
 }
-/**
- * Applies special Total comparison marker.
- *
- * RULES:
- * - Total column is column 0.
- * - Marker is always written into the segment column.
- * - "T" means segment is significantly higher than Total.
- * - "t" means segment is significantly lower than Total.
- * - Total marker has priority and must appear before segment markers.
- */
-function applyTotalComparisonMarkerToFullMarkerMatrix(fullMarkerMatrix, valueRowIndex, comparison) {
-  const firstColumnIndex = comparison.firstColumnIndex;
-  const secondColumnIndex = comparison.secondColumnIndex;
-
-  const segmentColumnIndex = firstColumnIndex === 0 ? secondColumnIndex : firstColumnIndex;
-  const segmentIsFirstColumn = segmentColumnIndex === firstColumnIndex;
-
-  const segmentIsHigher =
-    (segmentIsFirstColumn && comparison.result.direction === "first_higher") ||
-    (!segmentIsFirstColumn && comparison.result.direction === "second_higher");
-
-  const totalMarker = segmentIsHigher ? "T" : "t";
-
-  fullMarkerMatrix[valueRowIndex][segmentColumnIndex] = prependTotalMarker(
-    fullMarkerMatrix[valueRowIndex][segmentColumnIndex],
-    totalMarker
-  );
-}
-
-/**
- * Puts Total marker before ordinary segment markers.
- *
- * Example:
- * - existing "ab" + "T" -> "Tab"
- * - existing "tbc" + "T" -> "Tbc"
- */
-function prependTotalMarker(existingMarkers, totalMarker) {
-  const markerText = existingMarkers || "";
-  const markerTextWithoutOldTotalMarker = markerText.replace(/[tT]/g, "");
-
-  return `${totalMarker}${markerTextWithoutOldTotalMarker}`;
-}
 
 /**
  * Clears markers from rows that are not allowed to receive markers.


### PR DESCRIPTION
## Summary

- Removes `applyTotalComparisonMarkerToFullMarkerMatrix` (significance.js:1513), confirmed dead by exhaustive call-site search across the entire codebase.
- Removes `prependTotalMarker` (significance.js:1539), its exclusive helper — leaving it would have introduced a new `no-unused-vars` finding.
- Resolves the `no-unused-vars` lint debt item documented in `docs/PRE_1_0_AUDIT.md` (Issue C).

## Investigation evidence

Call-site search for `applyTotalComparisonMarkerToFullMarkerMatrix` returns **zero** call sites. The only match is the function definition itself.

The active path uses `applyTotalComparisonMarkerToFullCellResultMatrix` (line 1476), called at line 1419. That function operates on `fullCellResultMatrix` via `prependTotalMarkerToCellResult`. The removed function operated on the older `fullMarkerMatrix` structure via the now-also-removed `prependTotalMarker` helper — both were left behind during an earlier data-structure refactor.

## File changed

- `src/core/significance.js` — 42 lines deleted (two dead functions and their JSDoc blocks)

## Validation

- `npm test`: 302/302 pass, 0 fail
- `npm run build`: webpack compiled successfully (3 pre-existing size warnings, unchanged)
- `npm run lint`: exits with pre-existing debt; the target `no-unused-vars` finding for `applyTotalComparisonMarkerToFullMarkerMatrix` is absent from the output
- `git diff --check`: clean

## No behavior change

No statistical formula, comparison logic, marker behavior, Total/bannerTotal path, or Run/Clear/Check/Autorun/Contents workflow was touched. The removed code had no callers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)