### PR TITLE
refactor: extract status/message helpers from taskpane.js into taskpane-status.js

### DIFF
--- a/src/taskpane/taskpane-status.js
+++ b/src/taskpane/taskpane-status.js
@@ -1,0 +1,142 @@
+/* global document */
+
+import { t } from "./localization";
+
+// Banner message codes that should be surfaced to the user.
+// Moved here with the formatBannerUserMessages* helpers that consume it.
+const USER_VISIBLE_BANNER_MESSAGE_CODES = new Set([
+  "GLOBAL_TOTAL_USED",
+  "BANNER_AUTO_PREVIOUS_COLUMN_APPLIED",
+  "BANNER_TOTAL_ONLY_NO_TOTAL_PAIRS",
+  "BANNER_MULTIPLE_LOCAL_TOTALS",
+  "BANNER_TOTAL_OUTSIDE_SELECTION",
+  "BANNER_MALFORMED_STRUCTURE",
+  "BANNER_NO_ROWS_ABOVE_SELECTION",
+]);
+
+export function setStatusMessage(message) {
+  const statusPanel = document.getElementById("status-panel");
+  const outputElement = document.getElementById("significance-result");
+
+  if (statusPanel) {
+    statusPanel.style.display = "block";
+  }
+
+  if (outputElement) {
+    outputElement.textContent = message || "";
+  }
+}
+
+export function setCheckMessage(message) {
+  const checkPanel = document.getElementById("check-panel");
+  const checkResult = document.getElementById("check-result");
+
+  if (checkPanel) {
+    checkPanel.style.display = "block";
+  }
+
+  if (checkResult) {
+    checkResult.textContent = message || "";
+  }
+}
+
+export function setInventoryMessage(message) {
+  const panel = document.getElementById("inventory-panel");
+  const result = document.getElementById("inventory-result");
+  if (panel) panel.style.display = "block";
+  if (result) result.textContent = message || "";
+}
+
+// Shown when the user has a non-contiguous (multi-area) selection active.
+// context.workbook.getSelectedRange() throws a RichApi.Error for such selections.
+// Resolved via t() at call sites so the message respects the active UI language.
+export function nonContiguousSelectionMessage() {
+  return t("status.nonContiguousSelection");
+}
+
+export function formatBannerUserMessages(bannerStructure) {
+  if (!bannerStructure || !bannerStructure.messages) {
+    return "";
+  }
+
+  const visibleMessages = bannerStructure.messages.filter((message) =>
+    USER_VISIBLE_BANNER_MESSAGE_CODES.has(message.code)
+  );
+
+  if (visibleMessages.length === 0) {
+    return "";
+  }
+
+  if (visibleMessages.length === 1) {
+    return visibleMessages[0].text;
+  }
+
+  return ["Сообщения:", ...visibleMessages.map((message) => `- ${message.text}`)].join("\n");
+}
+
+export function formatBannerUserMessagesExcludingCodes(bannerStructure, excludedCodes = []) {
+  if (!bannerStructure || !bannerStructure.messages) {
+    return "";
+  }
+
+  const excludedCodeSet = new Set(excludedCodes);
+
+  const visibleMessages = bannerStructure.messages.filter(
+    (message) =>
+      USER_VISIBLE_BANNER_MESSAGE_CODES.has(message.code) && !excludedCodeSet.has(message.code)
+  );
+
+  if (visibleMessages.length === 0) {
+    return "";
+  }
+
+  if (visibleMessages.length === 1) {
+    return visibleMessages[0].text;
+  }
+
+  return ["Сообщения:", ...visibleMessages.map((message) => `- ${message.text}`)].join("\n");
+}
+
+export function formatSelectedRangeGuardrailMessages(warnings) {
+  if (!warnings || warnings.length === 0) {
+    return "";
+  }
+
+  const uniqueTexts = Array.from(new Set(warnings.map((warning) => warning.text).filter(Boolean)));
+
+  if (uniqueTexts.length === 1) {
+    return uniqueTexts[0];
+  }
+
+  return ["Предупреждения:", ...uniqueTexts.map((text) => `- ${text}`)].join("\n");
+}
+
+export function appendSelectedRangeGuardrailMessages(statusMessages, warnings) {
+  const guardrailMessage = formatSelectedRangeGuardrailMessages(warnings);
+
+  if (!guardrailMessage) {
+    return statusMessages;
+  }
+
+  return [...statusMessages, "", guardrailMessage];
+}
+
+export function formatStatusWithSelectedRangeGuardrails(message, warnings) {
+  return appendSelectedRangeGuardrailMessages([message], warnings).join("\n");
+}
+
+export function buildCheckResolverMessage(resolverResult) {
+  if (resolverResult.message) return resolverResult.message;
+  switch (resolverResult.status) {
+    case "no-table":
+      return t("status.resolverNoTable");
+    case "generated-sheet":
+      return t("status.resolverGeneratedSheet");
+    case "ambiguous-boundary":
+      return t("status.resolverAmbiguousBoundary");
+    case "blocked":
+      return t("status.resolverBlocked");
+    default:
+      return t("status.resolverFallback");
+  }
+}

--- a/src/taskpane/taskpane.js
+++ b/src/taskpane/taskpane.js
@@ -46,27 +46,23 @@ import { resolveCurrentTableFromActiveCell } from "./active-cell-resolver";
 
 import { t, setLanguage, loadSavedLanguage, applyI18n } from "./localization";
 
-const USER_VISIBLE_BANNER_MESSAGE_CODES = new Set([
-  "GLOBAL_TOTAL_USED",
-  "BANNER_AUTO_PREVIOUS_COLUMN_APPLIED",
-  "BANNER_TOTAL_ONLY_NO_TOTAL_PAIRS",
-  "BANNER_MULTIPLE_LOCAL_TOTALS",
-  "BANNER_TOTAL_OUTSIDE_SELECTION",
-  "BANNER_MALFORMED_STRUCTURE",
-  "BANNER_NO_ROWS_ABOVE_SELECTION",
-]);
+import {
+  setStatusMessage,
+  setCheckMessage,
+  setInventoryMessage,
+  nonContiguousSelectionMessage,
+  formatBannerUserMessages,
+  formatBannerUserMessagesExcludingCodes,
+  appendSelectedRangeGuardrailMessages,
+  formatStatusWithSelectedRangeGuardrails,
+  buildCheckResolverMessage,
+} from "./taskpane-status";
 
 const SCAN_CELL_LIMIT = 250000;
 const INVENTORY_CONTENT_SHEET_NAME = "Content";
 const RUN_REPORT_SHEET_NAME = "Run report";
 const GENERATED_SHEET_NAMES = new Set([INVENTORY_CONTENT_SHEET_NAME, RUN_REPORT_SHEET_NAME]);
 
-// Shown when the user has a non-contiguous (multi-area) selection active.
-// context.workbook.getSelectedRange() throws a RichApi.Error for such selections.
-// Resolved via t() at call sites so the message respects the active UI language.
-function nonContiguousSelectionMessage() {
-  return t("status.nonContiguousSelection");
-}
 const INVENTORY_CONTENT_COLUMNS = [
   "#",
   "Sheet",
@@ -104,77 +100,6 @@ const INVENTORY_FULL_CHECK_COLUMNS = [
   "Label split",
   "Label cols",
 ];
-
-function formatBannerUserMessages(bannerStructure) {
-  if (!bannerStructure || !bannerStructure.messages) {
-    return "";
-  }
-
-  const visibleMessages = bannerStructure.messages.filter((message) =>
-    USER_VISIBLE_BANNER_MESSAGE_CODES.has(message.code)
-  );
-
-  if (visibleMessages.length === 0) {
-    return "";
-  }
-
-  if (visibleMessages.length === 1) {
-    return visibleMessages[0].text;
-  }
-
-  return ["Сообщения:", ...visibleMessages.map((message) => `- ${message.text}`)].join("\n");
-}
-
-function formatSelectedRangeGuardrailMessages(warnings) {
-  if (!warnings || warnings.length === 0) {
-    return "";
-  }
-
-  const uniqueTexts = Array.from(new Set(warnings.map((warning) => warning.text).filter(Boolean)));
-
-  if (uniqueTexts.length === 1) {
-    return uniqueTexts[0];
-  }
-
-  return ["Предупреждения:", ...uniqueTexts.map((text) => `- ${text}`)].join("\n");
-}
-
-function appendSelectedRangeGuardrailMessages(statusMessages, warnings) {
-  const guardrailMessage = formatSelectedRangeGuardrailMessages(warnings);
-
-  if (!guardrailMessage) {
-    return statusMessages;
-  }
-
-  return [...statusMessages, "", guardrailMessage];
-}
-
-function formatStatusWithSelectedRangeGuardrails(message, warnings) {
-  return appendSelectedRangeGuardrailMessages([message], warnings).join("\n");
-}
-
-function formatBannerUserMessagesExcludingCodes(bannerStructure, excludedCodes = []) {
-  if (!bannerStructure || !bannerStructure.messages) {
-    return "";
-  }
-
-  const excludedCodeSet = new Set(excludedCodes);
-
-  const visibleMessages = bannerStructure.messages.filter(
-    (message) =>
-      USER_VISIBLE_BANNER_MESSAGE_CODES.has(message.code) && !excludedCodeSet.has(message.code)
-  );
-
-  if (visibleMessages.length === 0) {
-    return "";
-  }
-
-  if (visibleMessages.length === 1) {
-    return visibleMessages[0].text;
-  }
-
-  return ["Сообщения:", ...visibleMessages.map((message) => `- ${message.text}`)].join("\n");
-}
 
 const LOCAL_SETTINGS_STORAGE_KEY = "rit.settings.v1";
 const SETTINGS_COLLAPSED_KEY = "rit.ui.settingsCollapsed";
@@ -3431,28 +3356,6 @@ async function runCheckSelectedRange() {
   });
 }
 
-/**
- * Converts a non-ok resolver result into a user-facing message for the Check panel.
- *
- * Falls back to the resolver's own message where available; provides a generic
- * fallback for unexpected statuses.
- */
-function buildCheckResolverMessage(resolverResult) {
-  if (resolverResult.message) return resolverResult.message;
-  switch (resolverResult.status) {
-    case "no-table":
-      return t("status.resolverNoTable");
-    case "generated-sheet":
-      return t("status.resolverGeneratedSheet");
-    case "ambiguous-boundary":
-      return t("status.resolverAmbiguousBoundary");
-    case "blocked":
-      return t("status.resolverBlocked");
-    default:
-      return t("status.resolverFallback");
-  }
-}
-
 function formatCheckUserVisibleIssues(issues) {
   if (!Array.isArray(issues) || issues.length === 0) {
     return [];
@@ -3600,19 +3503,6 @@ function formatCheckBannerSummary(bannerStructure) {
   }
 
   return lines;
-}
-
-function setCheckMessage(message) {
-  const checkPanel = document.getElementById("check-panel");
-  const checkResult = document.getElementById("check-result");
-
-  if (checkPanel) {
-    checkPanel.style.display = "block";
-  }
-
-  if (checkResult) {
-    checkResult.textContent = message || "";
-  }
 }
 
 function getInventoryCandidateStatusLabel(candidateStatus) {
@@ -4882,13 +4772,6 @@ async function runTableInventory() {
   });
 }
 
-function setInventoryMessage(message) {
-  const panel = document.getElementById("inventory-panel");
-  const result = document.getElementById("inventory-result");
-  if (panel) panel.style.display = "block";
-  if (result) result.textContent = message || "";
-}
-
 /**
  * Reads calculation settings from the task pane UI.
  *
@@ -5472,19 +5355,6 @@ function initializePreviousColumnComparisonSettings() {
   }
 
   refreshSettingsPanelState();
-}
-
-function setStatusMessage(message) {
-  const statusPanel = document.getElementById("status-panel");
-  const outputElement = document.getElementById("significance-result");
-
-  if (statusPanel) {
-    statusPanel.style.display = "block";
-  }
-
-  if (outputElement) {
-    outputElement.textContent = message || "";
-  }
 }
 
 /**


### PR DESCRIPTION
## Summary

- Create `src/taskpane/taskpane-status.js` with 10 pure/near-pure status and message helpers extracted from `src/taskpane/taskpane.js`.
- Import those helpers back into `taskpane.js` — no runtime or product behavior changes.
- This is the first small taskpane decomposition PR per the architecture cleanup plan.

## Files changed

- `src/taskpane/taskpane-status.js` — new module (created)
- `src/taskpane/taskpane.js` — import added, function bodies removed

## Helpers moved

| Helper | Notes |
|---|---|
| `setStatusMessage` | DOM helper only |
| `setCheckMessage` | DOM helper only |
| `setInventoryMessage` | DOM helper only |
| `nonContiguousSelectionMessage` | calls `t()`, no Excel objects |
| `buildCheckResolverMessage` | calls `t()`, pure message build |
| `formatBannerUserMessages` | pure, needs `USER_VISIBLE_BANNER_MESSAGE_CODES` |
| `formatBannerUserMessagesExcludingCodes` | pure, needs same constant |
| `formatSelectedRangeGuardrailMessages` | pure |
| `appendSelectedRangeGuardrailMessages` | pure |
| `formatStatusWithSelectedRangeGuardrails` | pure |
| `USER_VISIBLE_BANNER_MESSAGE_CODES` (constant) | message-only constant, moved with banner helpers |

## Helpers intentionally left in taskpane.js

- `formatCheckBannerSummary`, `formatCheckUserVisibleIssues`, `formatCheckCalculationBlocks` — not in the preferred safe-candidate list; defer to a follow-up PR.
- `formatSkippedCandidateDetail` — embedded in autorun flow; defer.
- All Excel.run orchestration, range/worksheet logic, UI event wiring, settings persistence.

## Build / test / lint result

- `npm test`: 302/302 pass
- `npm run build`: success (3 pre-existing asset-size warnings only)
- `npm run lint`: pre-existing lint debt in `src/core/*` unchanged; no new lint categories introduced; `taskpane-status.js` is lint-clean
- `git diff --check`: clean

## No runtime behavior changes

All moved functions are imported back into `taskpane.js` under the same names. Call sites are unchanged. DOM selectors and message text are identical.

## Technical debt

No new debt introduced. Pre-existing lint debt in `src/core/*` is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)