### PR TITLE
Extract settings persistence/state helpers into taskpane-settings.js

### DIFF
--- a/src/taskpane/taskpane-settings.js
+++ b/src/taskpane/taskpane-settings.js
@@ -1,0 +1,225 @@
+/* global console, document */
+
+const LOCAL_SETTINGS_STORAGE_KEY = "rit.settings.v1";
+const SETTINGS_COLLAPSED_KEY = "rit.ui.settingsCollapsed";
+
+export const SETTINGS_CONTROL_CONFIG = [
+  { id: "confidence-level", type: "value", settingName: "confidenceLevel" },
+
+  {
+    id: "one-tailed-test",
+    type: "checked",
+    settingName: "oneTailedTest",
+  },
+
+  { id: "round-cell-values", type: "checked", settingName: "roundCellValues" },
+
+  {
+    id: "compare-with-previous-column",
+    type: "checked",
+    settingName: "compareWithPreviousColumn",
+  },
+  {
+    id: "apply-previous-column-fill",
+    type: "checked",
+    settingName: "applyPreviousColumnFill",
+  },
+
+  { id: "write-banner-letters", type: "checked", settingName: "writeBannerLetters" },
+  { id: "respect-banner-structure", type: "checked", settingName: "respectBannerStructure" },
+  {
+    id: "auto-detect-wave-banners",
+    type: "checked",
+    settingName: "autoDetectWaveBanners",
+  },
+  { id: "labels-on-left-side", type: "checked", settingName: "labelsOnLeftSide" },
+
+  { id: "compare-only-with-total", type: "checked", settingName: "compareOnlyWithTotal" },
+  {
+    id: "exclude-total-from-comparisons",
+    type: "checked",
+    settingName: "excludeTotalFromComparisons",
+  },
+
+  { id: "first-column-is-total", type: "checked", settingName: "firstColumnIsTotal" },
+  { id: "total-in-each-banner", type: "checked", settingName: "totalInEachBanner" },
+
+  { id: "significant-fill-color", type: "value", settingName: "significantFillColor" },
+  {
+    id: "lower-than-total-fill-color",
+    type: "value",
+    settingName: "lowerThanTotalFillColor",
+  },
+
+  {
+    id: "fill-only-total-comparisons",
+    type: "checked",
+    settingName: "fillOnlyTotalComparisons",
+  },
+
+  {
+    id: "exclude-small-bases",
+    type: "checked",
+    settingName: "excludeSmallBasesFromComparisons",
+  },
+  { id: "small-base-threshold", type: "number", settingName: "smallBaseThreshold" },
+  { id: "small-base-fill-color", type: "value", settingName: "smallBaseFillColor" },
+
+  { id: "preferred-base", type: "value", settingName: "preferredBase" },
+
+  { id: "settings-storage-mode", type: "value", settingName: "settingsStorageMode" },
+];
+
+export const DEFAULT_CALCULATION_SETTINGS = {
+  confidenceLevel: "95",
+  oneTailedTest: false,
+
+  roundCellValues: false,
+
+  compareWithPreviousColumn: false,
+  applyPreviousColumnFill: false,
+
+  writeBannerLetters: false,
+  respectBannerStructure: false,
+  autoDetectWaveBanners: false,
+  labelsOnLeftSide: false,
+
+  compareOnlyWithTotal: false,
+  excludeTotalFromComparisons: false,
+
+  firstColumnIsTotal: false,
+  totalInEachBanner: false,
+
+  significantFillColor: "#E2F0D9",
+  lowerThanTotalFillColor: "#FCE4D6",
+
+  fillOnlyTotalComparisons: false,
+
+  excludeSmallBasesFromComparisons: false,
+  smallBaseThreshold: 50,
+  smallBaseFillColor: "#D0D0D0",
+
+  preferredBase: "auto",
+
+  settingsStorageMode: "none",
+};
+
+function applySettingsCollapseState(toggleBtn, panelBody, isCollapsed) {
+  toggleBtn.setAttribute("aria-expanded", isCollapsed ? "false" : "true");
+  panelBody.classList.toggle("is-collapsed", isCollapsed);
+}
+
+export function initializeSettingsCollapse() {
+  const toggleBtn = document.getElementById("settings-toggle");
+  const panelBody = document.getElementById("settings-panel-body");
+
+  if (!toggleBtn || !panelBody) return;
+
+  let isCollapsed = false;
+  try {
+    const saved = localStorage.getItem(SETTINGS_COLLAPSED_KEY);
+    if (saved !== null) isCollapsed = saved === "true";
+  } catch (_) {
+    /* non-fatal */
+  }
+
+  applySettingsCollapseState(toggleBtn, panelBody, isCollapsed);
+
+  toggleBtn.addEventListener("click", () => {
+    const nextCollapsed = toggleBtn.getAttribute("aria-expanded") === "true";
+    applySettingsCollapseState(toggleBtn, panelBody, nextCollapsed);
+    try {
+      localStorage.setItem(SETTINGS_COLLAPSED_KEY, String(nextCollapsed));
+    } catch (_) {
+      /* non-fatal */
+    }
+  });
+}
+
+/**
+ * Loads saved settings into the panel if local saving was enabled.
+ */
+export function loadSavedSettingsIntoPanel() {
+  const savedSettings = readSettingsFromLocalStorage();
+
+  if (!savedSettings) {
+    return;
+  }
+
+  if (savedSettings.settingsStorageMode !== "local") {
+    return;
+  }
+
+  applySettingsToPanel(savedSettings);
+}
+
+/**
+ * Reads saved settings from localStorage.
+ */
+export function readSettingsFromLocalStorage() {
+  try {
+    const rawSettings = localStorage.getItem(LOCAL_SETTINGS_STORAGE_KEY);
+
+    if (!rawSettings) {
+      return null;
+    }
+
+    return JSON.parse(rawSettings);
+  } catch (error) {
+    console.warn("Could not read saved RIT settings.", error);
+    return null;
+  }
+}
+
+/**
+ * Saves settings to localStorage.
+ */
+export function saveSettingsToLocalStorage(settings) {
+  try {
+    localStorage.setItem(LOCAL_SETTINGS_STORAGE_KEY, JSON.stringify(settings));
+  } catch (error) {
+    console.warn("Could not save RIT settings.", error);
+  }
+}
+
+/**
+ * Clears saved local settings.
+ */
+export function clearSavedLocalSettings() {
+  try {
+    localStorage.removeItem(LOCAL_SETTINGS_STORAGE_KEY);
+  } catch (error) {
+    console.warn("Could not clear saved RIT settings.", error);
+  }
+}
+
+/**
+ * Applies saved settings to task pane controls.
+ */
+export function applySettingsToPanel(settings) {
+  for (const controlConfig of SETTINGS_CONTROL_CONFIG) {
+    const element = document.getElementById(controlConfig.id);
+
+    if (!element) {
+      continue;
+    }
+
+    const value = settings[controlConfig.settingName];
+
+    if (value === undefined || value === null) {
+      continue;
+    }
+
+    if (controlConfig.type === "checked") {
+      element.checked = Boolean(value);
+      continue;
+    }
+
+    if (controlConfig.type === "number") {
+      element.value = String(value);
+      continue;
+    }
+
+    element.value = String(value);
+  }
+}

--- a/src/taskpane/taskpane.js
+++ b/src/taskpane/taskpane.js
@@ -58,6 +58,16 @@ import {
   buildCheckResolverMessage,
 } from "./taskpane-status";
 
+import {
+  SETTINGS_CONTROL_CONFIG,
+  DEFAULT_CALCULATION_SETTINGS,
+  saveSettingsToLocalStorage,
+  clearSavedLocalSettings,
+  applySettingsToPanel,
+  loadSavedSettingsIntoPanel,
+  initializeSettingsCollapse,
+} from "./taskpane-settings";
+
 const SCAN_CELL_LIMIT = 250000;
 const INVENTORY_CONTENT_SHEET_NAME = "Content";
 const RUN_REPORT_SHEET_NAME = "Run report";
@@ -101,109 +111,6 @@ const INVENTORY_FULL_CHECK_COLUMNS = [
   "Label cols",
 ];
 
-const LOCAL_SETTINGS_STORAGE_KEY = "rit.settings.v1";
-const SETTINGS_COLLAPSED_KEY = "rit.ui.settingsCollapsed";
-
-const SETTINGS_CONTROL_CONFIG = [
-  { id: "confidence-level", type: "value", settingName: "confidenceLevel" },
-
-  {
-    id: "one-tailed-test",
-    type: "checked",
-    settingName: "oneTailedTest",
-  },
-
-  { id: "round-cell-values", type: "checked", settingName: "roundCellValues" },
-
-  {
-    id: "compare-with-previous-column",
-    type: "checked",
-    settingName: "compareWithPreviousColumn",
-  },
-  {
-    id: "apply-previous-column-fill",
-    type: "checked",
-    settingName: "applyPreviousColumnFill",
-  },
-
-  { id: "write-banner-letters", type: "checked", settingName: "writeBannerLetters" },
-  { id: "respect-banner-structure", type: "checked", settingName: "respectBannerStructure" },
-  {
-    id: "auto-detect-wave-banners",
-    type: "checked",
-    settingName: "autoDetectWaveBanners",
-  },
-  { id: "labels-on-left-side", type: "checked", settingName: "labelsOnLeftSide" },
-
-  { id: "compare-only-with-total", type: "checked", settingName: "compareOnlyWithTotal" },
-  {
-    id: "exclude-total-from-comparisons",
-    type: "checked",
-    settingName: "excludeTotalFromComparisons",
-  },
-
-  { id: "first-column-is-total", type: "checked", settingName: "firstColumnIsTotal" },
-  { id: "total-in-each-banner", type: "checked", settingName: "totalInEachBanner" },
-
-  { id: "significant-fill-color", type: "value", settingName: "significantFillColor" },
-  {
-    id: "lower-than-total-fill-color",
-    type: "value",
-    settingName: "lowerThanTotalFillColor",
-  },
-
-  {
-    id: "fill-only-total-comparisons",
-    type: "checked",
-    settingName: "fillOnlyTotalComparisons",
-  },
-
-  {
-    id: "exclude-small-bases",
-    type: "checked",
-    settingName: "excludeSmallBasesFromComparisons",
-  },
-  { id: "small-base-threshold", type: "number", settingName: "smallBaseThreshold" },
-  { id: "small-base-fill-color", type: "value", settingName: "smallBaseFillColor" },
-
-  { id: "preferred-base", type: "value", settingName: "preferredBase" },
-
-  { id: "settings-storage-mode", type: "value", settingName: "settingsStorageMode" },
-];
-
-const DEFAULT_CALCULATION_SETTINGS = {
-  confidenceLevel: "95",
-  oneTailedTest: false,
-
-  roundCellValues: false,
-
-  compareWithPreviousColumn: false,
-  applyPreviousColumnFill: false,
-
-  writeBannerLetters: false,
-  respectBannerStructure: false,
-  autoDetectWaveBanners: false,
-  labelsOnLeftSide: false,
-
-  compareOnlyWithTotal: false,
-  excludeTotalFromComparisons: false,
-
-  firstColumnIsTotal: false,
-  totalInEachBanner: false,
-
-  significantFillColor: "#E2F0D9",
-  lowerThanTotalFillColor: "#FCE4D6",
-
-  fillOnlyTotalComparisons: false,
-
-  excludeSmallBasesFromComparisons: false,
-  smallBaseThreshold: 50,
-  smallBaseFillColor: "#D0D0D0",
-
-  preferredBase: "auto",
-
-  settingsStorageMode: "none",
-};
 
 const SETTINGS_TOOLTIPS = {
   "confidence-level":
@@ -4839,44 +4746,6 @@ function getInputValue(elementId, fallbackValue) {
   return element ? element.value : fallbackValue;
 }
 
-/**
- * Initializes settings panel UI behavior.
- *
- * PURPOSE:
- * Handles mutually exclusive checkbox groups.
- */
-function applySettingsCollapseState(toggleBtn, panelBody, isCollapsed) {
-  toggleBtn.setAttribute("aria-expanded", isCollapsed ? "false" : "true");
-  panelBody.classList.toggle("is-collapsed", isCollapsed);
-}
-
-function initializeSettingsCollapse() {
-  const toggleBtn = document.getElementById("settings-toggle");
-  const panelBody = document.getElementById("settings-panel-body");
-
-  if (!toggleBtn || !panelBody) return;
-
-  let isCollapsed = false;
-  try {
-    const saved = localStorage.getItem(SETTINGS_COLLAPSED_KEY);
-    if (saved !== null) isCollapsed = saved === "true";
-  } catch (_) {
-    /* non-fatal */
-  }
-
-  applySettingsCollapseState(toggleBtn, panelBody, isCollapsed);
-
-  toggleBtn.addEventListener("click", () => {
-    const nextCollapsed = toggleBtn.getAttribute("aria-expanded") === "true";
-    applySettingsCollapseState(toggleBtn, panelBody, nextCollapsed);
-    try {
-      localStorage.setItem(SETTINGS_COLLAPSED_KEY, String(nextCollapsed));
-    } catch (_) {
-      /* non-fatal */
-    }
-  });
-}
-
 function initializeSettingsPanel() {
   initializeSettingsCollapse();
   initializeSettingsTooltips();
@@ -5501,94 +5370,6 @@ function handleSettingsPersistenceAfterChange() {
 
   if (settings.settingsStorageMode === "none") {
     clearSavedLocalSettings();
-  }
-}
-
-/**
- * Loads saved settings into the panel if local saving was enabled.
- */
-function loadSavedSettingsIntoPanel() {
-  const savedSettings = readSettingsFromLocalStorage();
-
-  if (!savedSettings) {
-    return;
-  }
-
-  if (savedSettings.settingsStorageMode !== "local") {
-    return;
-  }
-
-  applySettingsToPanel(savedSettings);
-}
-
-/**
- * Reads saved settings from localStorage.
- */
-function readSettingsFromLocalStorage() {
-  try {
-    const rawSettings = localStorage.getItem(LOCAL_SETTINGS_STORAGE_KEY);
-
-    if (!rawSettings) {
-      return null;
-    }
-
-    return JSON.parse(rawSettings);
-  } catch (error) {
-    console.warn("Could not read saved RIT settings.", error);
-    return null;
-  }
-}
-
-/**
- * Saves settings to localStorage.
- */
-function saveSettingsToLocalStorage(settings) {
-  try {
-    localStorage.setItem(LOCAL_SETTINGS_STORAGE_KEY, JSON.stringify(settings));
-  } catch (error) {
-    console.warn("Could not save RIT settings.", error);
-  }
-}
-
-/**
- * Clears saved local settings.
- */
-function clearSavedLocalSettings() {
-  try {
-    localStorage.removeItem(LOCAL_SETTINGS_STORAGE_KEY);
-  } catch (error) {
-    console.warn("Could not clear saved RIT settings.", error);
-  }
-}
-
-/**
- * Applies saved settings to task pane controls.
- */
-function applySettingsToPanel(settings) {
-  for (const controlConfig of SETTINGS_CONTROL_CONFIG) {
-    const element = document.getElementById(controlConfig.id);
-
-    if (!element) {
-      continue;
-    }
-
-    const value = settings[controlConfig.settingName];
-
-    if (value === undefined || value === null) {
-      continue;
-    }
-
-    if (controlConfig.type === "checked") {
-      element.checked = Boolean(value);
-      continue;
-    }
-
-    if (controlConfig.type === "number") {
-      element.value = String(value);
-      continue;
-    }
-
-    element.value = String(value);
   }
 }
 


### PR DESCRIPTION
## Summary

- Creates `src/taskpane/taskpane-settings.js` as a dedicated settings persistence/state module
- Moves constants and localStorage/collapse helpers out of the 5800-line `taskpane.js`
- `taskpane.js` imports the seven public symbols it still needs — no circular dependencies

## Files changed

- `src/taskpane/taskpane-settings.js` — new module (created)
- `src/taskpane/taskpane.js` — remove moved code, add import

## Exact helpers/constants moved

**Constants:**
- `LOCAL_SETTINGS_STORAGE_KEY`
- `SETTINGS_COLLAPSED_KEY`
- `SETTINGS_CONTROL_CONFIG`
- `DEFAULT_CALCULATION_SETTINGS`

**Functions:**
- `applySettingsCollapseState`
- `initializeSettingsCollapse`
- `loadSavedSettingsIntoPanel`
- `readSettingsFromLocalStorage`
- `saveSettingsToLocalStorage`
- `clearSavedLocalSettings`
- `applySettingsToPanel`

## Helpers intentionally left in taskpane.js and why

- `handleSettingsPersistenceAfterChange` — calls `readCalculationSettingsFromPanel` (stays in taskpane.js); moving it would require importing from taskpane.js, creating a circular dependency
- `initializeSettingsPersistence` — calls `refreshSettingsPanelState` and `handleSettingsPersistenceAfterChange` (both stay)
- `initializeSettingsResetButton` — calls `resetSettingsToDefaults` (stays)
- `resetSettingsToDefaults` — calls `refreshSettingsPanelState` (stays); also calls moved `applySettingsToPanel`/`clearSavedLocalSettings` via import
- `readCalculationSettingsFromPanel` — deeply used by run/check/autorun flows; scope instruction says do not move
- `refreshSettingsPanelState` / `refreshPreviousColumnComparisonState` / `refreshBannerStructureSettingsState` — tightly coupled with UI enable/disable logic
- `initializeAllSettingsControls` / `SETTINGS_TOOLTIPS` / `initializeSettingsTooltips` — scope instruction says leave panel-init wiring in place

## Test/build/lint result

- `npm test` — 302 tests pass, 0 failures
- `npm run build` — succeeds (3 pre-existing webpack size warnings, unchanged)
- `npm run lint` — not run (pre-existing lint debt; no new lint category introduced)
- `git diff --check` — clean

## Confirmation

- Settings behavior unchanged: localStorage persistence, storage mode switching, panel collapse state — all wired identically via the same function bodies, now imported rather than defined locally
- No runtime/product workflow behavior changed: Run, Clear, Check, Autorun all call the same functions unchanged
- No formatting diff beyond the moved code itself

## Technical debt

No new technical debt introduced. This is the second small decomposition PR in the taskpane modularization series.

🤖 Generated with [Claude Code](https://claude.com/claude-code)