### PR TITLE
Extract Run report formatter helpers into taskpane-run-report-formatters

### DIFF
--- a/src/taskpane/taskpane-run-report-formatters.js
+++ b/src/taskpane/taskpane-run-report-formatters.js
@@ -1,0 +1,67 @@
+import { BATCH_SKIP_REASONS } from "../core/batch-candidate-filter";
+
+export function runReportSkipReasonLabel(reason) {
+  switch (reason) {
+    case BATCH_SKIP_REASONS.MISSING_RANGE:      return "Нет диапазона";
+    case BATCH_SKIP_REASONS.CANDIDATE_UNCERTAIN: return "Кандидат неопределён";
+    case BATCH_SKIP_REASONS.CANDIDATE_REJECTED:  return "Не опознан как таблица";
+    default:                                      return "Неизвестный статус";
+  }
+}
+
+export function runReportStatusLabel(status) {
+  switch (status) {
+    case "processed": return "Обработано";
+    case "checked":   return "Проверено";
+    case "skipped":   return "Пропущено";
+    case "blocked":   return "Пропущено";
+    case "error":     return "Ошибка";
+    default:          return status || "";
+  }
+}
+
+export function runReportMetricTypes(item) {
+  if (!item) return "";
+  const parts = [];
+  if (item.hasProportions) parts.push("Пропорции");
+  if (item.hasMeans)       parts.push("Средние");
+  if (item.hasNps)         parts.push("NPS");
+  return parts.join(", ");
+}
+
+/**
+ * Formats issue details from an inventory item into a human-readable string.
+ *
+ * Prefers userVisibleIssues (full issue objects with message and location) when
+ * available. Falls back to qualityIssueCodes (code-only identifiers) for
+ * backward compatibility.
+ *
+ * Does NOT include candidateNotes — callers that need them append separately.
+ */
+export function formatIssueDetailsForReport(item) {
+  if (!item) return "";
+  if (item.userVisibleIssues && item.userVisibleIssues.length > 0) {
+    return item.userVisibleIssues.map((iss) => `[${iss.severity}] ${iss.message}`).join("; ");
+  }
+  if (item.qualityIssueCodes && item.qualityIssueCodes.length > 0) {
+    return item.qualityIssueCodes.map((q) => q.code).join(", ");
+  }
+  return "";
+}
+
+/**
+ * Builds a human-readable warning-detail string for the Run report Details column.
+ *
+ * Uses formatIssueDetailsForReport() for issue messages, then appends
+ * candidateNotes (structural candidate diagnostics).
+ */
+export function runReportWarningDetails(item) {
+  if (!item) return "";
+  const parts = [];
+  const issueDetails = formatIssueDetailsForReport(item);
+  if (issueDetails) parts.push(issueDetails);
+  if (item.candidateNotes && item.candidateNotes.length > 0) {
+    parts.push(...item.candidateNotes);
+  }
+  return parts.join("; ");
+}

--- a/src/taskpane/taskpane.js
+++ b/src/taskpane/taskpane.js
@@ -35,7 +35,7 @@ import { detectBannerStructure } from "../core/banner-detector";
 
 import { normalizeSelectedRange, hasEmptyDataRowGap, selectionHasMultiTableGap } from "../core/range-normalizer";
 
-import { filterWorkbookCandidates, BATCH_SKIP_REASONS } from "../core/batch-candidate-filter";
+import { filterWorkbookCandidates } from "../core/batch-candidate-filter";
 
 import {
   interpretSelectedRange,
@@ -75,6 +75,14 @@ import {
   formatCheckCalculationBlocks,
   formatCheckBannerSummary,
 } from "./taskpane-check-formatters";
+
+import {
+  runReportSkipReasonLabel,
+  runReportStatusLabel,
+  runReportMetricTypes,
+  formatIssueDetailsForReport,
+  runReportWarningDetails,
+} from "./taskpane-run-report-formatters";
 
 const SCAN_CELL_LIMIT = 250000;
 const INVENTORY_CONTENT_SHEET_NAME = "Content";
@@ -958,73 +966,6 @@ function buildItemMetadataMap(inventoryResults) {
   }
   return map;
 }
-
-function runReportSkipReasonLabel(reason) {
-  switch (reason) {
-    case BATCH_SKIP_REASONS.MISSING_RANGE:      return "Нет диапазона";
-    case BATCH_SKIP_REASONS.CANDIDATE_UNCERTAIN: return "Кандидат неопределён";
-    case BATCH_SKIP_REASONS.CANDIDATE_REJECTED:  return "Не опознан как таблица";
-    default:                                      return "Неизвестный статус";
-  }
-}
-
-function runReportStatusLabel(status) {
-  switch (status) {
-    case "processed": return "Обработано";
-    case "checked":   return "Проверено";
-    case "skipped":   return "Пропущено";
-    case "blocked":   return "Пропущено";
-    case "error":     return "Ошибка";
-    default:          return status || "";
-  }
-}
-
-function runReportMetricTypes(item) {
-  if (!item) return "";
-  const parts = [];
-  if (item.hasProportions) parts.push("Пропорции");
-  if (item.hasMeans)       parts.push("Средние");
-  if (item.hasNps)         parts.push("NPS");
-  return parts.join(", ");
-}
-
-/**
- * Formats issue details from an inventory item into a human-readable string.
- *
- * Prefers userVisibleIssues (full issue objects with message and location) when
- * available. Falls back to qualityIssueCodes (code-only identifiers) for
- * backward compatibility.
- *
- * Does NOT include candidateNotes — callers that need them append separately.
- */
-function formatIssueDetailsForReport(item) {
-  if (!item) return "";
-  if (item.userVisibleIssues && item.userVisibleIssues.length > 0) {
-    return item.userVisibleIssues.map((iss) => `[${iss.severity}] ${iss.message}`).join("; ");
-  }
-  if (item.qualityIssueCodes && item.qualityIssueCodes.length > 0) {
-    return item.qualityIssueCodes.map((q) => q.code).join(", ");
-  }
-  return "";
-}
-
-/**
- * Builds a human-readable warning-detail string for the Run report Details column.
- *
- * Uses formatIssueDetailsForReport() for issue messages, then appends
- * candidateNotes (structural candidate diagnostics).
- */
-function runReportWarningDetails(item) {
-  if (!item) return "";
-  const parts = [];
-  const issueDetails = formatIssueDetailsForReport(item);
-  if (issueDetails) parts.push(issueDetails);
-  if (item.candidateNotes && item.candidateNotes.length > 0) {
-    parts.push(...item.candidateNotes);
-  }
-  return parts.join("; ");
-}
-
 
 const RUN_REPORT_COLUMNS = [
   "Лист",


### PR DESCRIPTION
## Summary

Architecture cleanup only — no product behavior changes.

Moves five pure Run report formatting helpers from the large `taskpane.js` into a dedicated new module `src/taskpane/taskpane-run-report-formatters.js`, continuing the taskpane decomposition series.

## Files changed

| File | Change |
|------|--------|
| `src/taskpane/taskpane-run-report-formatters.js` | **New** — exports 5 pure helpers |
| `src/taskpane/taskpane.js` | Imports helpers from new module; removes 5 function definitions and `BATCH_SKIP_REASONS` import |

## Helpers moved

| Helper | Why safe |
|--------|----------|
| `runReportSkipReasonLabel` | Pure: reason → label string; only used by `runReportWarningDetails` and report-row builders |
| `runReportStatusLabel` | Pure: status string → label string; no external deps |
| `runReportMetricTypes` | Pure: item object → comma-separated string; no external deps |
| `formatIssueDetailsForReport` | Pure: item object → issue string; no external deps |
| `runReportWarningDetails` | Pure: composes `formatIssueDetailsForReport` + candidateNotes |

`BATCH_SKIP_REASONS` (previously imported in `taskpane.js` only for `runReportSkipReasonLabel`) is now imported directly in the new module. The `taskpane.js` import was simplified to `{ filterWorkbookCandidates }` only.

## Helpers intentionally left in taskpane.js

| Helper / Constant | Reason |
|-------------------|--------|
| `RUN_REPORT_COLUMNS` | Used by `writeRunReportContent` which writes Excel ranges and stays in `taskpane.js`; moving it would add an import just to support a function that can't be moved |
| `ensureRunReportWorksheet` | Calls `context.sync`, writes Excel worksheet — forbidden to move |
| `writeRunReportContent` | Writes Excel ranges — forbidden to move |
| `writeRunReportSheet` | Calls `Excel.run` — forbidden to move |

## Test / build / lint result

- `npm test`: **302/302 pass**
- `npm run build`: **success** (pre-existing bundle-size warnings only)
- `npm run lint`: pre-existing debt only; **no new lint category introduced**; new file has **0 lint findings**
- `git diff --check`: **clean**

## Report columns / row shape

- `RUN_REPORT_COLUMNS` not moved — column list unchanged.
- Row shape (field names and order in every `checkReportRows.push(...)` call) untouched.
- Generated sheet names `Content` / `Run report` untouched.

## No runtime/product behavior changed

All five moved helpers are pure string-formatting functions. Call sites in `taskpane.js` are identical — only the function definitions relocated. No calculation, writer, detection, or UI logic was touched.

## Manual smoke (for human reviewer)

- Автозапуск → Текущая таблица with report enabled: Base and metric type still filled.
- Автозапуск → Текущий лист with report enabled: report columns/rows still correct.
- Автозапуск → Вся книга with report enabled: report columns/rows still correct.
- Check with Записать результат still writes report as before.
- Generated sheets remain named `Content` / `Run report`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)