### PR TITLE
Extract taskpane inventory/Content formatting helpers

### DIFF
--- a/src/taskpane/taskpane-inventory-formatters.js
+++ b/src/taskpane/taskpane-inventory-formatters.js
@@ -1,0 +1,192 @@
+/**
+ * Pure inventory / Content display helpers.
+ *
+ * No Office.js dependencies, no Excel.run / context.sync calls.
+ * All functions map already-computed inventory data to display text or
+ * plain data structures.
+ */
+
+export const BACKLINK_MARKER = "← Оглавление";
+
+/**
+ * Returns true if the cell value is a generated backlink marker.
+ */
+export function isGeneratedBacklinkRow(cellValue) {
+  if (cellValue === null || cellValue === undefined) return false;
+  return String(cellValue).trim() === BACKLINK_MARKER;
+}
+
+export function getInventoryCandidateStatusLabel(candidateStatus) {
+  if (candidateStatus === "available") {
+    return "Кандидат — рекомендуется «Проверить таблицу»";
+  }
+
+  if (candidateStatus === "uncertain") {
+    return "Кандидат неопределён — требуется «Проверить таблицу»";
+  }
+
+  return "Не опознан как таблица ResearchSignal";
+}
+
+/**
+ * User-facing status label for Content sheet output.
+ * Uses warningsCount / criticalCount to produce plain-language readiness labels
+ * instead of internal candidate-finder wording.
+ */
+export function getContentCandidateStatusLabel(item) {
+  const status = item.candidateStatus;
+  const warnings = item.warningsCount ?? 0;
+  const criticals = item.criticalCount ?? 0;
+
+  if (status === "available") {
+    return warnings > 0 ? "Есть предупреждения" : "Готово к расчёту";
+  }
+
+  if (status === "uncertain") {
+    return criticals > 0 ? "Есть критические проблемы" : "Нужна проверка";
+  }
+
+  return "Пропущено";
+}
+
+export function formatInventoryItemLines(item, index) {
+  const lines = [];
+  // Prefer resolvedTitle (set after backlink normalization) over raw title.
+  // Fall back to raw title only if it is not a generated backlink marker.
+  const displayTitle =
+    item.resolvedTitle ||
+    (item.title && !isGeneratedBacklinkRow(item.title) ? item.title : null);
+  // Prefer resolvedRangeAddress (adjusted for any inserted backlink rows).
+  const displayRange = item.resolvedRangeAddress || item.rangeAddress;
+  const header = displayTitle ? `${index}. ${displayTitle} — ${displayRange}` : `${index}. ${displayRange}`;
+
+  lines.push(header);
+  lines.push(`   ${item.rowCount} строк, ${item.columnCount} колонок.`);
+
+  if (item.previewSummary) {
+    lines.push(`   ${item.previewSummary}.`);
+  }
+
+  if (item.selectedBaseSubtypeLabel) {
+    lines.push(`   База: ${item.selectedBaseSubtypeLabel}.`);
+  }
+
+  const warnParts = [];
+  if (item.criticalCount > 0) warnParts.push(`Критических: ${item.criticalCount}`);
+  if (item.warningsCount > 0) warnParts.push(`Предупреждений: ${item.warningsCount}`);
+  if (warnParts.length > 0) lines.push(`   ${warnParts.join(". ")}.`);
+
+  // candidateStatus replaces the former "Значимость: да/нет" line.
+  // Inventory is a candidate finder only; Check Table is the authoritative step.
+  lines.push(`   ${getInventoryCandidateStatusLabel(item.candidateStatus)}.`);
+
+  if (item.candidateNotes && item.candidateNotes.length > 0) {
+    lines.push(`   [${item.candidateNotes.join("; ")}]`);
+  }
+
+  return lines;
+}
+
+/**
+ * Returns true when a candidate title is a known total/banner/header-like label
+ * that should not be used as a table title in Content output.
+ *
+ * The scanner's detectFirstRowTitle fires on any sparse all-text first row —
+ * including a single-cell "Всего" or "Total" banner — and assigns
+ * titleConfidence "high".  This guard catches those labels before they reach
+ * the Content display layer.
+ *
+ * The list is intentionally conservative: only unambiguous aggregate/total
+ * words that cannot be a real research-table title on their own.
+ *
+ * @param {string} title - Raw title string from the scanner item.
+ * @returns {boolean}
+ */
+export function isContentTitleFallbackLabel(title) {
+  if (!title) return false;
+  const normalized = String(title).trim().toLowerCase();
+  // prettier-ignore
+  const TOTAL_LIKE_LABELS = new Set([
+    "всего",        // Russian "All / Total"
+    "итого",        // Russian "Grand total / Sum"
+    "total",        // English
+    "grand total",  // English compound
+    "overall",      // English
+    "all",          // English
+  ]);
+  return TOTAL_LIKE_LABELS.has(normalized);
+}
+
+/**
+ * Returns the Content-sheet display title for a detected table candidate.
+ *
+ * Only trusts a scanner/resolved title when:
+ *   1. titleConfidence === "high" (first row of the detected band was a
+ *      dedicated sparse heading row, not inferred from rows above), AND
+ *   2. The title is not a known total/banner-like label (e.g. "Всего",
+ *      "Total") that the scanner can legitimately detect as a sparse
+ *      first-row title but that is not a real table heading.
+ *
+ * Falls back to "Таблица N" for:
+ *   - titleConfidence !== "high" (medium / none)
+ *   - title is a known total/banner-like label
+ *   - title equals the generated backlink marker
+ *   - title is empty after all checks
+ *
+ * @param {object} item   - TableInventoryItem (may have resolvedTitle set by normalizeBacklinkItems).
+ * @param {number} index  - 1-based candidate number within the Content output.
+ * @returns {string}
+ */
+export function resolveContentDisplayTitle(item, index) {
+  const fallback = `Таблица ${index}`;
+
+  // Medium/none confidence titles come from rows above the band and may be
+  // banner or header text, not real table headings — always use the fallback.
+  if (item.titleConfidence !== "high") {
+    return fallback;
+  }
+
+  // High-confidence path: prefer post-backlink resolved title, then raw title.
+  const title =
+    item.resolvedTitle ||
+    (isGeneratedBacklinkRow(item.title) ? "" : (item.title || ""));
+
+  // Even high-confidence scanner titles can be total/banner-like labels
+  // (e.g. a lone "Всего" cell at the top of a band passes detectFirstRowTitle).
+  if (isContentTitleFallbackLabel(title)) {
+    return fallback;
+  }
+
+  return title || fallback;
+}
+
+export function buildClientContentRows(sheetResults) {
+  const rows = [];
+  let index = 1;
+  for (const sheetResult of sheetResults) {
+    for (const item of sheetResult.items) {
+      rows.push([index, resolveContentDisplayTitle(item, index), "", item.sheetName || sheetResult.sheetName]);
+      index++;
+    }
+  }
+  if (rows.length === 0) {
+    rows.push(["", "Кандидаты не обнаружены", "", ""]);
+  }
+  return rows;
+}
+
+export function getContentTableHyperlinkTarget(sheetName, rangeAddress) {
+  if (!sheetName || !rangeAddress) return null;
+  const escaped = sheetName.replace(/'/g, "''");
+  const needsQuotes = /[^A-Za-z0-9_]/.test(escaped);
+  const quotedSheet = needsQuotes ? `'${escaped}'` : escaped;
+  return `${quotedSheet}!${rangeAddress}`;
+}
+
+export function getContentRowReference(contentSheetName, contentRow) {
+  if (!contentSheetName || !contentRow) return null;
+  const escaped = contentSheetName.replace(/'/g, "''");
+  const needsQuotes = /[^A-Za-z0-9_]/.test(escaped);
+  const quotedSheet = needsQuotes ? `'${escaped}'` : escaped;
+  return `${quotedSheet}!A${contentRow}`;
+}

--- a/src/taskpane/taskpane.js
+++ b/src/taskpane/taskpane.js
@@ -90,7 +90,6 @@ import {
   getInventoryCandidateStatusLabel,
   getContentCandidateStatusLabel,
   formatInventoryItemLines,
-  isContentTitleFallbackLabel,
   resolveContentDisplayTitle,
   buildClientContentRows,
   getContentTableHyperlinkTarget,
@@ -3681,10 +3680,6 @@ function buildContentRowMap(sheetResults, mode) {
   return map;
 }
 
-/**
- * Builds a hyperlink documentReference pointing to the given 1-based row
- * in the Content sheet (column A).
- */
 /**
  * Returns the first title-like text from a row, or "" if the row is not
  * title-like.  A row qualifies as title-like when it has at most maxNonEmpty

--- a/src/taskpane/taskpane.js
+++ b/src/taskpane/taskpane.js
@@ -84,6 +84,19 @@ import {
   runReportWarningDetails,
 } from "./taskpane-run-report-formatters";
 
+import {
+  BACKLINK_MARKER,
+  isGeneratedBacklinkRow,
+  getInventoryCandidateStatusLabel,
+  getContentCandidateStatusLabel,
+  formatInventoryItemLines,
+  isContentTitleFallbackLabel,
+  resolveContentDisplayTitle,
+  buildClientContentRows,
+  getContentTableHyperlinkTarget,
+  getContentRowReference,
+} from "./taskpane-inventory-formatters";
+
 const SCAN_CELL_LIMIT = 250000;
 const INVENTORY_CONTENT_SHEET_NAME = "Content";
 const RUN_REPORT_SHEET_NAME = "Run report";
@@ -3180,77 +3193,6 @@ async function runCheckSelectedRange() {
 }
 
 
-function getInventoryCandidateStatusLabel(candidateStatus) {
-  if (candidateStatus === "available") {
-    return "Кандидат — рекомендуется «Проверить таблицу»";
-  }
-
-  if (candidateStatus === "uncertain") {
-    return "Кандидат неопределён — требуется «Проверить таблицу»";
-  }
-
-  return "Не опознан как таблица ResearchSignal";
-}
-
-/**
- * User-facing status label for Content sheet output.
- * Uses warningsCount / criticalCount to produce plain-language readiness labels
- * instead of internal candidate-finder wording.
- */
-function getContentCandidateStatusLabel(item) {
-  const status = item.candidateStatus;
-  const warnings = item.warningsCount ?? 0;
-  const criticals = item.criticalCount ?? 0;
-
-  if (status === "available") {
-    return warnings > 0 ? "Есть предупреждения" : "Готово к расчёту";
-  }
-
-  if (status === "uncertain") {
-    return criticals > 0 ? "Есть критические проблемы" : "Нужна проверка";
-  }
-
-  return "Пропущено";
-}
-
-function formatInventoryItemLines(item, index) {
-  const lines = [];
-  // Prefer resolvedTitle (set after backlink normalization) over raw title.
-  // Fall back to raw title only if it is not a generated backlink marker.
-  const displayTitle =
-    item.resolvedTitle ||
-    (item.title && !isGeneratedBacklinkRow(item.title) ? item.title : null);
-  // Prefer resolvedRangeAddress (adjusted for any inserted backlink rows).
-  const displayRange = item.resolvedRangeAddress || item.rangeAddress;
-  const header = displayTitle ? `${index}. ${displayTitle} — ${displayRange}` : `${index}. ${displayRange}`;
-
-  lines.push(header);
-  lines.push(`   ${item.rowCount} строк, ${item.columnCount} колонок.`);
-
-  if (item.previewSummary) {
-    lines.push(`   ${item.previewSummary}.`);
-  }
-
-  if (item.selectedBaseSubtypeLabel) {
-    lines.push(`   База: ${item.selectedBaseSubtypeLabel}.`);
-  }
-
-  const warnParts = [];
-  if (item.criticalCount > 0) warnParts.push(`Критических: ${item.criticalCount}`);
-  if (item.warningsCount > 0) warnParts.push(`Предупреждений: ${item.warningsCount}`);
-  if (warnParts.length > 0) lines.push(`   ${warnParts.join(". ")}.`);
-
-  // candidateStatus replaces the former "Значимость: да/нет" line.
-  // Inventory is a candidate finder only; Check Table is the authoritative step.
-  lines.push(`   ${getInventoryCandidateStatusLabel(item.candidateStatus)}.`);
-
-  if (item.candidateNotes && item.candidateNotes.length > 0) {
-    lines.push(`   [${item.candidateNotes.join("; ")}]`);
-  }
-
-  return lines;
-}
-
 function formatWorkbookInventoryMessage({ scannedSheets, sheetResults, skippedSheets }) {
   const totalCandidates = sheetResults.reduce((sum, sheetResult) => sum + sheetResult.items.length, 0);
   const lines = [
@@ -3743,24 +3685,6 @@ function buildContentRowMap(sheetResults, mode) {
  * Builds a hyperlink documentReference pointing to the given 1-based row
  * in the Content sheet (column A).
  */
-function getContentRowReference(contentSheetName, contentRow) {
-  if (!contentSheetName || !contentRow) return null;
-  const escaped = contentSheetName.replace(/'/g, "''");
-  const needsQuotes = /[^A-Za-z0-9_]/.test(escaped);
-  const quotedSheet = needsQuotes ? `'${escaped}'` : escaped;
-  return `${quotedSheet}!A${contentRow}`;
-}
-
-const BACKLINK_MARKER = "← Оглавление";
-
-/**
- * Returns true if the cell value is a generated backlink marker.
- */
-function isGeneratedBacklinkRow(cellValue) {
-  if (cellValue === null || cellValue === undefined) return false;
-  return String(cellValue).trim() === BACKLINK_MARKER;
-}
-
 /**
  * Returns the first title-like text from a row, or "" if the row is not
  * title-like.  A row qualifies as title-like when it has at most maxNonEmpty
@@ -3895,102 +3819,6 @@ async function ensureBacklinkRows(context, sheetResults, contentRowMap) {
       );
     }
   }
-}
-
-function getContentTableHyperlinkTarget(sheetName, rangeAddress) {
-  if (!sheetName || !rangeAddress) return null;
-  const escaped = sheetName.replace(/'/g, "''");
-  const needsQuotes = /[^A-Za-z0-9_]/.test(escaped);
-  const quotedSheet = needsQuotes ? `'${escaped}'` : escaped;
-  return `${quotedSheet}!${rangeAddress}`;
-}
-
-/**
- * Returns true when a candidate title is a known total/banner/header-like label
- * that should not be used as a table title in Content output.
- *
- * The scanner's detectFirstRowTitle fires on any sparse all-text first row —
- * including a single-cell "Всего" or "Total" banner — and assigns
- * titleConfidence "high".  This guard catches those labels before they reach
- * the Content display layer.
- *
- * The list is intentionally conservative: only unambiguous aggregate/total
- * words that cannot be a real research-table title on their own.
- *
- * @param {string} title - Raw title string from the scanner item.
- * @returns {boolean}
- */
-function isContentTitleFallbackLabel(title) {
-  if (!title) return false;
-  const normalized = String(title).trim().toLowerCase();
-  // prettier-ignore
-  const TOTAL_LIKE_LABELS = new Set([
-    "всего",        // Russian "All / Total"
-    "итого",        // Russian "Grand total / Sum"
-    "total",        // English
-    "grand total",  // English compound
-    "overall",      // English
-    "all",          // English
-  ]);
-  return TOTAL_LIKE_LABELS.has(normalized);
-}
-
-/**
- * Returns the Content-sheet display title for a detected table candidate.
- *
- * Only trusts a scanner/resolved title when:
- *   1. titleConfidence === "high" (first row of the detected band was a
- *      dedicated sparse heading row, not inferred from rows above), AND
- *   2. The title is not a known total/banner-like label (e.g. "Всего",
- *      "Total") that the scanner can legitimately detect as a sparse
- *      first-row title but that is not a real table heading.
- *
- * Falls back to "Таблица N" for:
- *   - titleConfidence !== "high" (medium / none)
- *   - title is a known total/banner-like label
- *   - title equals the generated backlink marker
- *   - title is empty after all checks
- *
- * @param {object} item   - TableInventoryItem (may have resolvedTitle set by normalizeBacklinkItems).
- * @param {number} index  - 1-based candidate number within the Content output.
- * @returns {string}
- */
-function resolveContentDisplayTitle(item, index) {
-  const fallback = `Таблица ${index}`;
-
-  // Medium/none confidence titles come from rows above the band and may be
-  // banner or header text, not real table headings — always use the fallback.
-  if (item.titleConfidence !== "high") {
-    return fallback;
-  }
-
-  // High-confidence path: prefer post-backlink resolved title, then raw title.
-  const title =
-    item.resolvedTitle ||
-    (isGeneratedBacklinkRow(item.title) ? "" : (item.title || ""));
-
-  // Even high-confidence scanner titles can be total/banner-like labels
-  // (e.g. a lone "Всего" cell at the top of a band passes detectFirstRowTitle).
-  if (isContentTitleFallbackLabel(title)) {
-    return fallback;
-  }
-
-  return title || fallback;
-}
-
-function buildClientContentRows(sheetResults) {
-  const rows = [];
-  let index = 1;
-  for (const sheetResult of sheetResults) {
-    for (const item of sheetResult.items) {
-      rows.push([index, resolveContentDisplayTitle(item, index), "", item.sheetName || sheetResult.sheetName]);
-      index++;
-    }
-  }
-  if (rows.length === 0) {
-    rows.push(["", "Кандидаты не обнаружены", "", ""]);
-  }
-  return rows;
 }
 
 async function ensureInventoryContentWorksheet(context) {


### PR DESCRIPTION
## Summary

- Create `src/taskpane/taskpane-inventory-formatters.js` with 10 pure presentation helpers extracted from `taskpane.js`.
- Import them back into `taskpane.js`; no call-site changes.
- Architecture cleanup only — no behavior changes.

## Files changed

| File | Change |
|---|---|
| `src/taskpane/taskpane-inventory-formatters.js` | New — exports 10 helpers + `BACKLINK_MARKER` constant |
| `src/taskpane/taskpane.js` | Remove 185 lines of definitions; add import block |

`taskpane.js`: 5377 → 5205 lines (−172).

## Helpers moved

| Helper | Notes |
|---|---|
| `BACKLINK_MARKER` | Presentation-only constant `"← Оглавление"` |
| `isGeneratedBacklinkRow` | Checks if cell value equals `BACKLINK_MARKER` |
| `getInventoryCandidateStatusLabel` | Maps `candidateStatus` → Russian label |
| `getContentCandidateStatusLabel` | Maps candidate `warningsCount`/`criticalCount` → status label |
| `formatInventoryItemLines` | Formats one inventory item into display lines |
| `isContentTitleFallbackLabel` | Guards against total/banner-like scanner titles |
| `resolveContentDisplayTitle` | Resolves Content-sheet display title for a candidate |
| `buildClientContentRows` | Builds client-mode Content row array |
| `getContentTableHyperlinkTarget` | Maps sheet name + range → hyperlink target string |
| `getContentRowReference` | Maps sheet name + row → `Sheet!A<row>` reference |

## Helpers intentionally left in `taskpane.js`

| Helper | Reason |
|---|---|
| `formatWorkbookInventoryMessage` | References `INVENTORY_CONTENT_SHEET_NAME` and `SCAN_CELL_LIMIT` directly from module scope; changing its signature would be extra churn for no gain in this PR |
| `resolveTitleLikeText` | Used only inside `normalizeBacklinkItems` (backlink processing logic), not a display formatter |
| `parseRangeStartCell` / `adjustRangeRows` | Range parsing utilities used by both backlink and batch-writing code |
| `normalizeBacklinkItems` | Backlink state processing, not a formatter |
| `writeOrUpdateBacklink` / `ensureBacklinkRows` | Excel writers |

## Build / test / lint

- `npm test`: **302/302 pass**
- `npm run build`: **success** (pre-existing size warnings unchanged)
- `npm run lint`: pre-existing 405 lint issues, no new category introduced by this PR
- `git diff --check`: clean

## Content columns and row shape

Not changed. `writeInventoryContentSheet`, `writeInventoryContent`, `ensureInventoryContentWorksheet`, `INVENTORY_CONTENT_COLUMNS`, and all Excel-writing functions remain in `taskpane.js` untouched.

## No runtime/product behavior changes

All moved functions are pure — no `Excel.run`, no `context.sync`, no workbook reads or writes. Extracted as-is with identical string content. Import replaces local definition transparently.

## Test plan

- [ ] `npm test` passes (302/302)
- [ ] `npm run build` succeeds
- [ ] Оглавление → Вся книга creates/updates Content sheet
- [ ] Content sheet columns and row values unchanged
- [ ] All Content output modes work (Для клиента, С минимальной проверкой, С полной проверкой)
- [ ] Safe fallback "Таблица N" still appears when no reliable title
- [ ] Backlinks still work if enabled
- [ ] Generated sheets still named Content / Run report
- [ ] Run / Check / Autorun quick sanity passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)