### PR TITLE
Add dev-only performance baseline for key taskpane flows

### DIFF
--- a/src/taskpane/taskpane-performance.js
+++ b/src/taskpane/taskpane-performance.js
@@ -1,0 +1,38 @@
+// Development-only performance instrumentation for RIT taskpane flows.
+//
+// Enable:  localStorage.setItem('RIT_PERF', '1')   (in browser DevTools)
+// Disable: localStorage.removeItem('RIT_PERF')
+//
+// When enabled, each instrumented flow emits a single console.debug entry:
+//   [RIT perf] <flowName>  { phase1Ms, phase2Ms, ..., totalMs }
+//
+// All exported functions are no-ops when disabled, adding zero overhead to
+// production runs.
+
+const _perfEnabled = (() => {
+  try {
+    return typeof localStorage !== "undefined" && localStorage.getItem("RIT_PERF") === "1";
+  } catch (_) {
+    return false;
+  }
+})();
+
+export function perfEnabled() {
+  return _perfEnabled;
+}
+
+// Returns Date.now() when enabled, 0 otherwise.
+export function perfNow() {
+  return _perfEnabled ? Date.now() : 0;
+}
+
+// Returns milliseconds elapsed since startMs when enabled, 0 otherwise.
+export function perfElapsed(startMs) {
+  return _perfEnabled && startMs ? Date.now() - startMs : 0;
+}
+
+// Emits a console.debug entry when enabled. No-op otherwise.
+export function perfLog(flowName, phases) {
+  if (!_perfEnabled) return;
+  console.debug("[RIT perf]", flowName, phases);
+}

--- a/src/taskpane/taskpane-performance.js
+++ b/src/taskpane/taskpane-performance.js
@@ -9,30 +9,30 @@
 // All exported functions are no-ops when disabled, adding zero overhead to
 // production runs.
 
-const _perfEnabled = (() => {
+function _perfEnabled() {
   try {
     return typeof localStorage !== "undefined" && localStorage.getItem("RIT_PERF") === "1";
   } catch (_) {
     return false;
   }
-})();
+}
 
 export function perfEnabled() {
-  return _perfEnabled;
+  return _perfEnabled();
 }
 
 // Returns Date.now() when enabled, 0 otherwise.
 export function perfNow() {
-  return _perfEnabled ? Date.now() : 0;
+  return _perfEnabled() ? Date.now() : 0;
 }
 
 // Returns milliseconds elapsed since startMs when enabled, 0 otherwise.
 export function perfElapsed(startMs) {
-  return _perfEnabled && startMs ? Date.now() - startMs : 0;
+  return _perfEnabled() && startMs ? Date.now() - startMs : 0;
 }
 
 // Emits a console.debug entry when enabled. No-op otherwise.
 export function perfLog(flowName, phases) {
-  if (!_perfEnabled) return;
+  if (!_perfEnabled()) return;
   console.debug("[RIT perf]", flowName, phases);
 }

--- a/src/taskpane/taskpane.js
+++ b/src/taskpane/taskpane.js
@@ -96,6 +96,8 @@ import {
   getContentRowReference,
 } from "./taskpane-inventory-formatters";
 
+import { perfNow, perfElapsed, perfLog } from "./taskpane-performance";
+
 const SCAN_CELL_LIMIT = 250000;
 const INVENTORY_CONTENT_SHEET_NAME = "Content";
 const RUN_REPORT_SHEET_NAME = "Run report";
@@ -444,6 +446,7 @@ function initActionScopeShell() {
  * - NPS + SD/Variance + Base
  */
 async function runSignificanceFromSelection() {
+  const _t0 = perfNow();
   await Excel.run(async (context) => {
     const calculationSettings = readCalculationSettingsFromPanel();
     if (calculationSettings.compareWithPreviousColumn && calculationSettings.compareOnlyWithTotal) {
@@ -516,6 +519,7 @@ async function runSignificanceFromSelection() {
       return;
     }
 
+    const _tInterp = perfNow();
     const interpretation = await interpretSelectedRange(
       context,
       selectedRange,
@@ -681,6 +685,7 @@ async function runSignificanceFromSelection() {
 
     keepMarkersOnlyInAllowedRows(fullCellResultMatrix, allowedMarkerRows);
 
+    const _tWrite = perfNow();
     writeCellResultsToSelectedRange(
       writeTargetRange,
       textForCalculation,
@@ -743,6 +748,11 @@ async function runSignificanceFromSelection() {
       statusMessages.push(bannerUserMessages);
     }
 
+    perfLog("runSignificanceFromSelection", {
+      interpretMs: _tWrite - _tInterp,
+      writeMs: perfElapsed(_tWrite),
+      totalMs: perfElapsed(_t0),
+    });
     setStatusMessage(
       appendSelectedRangeGuardrailMessages(statusMessages, selectedRangeGuardrailWarnings).join(
         "\n"
@@ -1115,6 +1125,7 @@ function writeRunReportContent(worksheet, reportRows, runLabel) {
  *   that content forward.
  */
 async function writeRunReportSheet(context, reportRows, runLabel) {
+  const _t0 = perfNow();
   const worksheet = await ensureRunReportWorksheet(context);
 
   const existingUsed = worksheet.getUsedRangeOrNullObject();
@@ -1145,6 +1156,7 @@ async function writeRunReportSheet(context, reportRows, runLabel) {
   await context.sync();
 
   if (worksheet.position === worksheets.count - 1) {
+    perfLog("writeRunReportSheet", { totalMs: perfElapsed(_t0), tier: 1 });
     return worksheet; // Tier 1 succeeded — sheet is already last.
   }
 
@@ -1167,6 +1179,7 @@ async function writeRunReportSheet(context, reportRows, runLabel) {
 
   if (lastSheet === null) {
     // The Run report is the only sheet; it is trivially last.
+    perfLog("writeRunReportSheet", { totalMs: perfElapsed(_t0), tier: "only-sheet" });
     return worksheet;
   }
 
@@ -1186,6 +1199,7 @@ async function writeRunReportSheet(context, reportRows, runLabel) {
   copy.name = RUN_REPORT_SHEET_NAME;
   await context.sync();
 
+  perfLog("writeRunReportSheet", { totalMs: perfElapsed(_t0), tier: 2 });
   return copy;
 }
 
@@ -1201,6 +1215,7 @@ async function writeRunReportSheet(context, reportRows, runLabel) {
  * significance status panel when done.
  */
 async function runAutoSignificance() {
+  const _t0 = perfNow();
   const calculationSettings = readCalculationSettingsFromPanel();
 
   if (calculationSettings.compareWithPreviousColumn && calculationSettings.compareOnlyWithTotal) {
@@ -1244,6 +1259,7 @@ async function runAutoSignificance() {
   }
 
   // Collect inventory to identify eligible candidates.
+  const _tScan = perfNow();
   let inventoryResults;
   try {
     await Excel.run(async (context) => {
@@ -1315,6 +1331,7 @@ async function runAutoSignificance() {
   let processed = 0;
   let errors = 0;
 
+  const _tLoop = perfNow();
   for (const candidate of eligible) {
     const item = itemMap.get(`${candidate.sheetName}!${candidate.rangeAddress}`);
     try {
@@ -1373,6 +1390,7 @@ async function runAutoSignificance() {
     }
   }
 
+  const _tLoopDone = perfNow();
   const summaryLines = [
     "Автозапуск завершён.",
     `Обработано таблиц: ${processed}.`,
@@ -1384,6 +1402,12 @@ async function runAutoSignificance() {
     summaryLines.push("", ...detailLines);
   }
 
+  perfLog("runAutoSignificance", {
+    scanMs: _tLoop - _tScan,
+    loopMs: _tLoopDone - _tLoop,
+    tablesProcessed: processed,
+    totalMs: perfElapsed(_t0),
+  });
   setStatusMessage(summaryLines.join("\n"));
 
   if (addReport) {
@@ -1411,6 +1435,7 @@ async function runAutoSignificance() {
  * Delegates the significance pipeline to runSignificanceForRange.
  */
 async function runAutoCurrentTableSignificance() {
+  const _t0 = perfNow();
   const calculationSettings = readCalculationSettingsFromPanel();
 
   if (calculationSettings.compareWithPreviousColumn && calculationSettings.compareOnlyWithTotal) {
@@ -1520,6 +1545,7 @@ async function runAutoCurrentTableSignificance() {
   const { sheetName, rangeAddress } = resolverResult;
   const resolvedTableTitle = resolveContentDisplayTitle(resolverResult.candidateMeta, 1);
 
+  const _tRun = perfNow();
   let result;
   try {
     result = await runSignificanceForRange(sheetName, rangeAddress, calculationSettings);
@@ -1556,6 +1582,11 @@ async function runAutoCurrentTableSignificance() {
       ? t("status.autorunProcessed", { sheet: sheetName, range: rangeAddress, count: result.blocksProcessed })
       : t("status.autorunSkipped", { msg: result.message || t("status.resolverFallback") });
 
+  perfLog("runAutoCurrentTableSignificance", {
+    resolveMs: _tRun - _t0,
+    runMs: perfElapsed(_tRun),
+    totalMs: perfElapsed(_t0),
+  });
   setStatusMessage(statusMsg);
 
   if (addReport) {
@@ -1856,6 +1887,7 @@ async function clearAutoSignificance() {
  * Settings validation is identical to runAutoSignificance().
  */
 async function runCurrentSheetSignificance() {
+  const _t0 = perfNow();
   const calculationSettings = readCalculationSettingsFromPanel();
 
   if (calculationSettings.compareWithPreviousColumn && calculationSettings.compareOnlyWithTotal) {
@@ -1898,6 +1930,7 @@ async function runCurrentSheetSignificance() {
     return;
   }
 
+  const _tScan = perfNow();
   let inventoryResults;
   try {
     await Excel.run(async (context) => {
@@ -1965,6 +1998,7 @@ async function runCurrentSheetSignificance() {
   let processed = 0;
   let errors = 0;
 
+  const _tLoop = perfNow();
   for (const candidate of eligible) {
     const item = itemMap.get(`${candidate.sheetName}!${candidate.rangeAddress}`);
     try {
@@ -2023,6 +2057,7 @@ async function runCurrentSheetSignificance() {
     }
   }
 
+  const _tLoopDone = perfNow();
   const summaryLines = [
     "Лист — запуск завершён.",
     `Обработано таблиц: ${processed}.`,
@@ -2034,6 +2069,12 @@ async function runCurrentSheetSignificance() {
     summaryLines.push("", ...detailLines);
   }
 
+  perfLog("runCurrentSheetSignificance", {
+    scanMs: _tLoop - _tScan,
+    loopMs: _tLoopDone - _tLoop,
+    tablesProcessed: processed,
+    totalMs: perfElapsed(_t0),
+  });
   setStatusMessage(summaryLines.join("\n"));
 
   if (addReport) {
@@ -4234,7 +4275,9 @@ async function writeInventoryContentSheet(context, inventoryResults) {
 
 async function runTableInventory() {
   await Excel.run(async (context) => {
+    const _t0 = perfNow();
     const inventoryResults = await collectWorkbookInventoryResults(context, readCalculationSettingsFromPanel());
+    const _tScan = perfNow();
     const addBacklinks = readBacklinkSettingFromPanel();
     const contentMode = readContentOutputModeFromPanel();
 
@@ -4260,6 +4303,11 @@ async function runTableInventory() {
     contentWorksheet.activate();
     await context.sync();
 
+    perfLog("runTableInventory", {
+      scanMs: _tScan - _t0,
+      contentWriteMs: perfElapsed(_tScan),
+      totalMs: perfElapsed(_t0),
+    });
     setInventoryMessage(
       formatWorkbookInventoryMessage({
         scannedSheets: inventoryResults.scannedSheets,


### PR DESCRIPTION
## Summary

- Adds `src/taskpane/taskpane-performance.js` — a new pure module with four exported helpers (`perfEnabled`, `perfNow`, `perfElapsed`, `perfLog`) gated behind `localStorage.getItem('RIT_PERF') === '1'`. All functions are no-ops when the flag is absent.
- Instruments six flow entry points in `src/taskpane/taskpane.js` with phase-level timing that emits `[RIT perf] <flowName> { ...phases, totalMs }` via `console.debug` when enabled.

## Flows instrumented

| Flow | Phases measured |
|---|---|
| `runSignificanceFromSelection` | `interpretMs`, `writeMs`, `totalMs` |
| `runAutoCurrentTableSignificance` | `resolveMs`, `runMs`, `totalMs` |
| `runCurrentSheetSignificance` | `scanMs`, `loopMs`, `tablesProcessed`, `totalMs` |
| `runAutoSignificance` | `scanMs`, `loopMs`, `tablesProcessed`, `totalMs` |
| `runTableInventory` (Content generation) | `scanMs`, `contentWriteMs`, `totalMs` |
| `writeRunReportSheet` (Run report writing) | `totalMs`, `tier` (1 / 2 / only-sheet) |

## How to enable

In browser DevTools console while the add-in taskpane is open:
```js
localStorage.setItem('RIT_PERF', '1')
// then trigger the flow — results appear in DevTools console as:
// [RIT perf] runSignificanceFromSelection { interpretMs: 42, writeMs: 381, totalMs: 437 }

// Disable:
localStorage.removeItem('RIT_PERF')
```

## Skipped measurement points and why

**`context.sync` call counting** — skipped. The only safe approach without monkey-patching the Office.js global would be to replace every `await context.sync()` call site with a counted wrapper. That touches ~40+ call sites across `taskpane.js` and is too invasive for a pure instrumentation PR. Will revisit in a follow-up if sync count is needed for optimization work.

## Build / test result

- `npm test` — 302/302 pass, 0 fail
- `npm run build` — compiled successfully; only pre-existing bundle-size warnings (no new warnings)
- `git diff --check` — no whitespace issues

## No product behavior changed

- All instrumentation is behind `RIT_PERF` flag; no-ops in production
- No UI output added; no status messages changed
- No statistical logic touched
- `significance.js` and `excel-writer.js` not modified

## Technical debt

None introduced. Instrumentation is additive and deletable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)