### PR TITLE
Support runtime RIT_PERF flag when storage is blocked

### DIFF
--- a/docs/PERFORMANCE_BASELINE.md
+++ b/docs/PERFORMANCE_BASELINE.md
@@ -17,12 +17,28 @@ Use this baseline to capture current timing characteristics before 1.0 so later 
 Enable the dev-only instrumentation from the taskpane devtools console:
 
 ```js
+window.__RIT_PERF = true
+```
+
+This runtime flag is read dynamically, so the next flow you run should emit timing logs without reloading the taskpane. This path is useful when Office or the WebView blocks storage access.
+
+The existing storage-backed path still works when storage is available:
+
+```js
 localStorage.setItem('RIT_PERF', '1')
 ```
 
-The flag is read dynamically, so the next flow you run should emit timing logs without reloading the taskpane.
+That flag is also read dynamically, so no taskpane reload is required.
+
+When enabled, the instrumentation emits `[RIT perf]` timing logs through `console.info`, which is usually visible in DevTools without changing the default log filter.
 
 To disable it later:
+
+```js
+window.__RIT_PERF = false
+```
+
+Or, if you enabled it through storage:
 
 ```js
 localStorage.removeItem('RIT_PERF')

--- a/src/taskpane/taskpane-performance.js
+++ b/src/taskpane/taskpane-performance.js
@@ -2,11 +2,16 @@
 //
 // Enable from DevTools with either:
 //   window.__RIT_PERF = true
+//   window.__RIT_PERF = "1"
 //   localStorage.setItem('RIT_PERF', '1')
 //
 // Disable with either:
 //   window.__RIT_PERF = false
 //   localStorage.removeItem('RIT_PERF')
+//
+// The runtime window/globalThis flag takes priority over storage. This lets
+// DevTools disable logging for the current taskpane session even if a stored
+// RIT_PERF value exists.
 //
 // The flag is read dynamically on every call, so no taskpane reload is needed.
 //
@@ -16,13 +21,22 @@
 // All exported functions are no-ops when disabled, adding zero overhead to
 // production runs.
 
-function _perfWindowFlagEnabled() {
+function _readPerfRuntimeFlag() {
   try {
-    if (typeof globalThis === "undefined") return false;
-    return globalThis.__RIT_PERF === true;
+    if (typeof globalThis === "undefined") return undefined;
+    return globalThis.__RIT_PERF;
   } catch (_) {
-    return false;
+    return undefined;
   }
+}
+
+function _perfRuntimeFlagEnabled() {
+  const runtimeFlag = _readPerfRuntimeFlag();
+
+  if (runtimeFlag === true || runtimeFlag === "1") return true;
+  if (runtimeFlag === false || runtimeFlag === "0") return false;
+
+  return undefined;
 }
 
 function _perfStorageFlagEnabled() {
@@ -34,7 +48,11 @@ function _perfStorageFlagEnabled() {
 }
 
 function _perfEnabled() {
-  return _perfWindowFlagEnabled() || _perfStorageFlagEnabled();
+  const runtimeEnabled = _perfRuntimeFlagEnabled();
+
+  if (runtimeEnabled !== undefined) return runtimeEnabled;
+
+  return _perfStorageFlagEnabled();
 }
 
 export function perfEnabled() {

--- a/src/taskpane/taskpane-performance.js
+++ b/src/taskpane/taskpane-performance.js
@@ -1,20 +1,40 @@
 // Development-only performance instrumentation for RIT taskpane flows.
 //
-// Enable:  localStorage.setItem('RIT_PERF', '1')   (in browser DevTools)
-// Disable: localStorage.removeItem('RIT_PERF')
+// Enable from DevTools with either:
+//   window.__RIT_PERF = true
+//   localStorage.setItem('RIT_PERF', '1')
 //
-// When enabled, each instrumented flow emits a single console.debug entry:
+// Disable with either:
+//   window.__RIT_PERF = false
+//   localStorage.removeItem('RIT_PERF')
+//
+// The flag is read dynamically on every call, so no taskpane reload is needed.
+//
+// When enabled, each instrumented flow emits a single console.info entry:
 //   [RIT perf] <flowName>  { phase1Ms, phase2Ms, ..., totalMs }
 //
 // All exported functions are no-ops when disabled, adding zero overhead to
 // production runs.
 
-function _perfEnabled() {
+function _perfWindowFlagEnabled() {
+  try {
+    if (typeof globalThis === "undefined") return false;
+    return globalThis.__RIT_PERF === true;
+  } catch (_) {
+    return false;
+  }
+}
+
+function _perfStorageFlagEnabled() {
   try {
     return typeof localStorage !== "undefined" && localStorage.getItem("RIT_PERF") === "1";
   } catch (_) {
     return false;
   }
+}
+
+function _perfEnabled() {
+  return _perfWindowFlagEnabled() || _perfStorageFlagEnabled();
 }
 
 export function perfEnabled() {
@@ -31,8 +51,8 @@ export function perfElapsed(startMs) {
   return _perfEnabled() && startMs ? Date.now() - startMs : 0;
 }
 
-// Emits a console.debug entry when enabled. No-op otherwise.
+// Emits a console.info entry when enabled. No-op otherwise.
 export function perfLog(flowName, phases) {
   if (!_perfEnabled()) return;
-  console.debug("[RIT perf]", flowName, phases);
+  console.info("[RIT perf]", flowName, phases);
 }


### PR DESCRIPTION
## Files changed
- src/taskpane/taskpane-performance.js
- docs/PERFORMANCE_BASELINE.md

## Summary
- Added a runtime devtools flag path via window.__RIT_PERF = true so dev-only performance logging works even when Office/WebView blocks storage access.
- Kept the existing localStorage.setItem('RIT_PERF', '1') path working when storage is available.
- Continued reading the flag dynamically on each helper call, so no taskpane reload is required.
- Switched [RIT perf] output from console.debug to console.info so logs are visible in DevTools by default more often.
- Updated the performance baseline doc with the new runtime enable/disable flow.

## Validation result
- 
pm test passed: 302/302 tests.
- 
pm.cmd run build passed.
- git diff --check passed for whitespace checks; local Git still prints working-tree line-ending warnings for the touched files in this environment.

## Manual smoke
- Not run here. This environment cannot open Excel taskpane DevTools for the requested manual verification steps.

## Assumptions / limitations
- window.__RIT_PERF = true is treated as a strictly dev-only runtime switch and does not change product behavior outside instrumentation.
- The runtime flag is checked via globalThis.__RIT_PERF so it works from taskpane DevTools without requiring changes in 	askpane.js.
- I did not add context.sync counting or any new timing phases.