### PR TITLE
Batch autorun tables in single Excel.run context (#258)

### DIFF
--- a/src/taskpane/taskpane.js
+++ b/src/taskpane/taskpane.js
@@ -763,206 +763,222 @@ async function runSignificanceFromSelection() {
 
 
 /**
- * Runs the full significance pipeline for a single named range on a named sheet.
+ * Core significance pipeline for a single named range, using a caller-supplied
+ * Office.js RequestContext.
  *
- * Mirrors the core calculation path of runSignificanceFromSelection() without
- * touching the selected-range UI state. Returns a compact result object so the
- * caller can aggregate per-table outcomes without crashing on the first failure.
+ * Extracted so sheet/workbook autorun loops can share one Excel.run context
+ * across all tables, amortising per-context initialisation overhead. Callers
+ * that need a self-contained execution unit use runSignificanceForRange below,
+ * which wraps this function in its own Excel.run.
  *
  * Returns { status, blocksProcessed, message, rangeAddress }.
  * status: "processed" | "skipped" | "blocked" | "error"
- *
- * NOTE: runSignificanceFromSelection() and this helper share the same pipeline
- * logic. A future refactor could unify them once the auto-runner pattern is
- * proven stable. Tracked as a follow-up tech-debt item.
  */
-async function runSignificanceForRange(sheetName, rangeAddress, calculationSettings) {
-  return await Excel.run(async (context) => {
-    const worksheet = context.workbook.worksheets.getItem(sheetName);
-    const sourceRange = worksheet.getRange(rangeAddress);
+async function runSignificanceForRangeInContext(context, sheetName, rangeAddress, calculationSettings) {
+  const worksheet = context.workbook.worksheets.getItem(sheetName);
+  const sourceRange = worksheet.getRange(rangeAddress);
 
-    sourceRange.load(["values", "text", "rowIndex", "columnIndex", "rowCount", "columnCount"]);
+  sourceRange.load(["values", "text", "rowIndex", "columnIndex", "rowCount", "columnCount"]);
 
-    await context.sync();
+  await context.sync();
 
-    const selectedValues = sourceRange.values;
-    const selectedText = sourceRange.text;
+  const selectedValues = sourceRange.values;
+  const selectedText = sourceRange.text;
 
-    if (!selectedValues || selectedValues.length < 2 || selectedValues[0].length < 2) {
-      return { status: "skipped", message: "слишком мало данных", rangeAddress };
-    }
+  if (!selectedValues || selectedValues.length < 2 || selectedValues[0].length < 2) {
+    return { status: "skipped", message: "слишком мало данных", rangeAddress };
+  }
 
-    const interpretation = await interpretSelectedRange(
-      context,
-      sourceRange,
-      selectedValues,
-      selectedText,
-      calculationSettings
-    );
+  const interpretation = await interpretSelectedRange(
+    context,
+    sourceRange,
+    selectedValues,
+    selectedText,
+    calculationSettings
+  );
 
-    if (interpretation.state === "blocked") {
-      const codes =
-        interpretation.blockingReasons && interpretation.blockingReasons.length > 0
-          ? ` [${interpretation.blockingReasons.join(", ")}]`
-          : "";
-      return {
-        status: "blocked",
-        message: `${interpretation.blockingMessage}${codes}`,
-        rangeAddress,
-      };
-    }
-
-    const {
-      valuesForCalculation,
-      textForCalculation,
-      leftLabelValues,
-      bannerContext: interpretedBannerContext,
-    } = interpretation;
-
-    let { writeTargetRange } = interpretation;
-
-    if (
-      !valuesForCalculation ||
-      valuesForCalculation.length < 2 ||
-      !valuesForCalculation[0] ||
-      valuesForCalculation[0].length < 2
-    ) {
-      return { status: "skipped", message: "нет данных для расчёта", rangeAddress };
-    }
-
-    writeTargetRange.load(["rowIndex", "columnIndex", "rowCount", "columnCount"]);
-
-    await context.sync();
-
-    const targetStartRowIndex = writeTargetRange.rowIndex;
-
-    if (calculationSettings.writeBannerLetters && targetStartRowIndex === 0) {
-      return {
-        status: "skipped",
-        message: "данные в первой строке — баннер недоступен",
-        rangeAddress,
-      };
-    }
-
-    writeTargetRange.values = valuesForCalculation;
-    writeTargetRange.format.font.bold = false;
-    writeTargetRange.format.fill.clear();
-    writeTargetRange.format.horizontalAlignment = "Center";
-    writeTargetRange.format.verticalAlignment = "Center";
-
-    await context.sync();
-
-    const detectionResult = detectMetricRowsFromLeftLabels(valuesForCalculation, leftLabelValues);
-    const calculationBlocks = buildCalculationBlocks(detectionResult, { preferredBase: calculationSettings.preferredBase });
-
-    if (!calculationBlocks || calculationBlocks.length === 0) {
-      return { status: "skipped", message: "нет блоков расчёта", rangeAddress };
-    }
-
-    let bannerStructure = null;
-
-    if (calculationSettings.respectBannerStructure) {
-      const bannerContext = interpretedBannerContext;
-      bannerStructure = detectBannerStructure(bannerContext, calculationSettings);
-      if (bannerContext && bannerContext.messages && bannerContext.messages.length > 0) {
-        bannerStructure.messages = [...bannerContext.messages, ...(bannerStructure.messages || [])];
-      }
-    }
-
-    const fullCellResultMatrix = createEmptyCellResultMatrix(
-      valuesForCalculation.length,
-      valuesForCalculation[0].length
-    );
-
-    for (const calculationBlock of calculationBlocks) {
-      const smallBaseResult = applySmallBaseRulesForCalculationBlock(
-        valuesForCalculation,
-        calculationBlock,
-        fullCellResultMatrix,
-        calculationSettings
-      );
-
-      if (smallBaseResult.errorMessage) {
-        return { status: "error", message: smallBaseResult.errorMessage, rangeAddress };
-      }
-
-      const blockCalculationSettings = {
-        ...calculationSettings,
-        excludedColumnIndexes: smallBaseResult.excludedColumnIndexes,
-        bannerStructure,
-      };
-
-      const blockResults = calculateBlockResults(
-        valuesForCalculation,
-        calculationBlock,
-        blockCalculationSettings
-      );
-
-      const bannerStructureError = getFirstBannerStructureError(bannerStructure);
-
-      if (bannerStructureError) {
-        return { status: "error", message: bannerStructureError.text, rangeAddress };
-      }
-
-      if (!blockResults) {
-        continue;
-      }
-
-      applyComparisonResultsToFullCellResultMatrix(
-        blockResults,
-        fullCellResultMatrix,
-        blockCalculationSettings
-      );
-    }
-
-    const allowedMarkerRows = getAllowedMarkerRowIndexes(calculationBlocks);
-
-    keepMarkersOnlyInAllowedRows(fullCellResultMatrix, allowedMarkerRows);
-
-    writeCellResultsToSelectedRange(
-      writeTargetRange,
-      textForCalculation,
-      fullCellResultMatrix,
-      detectionResult,
-      calculationSettings
-    );
-
-    if (calculationSettings.writeBannerLetters) {
-      await clearStaleBannerMarkersLeftOfWriteRange(
-        context,
-        writeTargetRange.worksheet,
-        sourceRange.columnIndex,
-        writeTargetRange.rowIndex,
-        writeTargetRange.columnIndex
-      );
-
-      // Pre-clear all existing banner markers above the write range before
-      // writing fresh ones.  Same reason as in runSignificanceFromSelection:
-      // vertically merged banner cells retain stale markers when re-run with
-      // different banner/wave settings.
-      await clearBannerMarkersAboveRange(context, writeTargetRange);
-
-      if (calculationSettings.respectBannerStructure && bannerStructure) {
-        await writeBannerMarkersAboveSelectedRangeUsingBannerStructure(
-          context,
-          writeTargetRange,
-          bannerStructure,
-          calculationSettings
-        );
-      } else {
-        await writeBannerMarkersAboveSelectedRange(context, writeTargetRange, calculationSettings);
-      }
-    }
-
-    await context.sync();
-
+  if (interpretation.state === "blocked") {
+    const codes =
+      interpretation.blockingReasons && interpretation.blockingReasons.length > 0
+        ? ` [${interpretation.blockingReasons.join(", ")}]`
+        : "";
     return {
-      status: "processed",
-      blocksProcessed: calculationBlocks.length,
-      message: `обработано блоков: ${calculationBlocks.length}`,
+      status: "blocked",
+      message: `${interpretation.blockingMessage}${codes}`,
       rangeAddress,
     };
-  });
+  }
+
+  const {
+    valuesForCalculation,
+    textForCalculation,
+    leftLabelValues,
+    bannerContext: interpretedBannerContext,
+  } = interpretation;
+
+  const { writeTargetRange } = interpretation;
+
+  if (
+    !valuesForCalculation ||
+    valuesForCalculation.length < 2 ||
+    !valuesForCalculation[0] ||
+    valuesForCalculation[0].length < 2
+  ) {
+    return { status: "skipped", message: "нет данных для расчёта", rangeAddress };
+  }
+
+  // Compute write-target row/column indices from the already-loaded sourceRange
+  // properties rather than issuing a separate load+sync on writeTargetRange.
+  // sourceRange.rowIndex and .columnIndex are loaded in the sync above;
+  // interpretation.dataRowOffset / dataColOffset are pure-JS values from the
+  // normalization path, so no additional round-trip is required.
+  const targetStartRowIndex = sourceRange.rowIndex + interpretation.dataRowOffset;
+  const targetStartColIndex = sourceRange.columnIndex + interpretation.dataColOffset;
+
+  if (calculationSettings.writeBannerLetters && targetStartRowIndex === 0) {
+    return {
+      status: "skipped",
+      message: "данные в первой строке — баннер недоступен",
+      rangeAddress,
+    };
+  }
+
+  writeTargetRange.values = valuesForCalculation;
+  writeTargetRange.format.font.bold = false;
+  writeTargetRange.format.fill.clear();
+  writeTargetRange.format.horizontalAlignment = "Center";
+  writeTargetRange.format.verticalAlignment = "Center";
+
+  await context.sync();
+
+  const detectionResult = detectMetricRowsFromLeftLabels(valuesForCalculation, leftLabelValues);
+  const calculationBlocks = buildCalculationBlocks(detectionResult, { preferredBase: calculationSettings.preferredBase });
+
+  if (!calculationBlocks || calculationBlocks.length === 0) {
+    return { status: "skipped", message: "нет блоков расчёта", rangeAddress };
+  }
+
+  let bannerStructure = null;
+
+  if (calculationSettings.respectBannerStructure) {
+    const bannerContext = interpretedBannerContext;
+    bannerStructure = detectBannerStructure(bannerContext, calculationSettings);
+    if (bannerContext && bannerContext.messages && bannerContext.messages.length > 0) {
+      bannerStructure.messages = [...bannerContext.messages, ...(bannerStructure.messages || [])];
+    }
+  }
+
+  const fullCellResultMatrix = createEmptyCellResultMatrix(
+    valuesForCalculation.length,
+    valuesForCalculation[0].length
+  );
+
+  for (const calculationBlock of calculationBlocks) {
+    const smallBaseResult = applySmallBaseRulesForCalculationBlock(
+      valuesForCalculation,
+      calculationBlock,
+      fullCellResultMatrix,
+      calculationSettings
+    );
+
+    if (smallBaseResult.errorMessage) {
+      return { status: "error", message: smallBaseResult.errorMessage, rangeAddress };
+    }
+
+    const blockCalculationSettings = {
+      ...calculationSettings,
+      excludedColumnIndexes: smallBaseResult.excludedColumnIndexes,
+      bannerStructure,
+    };
+
+    const blockResults = calculateBlockResults(
+      valuesForCalculation,
+      calculationBlock,
+      blockCalculationSettings
+    );
+
+    const bannerStructureError = getFirstBannerStructureError(bannerStructure);
+
+    if (bannerStructureError) {
+      return { status: "error", message: bannerStructureError.text, rangeAddress };
+    }
+
+    if (!blockResults) {
+      continue;
+    }
+
+    applyComparisonResultsToFullCellResultMatrix(
+      blockResults,
+      fullCellResultMatrix,
+      blockCalculationSettings
+    );
+  }
+
+  const allowedMarkerRows = getAllowedMarkerRowIndexes(calculationBlocks);
+
+  keepMarkersOnlyInAllowedRows(fullCellResultMatrix, allowedMarkerRows);
+
+  writeCellResultsToSelectedRange(
+    writeTargetRange,
+    textForCalculation,
+    fullCellResultMatrix,
+    detectionResult,
+    calculationSettings
+  );
+
+  if (calculationSettings.writeBannerLetters) {
+    await clearStaleBannerMarkersLeftOfWriteRange(
+      context,
+      writeTargetRange.worksheet,
+      sourceRange.columnIndex,
+      targetStartRowIndex,
+      targetStartColIndex
+    );
+
+    // Pre-clear all existing banner markers above the write range before
+    // writing fresh ones.  Same reason as in runSignificanceFromSelection:
+    // vertically merged banner cells retain stale markers when re-run with
+    // different banner/wave settings.
+    await clearBannerMarkersAboveRange(context, writeTargetRange);
+
+    if (calculationSettings.respectBannerStructure && bannerStructure) {
+      await writeBannerMarkersAboveSelectedRangeUsingBannerStructure(
+        context,
+        writeTargetRange,
+        bannerStructure,
+        calculationSettings
+      );
+    } else {
+      await writeBannerMarkersAboveSelectedRange(context, writeTargetRange, calculationSettings);
+    }
+  }
+
+  await context.sync();
+
+  return {
+    status: "processed",
+    blocksProcessed: calculationBlocks.length,
+    message: `обработано блоков: ${calculationBlocks.length}`,
+    rangeAddress,
+  };
+}
+
+
+/**
+ * Runs the full significance pipeline for a single named range on a named sheet.
+ *
+ * Thin wrapper around runSignificanceForRangeInContext that provides its own
+ * Excel.run context. Used by current-table autorun and as a per-table fallback
+ * when the shared-context batch in sheet/workbook autorun encounters an
+ * Office.js error that corrupts the shared context.
+ *
+ * Returns { status, blocksProcessed, message, rangeAddress }.
+ * status: "processed" | "skipped" | "blocked" | "error"
+ */
+async function runSignificanceForRange(sheetName, rangeAddress, calculationSettings) {
+  return Excel.run((context) =>
+    runSignificanceForRangeInContext(context, sheetName, rangeAddress, calculationSettings)
+  );
 }
 
 
@@ -1331,30 +1347,86 @@ async function runAutoSignificance() {
   let processed = 0;
   let errors = 0;
 
+  // Process all eligible tables in a single Excel.run to amortise per-context
+  // overhead. If any table causes an Office.js sync error (corrupting the shared
+  // context), we record that table as an error, exit the shared context, and
+  // fall back to per-table Excel.run for any remaining candidates.
   const _tLoop = perfNow();
-  for (const candidate of eligible) {
+  let _batchEndedAt = 0;
+  try {
+    await Excel.run(async (context) => {
+      for (let _bi = 0; _bi < eligible.length; _bi++) {
+        const candidate = eligible[_bi];
+        const item = itemMap.get(`${candidate.sheetName}!${candidate.rangeAddress}`);
+        try {
+          const result = await runSignificanceForRangeInContext(
+            context,
+            candidate.sheetName,
+            candidate.rangeAddress,
+            calculationSettings
+          );
+          if (result.status === "processed") {
+            processed++;
+          } else if (result.status === "skipped" || result.status === "blocked") {
+            skipped++;
+            detailLines.push(`- ${candidate.sheetName} ${candidate.rangeAddress}: пропущено — ${result.message}`);
+          } else {
+            errors++;
+            detailLines.push(`- ${candidate.sheetName} ${candidate.rangeAddress}: ошибка — ${result.message}`);
+          }
+          reportRows.push({
+            sheetName: candidate.sheetName,
+            title: candidate.title,
+            rangeAddress: candidate.rangeAddress,
+            status: result.status,
+            message: result.message || "",
+            selectedBase: item ? (item.selectedBaseSubtypeLabel || "") : "",
+            metricTypes: runReportMetricTypes(item),
+            warnings: item ? (item.warningsCount ?? "") : "",
+            critical: item ? (item.criticalCount ?? "") : "",
+            warningDetails: runReportWarningDetails(item),
+            blocksProcessed: result.blocksProcessed != null ? result.blocksProcessed : "",
+          });
+        } catch (err) {
+          errors++;
+          const errMsg = err.message || "неизвестная ошибка";
+          detailLines.push(`- ${candidate.sheetName} ${candidate.rangeAddress}: ошибка — ${errMsg}`);
+          reportRows.push({
+            sheetName: candidate.sheetName,
+            title: candidate.title,
+            rangeAddress: candidate.rangeAddress,
+            status: "error",
+            message: errMsg,
+            selectedBase: item ? (item.selectedBaseSubtypeLabel || "") : "",
+            metricTypes: runReportMetricTypes(item),
+            warnings: item ? (item.warningsCount ?? "") : "",
+            critical: item ? (item.criticalCount ?? "") : "",
+            warningDetails: runReportWarningDetails(item),
+            blocksProcessed: "",
+          });
+          _batchEndedAt = _bi + 1;
+          throw err; // shared context may be corrupted; exit batch
+        }
+      }
+      _batchEndedAt = eligible.length;
+    });
+  } catch (_batchErr) {
+    // shared context aborted; fall back to per-table for any remaining candidates
+  }
+  for (let _fi = _batchEndedAt; _fi < eligible.length; _fi++) {
+    const candidate = eligible[_fi];
     const item = itemMap.get(`${candidate.sheetName}!${candidate.rangeAddress}`);
     try {
-      const result = await runSignificanceForRange(
-        candidate.sheetName,
-        candidate.rangeAddress,
-        calculationSettings
-      );
-
+      const result = await runSignificanceForRange(candidate.sheetName, candidate.rangeAddress, calculationSettings);
       if (result.status === "processed") {
         processed++;
       } else if (result.status === "skipped" || result.status === "blocked") {
         skipped++;
-        detailLines.push(
-          `- ${candidate.sheetName} ${candidate.rangeAddress}: пропущено — ${result.message}`
-        );
+        detailLines.push(`- ${candidate.sheetName} ${candidate.rangeAddress}: пропущено — ${result.message}`);
       } else {
         errors++;
-        detailLines.push(
-          `- ${candidate.sheetName} ${candidate.rangeAddress}: ошибка — ${result.message}`
-        );
+        detailLines.push(`- ${candidate.sheetName} ${candidate.rangeAddress}: ошибка — ${result.message}`);
       }
-
       reportRows.push({
         sheetName: candidate.sheetName,
         title: candidate.title,
@@ -1371,9 +1443,7 @@ async function runAutoSignificance() {
     } catch (err) {
       errors++;
       const errMsg = err.message || "неизвестная ошибка";
-      detailLines.push(
-        `- ${candidate.sheetName} ${candidate.rangeAddress}: ошибка — ${errMsg}`
-      );
+      detailLines.push(`- ${candidate.sheetName} ${candidate.rangeAddress}: ошибка — ${errMsg}`);
       reportRows.push({
         sheetName: candidate.sheetName,
         title: candidate.title,
@@ -1998,30 +2068,86 @@ async function runCurrentSheetSignificance() {
   let processed = 0;
   let errors = 0;
 
+  // Process all eligible tables in a single Excel.run to amortise per-context
+  // overhead. Same fallback strategy as runAutoSignificance: on any Office.js
+  // sync error we record that table as an error, exit the shared context, and
+  // continue with per-table Excel.run for any remaining candidates.
   const _tLoop = perfNow();
-  for (const candidate of eligible) {
+  let _batchEndedAt = 0;
+  try {
+    await Excel.run(async (context) => {
+      for (let _bi = 0; _bi < eligible.length; _bi++) {
+        const candidate = eligible[_bi];
+        const item = itemMap.get(`${candidate.sheetName}!${candidate.rangeAddress}`);
+        try {
+          const result = await runSignificanceForRangeInContext(
+            context,
+            candidate.sheetName,
+            candidate.rangeAddress,
+            calculationSettings
+          );
+          if (result.status === "processed") {
+            processed++;
+          } else if (result.status === "skipped" || result.status === "blocked") {
+            skipped++;
+            detailLines.push(`- ${candidate.sheetName} ${candidate.rangeAddress}: пропущено — ${result.message}`);
+          } else {
+            errors++;
+            detailLines.push(`- ${candidate.sheetName} ${candidate.rangeAddress}: ошибка — ${result.message}`);
+          }
+          reportRows.push({
+            sheetName: candidate.sheetName,
+            title: candidate.title,
+            rangeAddress: candidate.rangeAddress,
+            status: result.status,
+            message: result.message || "",
+            selectedBase: item ? (item.selectedBaseSubtypeLabel || "") : "",
+            metricTypes: runReportMetricTypes(item),
+            warnings: item ? (item.warningsCount ?? "") : "",
+            critical: item ? (item.criticalCount ?? "") : "",
+            warningDetails: runReportWarningDetails(item),
+            blocksProcessed: result.blocksProcessed != null ? result.blocksProcessed : "",
+          });
+        } catch (err) {
+          errors++;
+          const errMsg = err.message || "неизвестная ошибка";
+          detailLines.push(`- ${candidate.sheetName} ${candidate.rangeAddress}: ошибка — ${errMsg}`);
+          reportRows.push({
+            sheetName: candidate.sheetName,
+            title: candidate.title,
+            rangeAddress: candidate.rangeAddress,
+            status: "error",
+            message: errMsg,
+            selectedBase: item ? (item.selectedBaseSubtypeLabel || "") : "",
+            metricTypes: runReportMetricTypes(item),
+            warnings: item ? (item.warningsCount ?? "") : "",
+            critical: item ? (item.criticalCount ?? "") : "",
+            warningDetails: runReportWarningDetails(item),
+            blocksProcessed: "",
+          });
+          _batchEndedAt = _bi + 1;
+          throw err; // shared context may be corrupted; exit batch
+        }
+      }
+      _batchEndedAt = eligible.length;
+    });
+  } catch (_batchErr) {
+    // shared context aborted; fall back to per-table for any remaining candidates
+  }
+  for (let _fi = _batchEndedAt; _fi < eligible.length; _fi++) {
+    const candidate = eligible[_fi];
     const item = itemMap.get(`${candidate.sheetName}!${candidate.rangeAddress}`);
     try {
-      const result = await runSignificanceForRange(
-        candidate.sheetName,
-        candidate.rangeAddress,
-        calculationSettings
-      );
-
+      const result = await runSignificanceForRange(candidate.sheetName, candidate.rangeAddress, calculationSettings);
       if (result.status === "processed") {
         processed++;
       } else if (result.status === "skipped" || result.status === "blocked") {
         skipped++;
-        detailLines.push(
-          `- ${candidate.sheetName} ${candidate.rangeAddress}: пропущено — ${result.message}`
-        );
+        detailLines.push(`- ${candidate.sheetName} ${candidate.rangeAddress}: пропущено — ${result.message}`);
       } else {
         errors++;
-        detailLines.push(
-          `- ${candidate.sheetName} ${candidate.rangeAddress}: ошибка — ${result.message}`
-        );
+        detailLines.push(`- ${candidate.sheetName} ${candidate.rangeAddress}: ошибка — ${result.message}`);
       }
-
       reportRows.push({
         sheetName: candidate.sheetName,
         title: candidate.title,
@@ -2038,9 +2164,7 @@ async function runCurrentSheetSignificance() {
     } catch (err) {
       errors++;
       const errMsg = err.message || "неизвестная ошибка";
-      detailLines.push(
-        `- ${candidate.sheetName} ${candidate.rangeAddress}: ошибка — ${errMsg}`
-      );
+      detailLines.push(`- ${candidate.sheetName} ${candidate.rangeAddress}: ошибка — ${errMsg}`);
       reportRows.push({
         sheetName: candidate.sheetName,
         title: candidate.title,


### PR DESCRIPTION
## Root cause confirmed

Sheet/workbook autorun called `runSignificanceForRange` once per candidate. That function wrapped each table in its own `Excel.run(async (context) => {...})`, creating N separate Office.js request contexts. Each context initialization adds overhead on top of the 4–5 `context.sync()` round-trips already needed per table. For 38 tables (workbook baseline: loopMs 4766 ms) that is 38 context creations that can be amortised.

## Changes

**`src/taskpane/taskpane.js`**

- **Extracted `runSignificanceForRangeInContext(context, sheetName, rangeAddress, calculationSettings)`** — body of `runSignificanceForRange` promoted to a standalone function that accepts a caller-supplied `RequestContext`. No logic changes to the significance/write pipeline.

- **`runSignificanceForRange`** reduced to a thin `Excel.run` wrapper delegating to the new function. All existing callers (current-table autorun, clear fallback) are unaffected.

- **Eliminated one `context.sync()` per table** — removed the `writeTargetRange.load(["rowIndex","columnIndex","rowCount","columnCount"])` + sync that previously preceded each write phase. `targetStartRowIndex` and `targetStartColIndex` are now computed from `sourceRange.rowIndex + interpretation.dataRowOffset` / `sourceRange.columnIndex + interpretation.dataColOffset`, which are already loaded in the first sync. Saves one round-trip per table in both the shared-context and per-table fallback paths.

- **`runAutoSignificance` and `runCurrentSheetSignificance` loops** updated to call `runSignificanceForRangeInContext` inside a single `Excel.run`. Per-table error isolation is preserved: on any Office.js sync error the shared context is abandoned (`throw err` exits the `Excel.run`), the failed table is recorded as `error`, and a fallback `for` loop processes any remaining candidates with individual `runSignificanceForRange` calls (each with their own context).

## Before/after RIT_PERF (estimated from baseline; no live re-measure)

| Flow | Before | Expected after |
|---|---|---|
| Sheet autorun (5 tables) | loopMs ~898 | ~450–600 ms |
| Workbook autorun (38 tables) | loopMs ~4766 | ~1200–2500 ms |

The saving scales with N: for the workbook case (38 tables) the shared context eliminates 37 `Excel.run` overhead costs and 38 extra `context.sync()` calls.

## Test / build result

- `npm test`: 302 tests, 0 failures ✓
- `npm run build`: compiled with 0 errors (pre-existing bundle-size warnings only) ✓
- `git diff --check`: no whitespace errors ✓

## Smoke checklist (for human tester)

- [ ] Manual selected-range Run still works (unchanged path — `runSignificanceFromSelection` not modified)
- [ ] Current-table autorun still works (`runSignificanceForRange` wrapper unchanged)
- [ ] Current-sheet autorun still works (shared-context loop)
- [ ] Workbook autorun still works (shared-context loop)
- [ ] Run report output shape unchanged
- [ ] Capture `RIT_PERF` logs before/after for current-sheet or workbook autorun

## Known limitations

- The shared context is abandoned on the **first** Office.js sync error in any table. Subsequent tables use per-table contexts (original behavior). This is correct — a corrupted context cannot be reused — but means a single transient error will cause N − i remaining tables to run in the slower per-table path for that invocation.
- No statistical formula, significance marker semantics, or Excel writer behavior changed.
- `writeRunReportSheet` optimization deferred per issue scope.

## No statistical/writer behavior changed

The change affects only how the Office.js execution context is shared between table calls. The significance calculation pipeline (`runSignificanceForRangeInContext`) is byte-for-byte identical to the previous `runSignificanceForRange` body except for the eliminated `writeTargetRange.load` + sync, which only loaded properties already derivable from `sourceRange`.

Fixes #258.

🤖 Generated with [Claude Code](https://claude.com/claude-code)