### PR TITLE
perf: add phase timing and remove intermediate sync from autorun loop (#260)

### DIFF
--- a/src/taskpane/taskpane.js
+++ b/src/taskpane/taskpane.js
@@ -775,12 +775,14 @@ async function runSignificanceFromSelection() {
  * status: "processed" | "skipped" | "blocked" | "error"
  */
 async function runSignificanceForRangeInContext(context, sheetName, rangeAddress, calculationSettings) {
+  const _p0 = perfNow();
   const worksheet = context.workbook.worksheets.getItem(sheetName);
   const sourceRange = worksheet.getRange(rangeAddress);
 
   sourceRange.load(["values", "text", "rowIndex", "columnIndex", "rowCount", "columnCount"]);
 
   await context.sync();
+  const _pLoad = perfNow();
 
   const selectedValues = sourceRange.values;
   const selectedText = sourceRange.text;
@@ -827,6 +829,8 @@ async function runSignificanceForRangeInContext(context, sheetName, rangeAddress
     return { status: "skipped", message: "нет данных для расчёта", rangeAddress };
   }
 
+  const _pInterp = perfNow();
+
   // Compute write-target row/column indices from the already-loaded sourceRange
   // properties rather than issuing a separate load+sync on writeTargetRange.
   // sourceRange.rowIndex and .columnIndex are loaded in the sync above;
@@ -849,8 +853,10 @@ async function runSignificanceForRangeInContext(context, sheetName, rangeAddress
   writeTargetRange.format.horizontalAlignment = "Center";
   writeTargetRange.format.verticalAlignment = "Center";
 
-  await context.sync();
-
+  // No intermediate sync here. The pre-write format ops and
+  // writeCellResultsToSelectedRange are all writes with no intervening Excel
+  // reads, so they can share the final context.sync below. Removing this
+  // round-trip saves one Office.js sync per table in the autorun batch loop.
   const detectionResult = detectMetricRowsFromLeftLabels(valuesForCalculation, leftLabelValues);
   const calculationBlocks = buildCalculationBlocks(detectionResult, { preferredBase: calculationSettings.preferredBase });
 
@@ -918,6 +924,8 @@ async function runSignificanceForRangeInContext(context, sheetName, rangeAddress
 
   keepMarkersOnlyInAllowedRows(fullCellResultMatrix, allowedMarkerRows);
 
+  const _pCalc = perfNow();
+
   writeCellResultsToSelectedRange(
     writeTargetRange,
     textForCalculation,
@@ -954,12 +962,19 @@ async function runSignificanceForRangeInContext(context, sheetName, rangeAddress
   }
 
   await context.sync();
+  const _pWrite = perfNow();
 
   return {
     status: "processed",
     blocksProcessed: calculationBlocks.length,
     message: `обработано блоков: ${calculationBlocks.length}`,
     rangeAddress,
+    _phasesMs: _p0 !== 0 ? {
+      loadMs: _pLoad - _p0,
+      interpMs: _pInterp - _pLoad,
+      calcMs: _pCalc - _pInterp,
+      writeMs: _pWrite - _pCalc,
+    } : null,
   };
 }
 
@@ -976,9 +991,13 @@ async function runSignificanceForRangeInContext(context, sheetName, rangeAddress
  * status: "processed" | "skipped" | "blocked" | "error"
  */
 async function runSignificanceForRange(sheetName, rangeAddress, calculationSettings) {
-  return Excel.run((context) =>
+  const result = await Excel.run((context) =>
     runSignificanceForRangeInContext(context, sheetName, rangeAddress, calculationSettings)
   );
+  if (result._phasesMs) {
+    perfLog("runSignificanceForRange", { ...result._phasesMs, rangeAddress });
+  }
+  return result;
 }
 
 
@@ -1352,6 +1371,7 @@ async function runAutoSignificance() {
   // context), we record that table as an error, exit the shared context, and
   // fall back to per-table Excel.run for any remaining candidates.
   const _tLoop = perfNow();
+  const _perfPhases = { loadMs: 0, interpMs: 0, calcMs: 0, writeMs: 0 };
   let _batchEndedAt = 0;
   try {
     await Excel.run(async (context) => {
@@ -1373,6 +1393,12 @@ async function runAutoSignificance() {
           } else {
             errors++;
             detailLines.push(`- ${candidate.sheetName} ${candidate.rangeAddress}: ошибка — ${result.message}`);
+          }
+          if (result._phasesMs) {
+            _perfPhases.loadMs += result._phasesMs.loadMs;
+            _perfPhases.interpMs += result._phasesMs.interpMs;
+            _perfPhases.calcMs += result._phasesMs.calcMs;
+            _perfPhases.writeMs += result._phasesMs.writeMs;
           }
           reportRows.push({
             sheetName: candidate.sheetName,
@@ -1427,6 +1453,12 @@ async function runAutoSignificance() {
         errors++;
         detailLines.push(`- ${candidate.sheetName} ${candidate.rangeAddress}: ошибка — ${result.message}`);
       }
+      if (result._phasesMs) {
+        _perfPhases.loadMs += result._phasesMs.loadMs;
+        _perfPhases.interpMs += result._phasesMs.interpMs;
+        _perfPhases.calcMs += result._phasesMs.calcMs;
+        _perfPhases.writeMs += result._phasesMs.writeMs;
+      }
       reportRows.push({
         sheetName: candidate.sheetName,
         title: candidate.title,
@@ -1476,6 +1508,7 @@ async function runAutoSignificance() {
     scanMs: _tLoop - _tScan,
     loopMs: _tLoopDone - _tLoop,
     tablesProcessed: processed,
+    ...(processed > 0 ? { perTablePhaseMs: _perfPhases } : {}),
     totalMs: perfElapsed(_t0),
   });
   setStatusMessage(summaryLines.join("\n"));
@@ -2073,6 +2106,7 @@ async function runCurrentSheetSignificance() {
   // sync error we record that table as an error, exit the shared context, and
   // continue with per-table Excel.run for any remaining candidates.
   const _tLoop = perfNow();
+  const _perfPhases = { loadMs: 0, interpMs: 0, calcMs: 0, writeMs: 0 };
   let _batchEndedAt = 0;
   try {
     await Excel.run(async (context) => {
@@ -2094,6 +2128,12 @@ async function runCurrentSheetSignificance() {
           } else {
             errors++;
             detailLines.push(`- ${candidate.sheetName} ${candidate.rangeAddress}: ошибка — ${result.message}`);
+          }
+          if (result._phasesMs) {
+            _perfPhases.loadMs += result._phasesMs.loadMs;
+            _perfPhases.interpMs += result._phasesMs.interpMs;
+            _perfPhases.calcMs += result._phasesMs.calcMs;
+            _perfPhases.writeMs += result._phasesMs.writeMs;
           }
           reportRows.push({
             sheetName: candidate.sheetName,
@@ -2148,6 +2188,12 @@ async function runCurrentSheetSignificance() {
         errors++;
         detailLines.push(`- ${candidate.sheetName} ${candidate.rangeAddress}: ошибка — ${result.message}`);
       }
+      if (result._phasesMs) {
+        _perfPhases.loadMs += result._phasesMs.loadMs;
+        _perfPhases.interpMs += result._phasesMs.interpMs;
+        _perfPhases.calcMs += result._phasesMs.calcMs;
+        _perfPhases.writeMs += result._phasesMs.writeMs;
+      }
       reportRows.push({
         sheetName: candidate.sheetName,
         title: candidate.title,
@@ -2197,6 +2243,7 @@ async function runCurrentSheetSignificance() {
     scanMs: _tLoop - _tScan,
     loopMs: _tLoopDone - _tLoop,
     tablesProcessed: processed,
+    ...(processed > 0 ? { perTablePhaseMs: _perfPhases } : {}),
     totalMs: perfElapsed(_t0),
   });
   setStatusMessage(summaryLines.join("\n"));


### PR DESCRIPTION
## Phase breakdown (root cause analysis)

For each table processed by `runSignificanceForRangeInContext`, the pre-#260 sync count per table was:

| Phase | Syncs |
|---|---|
| Source range load | 1 |
| `interpretSelectedRange` (label load) | 1–2 (incl. redundant selectedRange.load) |
| `interpretSelectedRange` (banner load, if respectBannerStructure) | 1–2 |
| **Pre-write clear (intermediate sync — removed here)** | **1** |
| Final write + sync | 1 |
| **Total (banner off)** | **4–5 per table** |
| **Total (banner on)** | **7–9 per table** |

With 38 tables and ~15 ms per sync, the intermediate sync alone accounts for roughly 570 ms of the measured 3584 ms loopMs.

## Optimization implemented

**Removed the intermediate `context.sync()` in `runSignificanceForRangeInContext`** (line ~852 pre-patch).

That sync was placed between the pre-write format clear (`writeTargetRange.format.fill.clear()` etc.) and the significance calculation. It was unnecessary because:
- No Excel reads occur between those writes and the final `context.sync()`.
- The significance calculation is pure JS on already-loaded `valuesForCalculation`.
- `writeCellResultsToSelectedRange` only issues writes (no reads).
- Office.js processes queued operations in order within a single sync, so `fill.clear()` followed by `writeCellResultsToSelectedRange` fills is correct without an intermediate flush.

Saving 1 sync × 38 tables ≈ **~500–700 ms** expected reduction in workbook autorun `loopMs`.

## Timing instrumentation added

Granular `RIT_PERF` phase markers added inside `runSignificanceForRangeInContext`:
- `loadMs` — first source range load + sync
- `interpMs` — `interpretSelectedRange` total (includes all label/banner loads)
- `calcMs` — pure-JS detection + significance calculation
- `writeMs` — `writeCellResultsToSelectedRange` + final sync (+ banner writes when enabled)

Aggregated across all tables and reported in the outer `perfLog` as `perTablePhaseMs`:
```
[RIT perf] runAutoSignificance {
  scanMs: 82,
  loopMs: ...,
  tablesProcessed: 38,
  perTablePhaseMs: { loadMs: ..., interpMs: ..., calcMs: ..., writeMs: ... },
  totalMs: ...
}
```
Single-table autorun (`runSignificanceForRange`) logs phases per-call.

## Files changed

- `src/taskpane/taskpane.js` — 50 lines added, 3 removed

## Build / test result

- `npm test`: 302/302 pass, 0 fail
- `npm run build`: compiled with 3 warnings (pre-existing bundle-size warnings, no new issues)
- `git diff --check`: clean

## Known limitations

- `interpMs` captures the full `interpretSelectedRange` time, which includes two sub-phases with redundant `selectedRange.load()` calls:
  - `loadLabelsImmediatelyLeftOfSelection` re-loads `rowIndex/columnIndex/rowCount` that are already loaded from sync #1
  - `loadBannerContextForSelectedRange` does the same
  Both cost 1 extra sync each per table. If `interpMs` shows as the dominant phase in measurement, a follow-up in `selected-range-interpreter.js` can eliminate these with a small parameter-passing change (allowed files clause covers this).
- The intermediate sync in the **manual selected-range Run** path (`runSignificanceFromSelection`) is not removed — the user may notice the visual "reset" mid-run as a feature, and it is not in the autorun hot path.

## No behavior changes

- Statistical formulas unchanged.
- Marker semantics unchanged.
- Writer output unchanged.
- Manual selected-range Run unchanged.
- Current-table autorun unchanged.
- Run report shape unchanged.

## Smoke testing (manual, in Excel)

The following flows should be verified before merge:
- [ ] Manual selected-range Run (should be identical)
- [ ] Current-table autorun (totalMs should be similar to pre-patch ~197 ms)
- [ ] Current-sheet autorun with RIT_PERF (observe perTablePhaseMs breakdown)
- [ ] Workbook autorun with RIT_PERF (observe perTablePhaseMs, loopMs should be lower)
- [ ] Run report shape unchanged
- [ ] Capture before/after RIT_PERF logs for PERFORMANCE_BASELINE.md update

🤖 Generated with [Claude Code](https://claude.com/claude-code)