### PR TITLE
Skip redundant metadata load+sync in label/banner loaders during autorun

### DIFF
--- a/src/taskpane/selected-range-interpreter.js
+++ b/src/taskpane/selected-range-interpreter.js
@@ -437,26 +437,35 @@ function sanitizeBannerContextForDetection(bannerContext) {
  * If labelsOnLeftSide is enabled, reads labels from the leftmost sheet columns.
  *
  * Exported for use by runMetricDetectionDiagnostics.
+ *
+ * @param {object|null} meta - Optional preloaded range metadata { rowIndex, columnIndex, rowCount }.
+ *   When provided, skips a redundant load+sync for those properties.
  */
-export async function loadLabelValuesForSelectedRange(context, selectedRange, calculationSettings) {
+export async function loadLabelValuesForSelectedRange(context, selectedRange, calculationSettings, meta = null) {
   if (calculationSettings.labelsOnLeftSide) {
-    return loadLabelsFromLeftSideOfSheet(context, selectedRange);
+    return loadLabelsFromLeftSideOfSheet(context, selectedRange, meta);
   }
 
-  return loadLabelsImmediatelyLeftOfSelection(context, selectedRange);
+  return loadLabelsImmediatelyLeftOfSelection(context, selectedRange, meta);
 }
 
 /**
  * Reads labels immediately to the left of selected range.
  */
-async function loadLabelsImmediatelyLeftOfSelection(context, selectedRange) {
-  selectedRange.load(["rowIndex", "columnIndex", "rowCount"]);
+async function loadLabelsImmediatelyLeftOfSelection(context, selectedRange, meta = null) {
+  let selectedStartRowIndex, selectedStartColumnIndex, selectedRowCount;
 
-  await context.sync();
-
-  const selectedStartRowIndex = selectedRange.rowIndex;
-  const selectedStartColumnIndex = selectedRange.columnIndex;
-  const selectedRowCount = selectedRange.rowCount;
+  if (meta) {
+    selectedStartRowIndex = meta.rowIndex;
+    selectedStartColumnIndex = meta.columnIndex;
+    selectedRowCount = meta.rowCount;
+  } else {
+    selectedRange.load(["rowIndex", "columnIndex", "rowCount"]);
+    await context.sync();
+    selectedStartRowIndex = selectedRange.rowIndex;
+    selectedStartColumnIndex = selectedRange.columnIndex;
+    selectedRowCount = selectedRange.rowCount;
+  }
 
   if (selectedStartColumnIndex === 0) {
     return [];
@@ -486,14 +495,20 @@ async function loadLabelsImmediatelyLeftOfSelection(context, selectedRange) {
  * Supports wide horizontal tables where metric labels stay on the far left,
  * while the user selects data columns far to the right.
  */
-async function loadLabelsFromLeftSideOfSheet(context, selectedRange) {
-  selectedRange.load(["rowIndex", "rowCount", "columnIndex"]);
+async function loadLabelsFromLeftSideOfSheet(context, selectedRange, meta = null) {
+  let selectedStartRowIndex, selectedRowCount, selectedStartColumnIndex;
 
-  await context.sync();
-
-  const selectedStartRowIndex = selectedRange.rowIndex;
-  const selectedRowCount = selectedRange.rowCount;
-  const selectedStartColumnIndex = selectedRange.columnIndex;
+  if (meta) {
+    selectedStartRowIndex = meta.rowIndex;
+    selectedRowCount = meta.rowCount;
+    selectedStartColumnIndex = meta.columnIndex;
+  } else {
+    selectedRange.load(["rowIndex", "rowCount", "columnIndex"]);
+    await context.sync();
+    selectedStartRowIndex = selectedRange.rowIndex;
+    selectedRowCount = selectedRange.rowCount;
+    selectedStartColumnIndex = selectedRange.columnIndex;
+  }
 
   if (selectedStartColumnIndex === 0) {
     return [];
@@ -522,16 +537,22 @@ async function loadLabelsFromLeftSideOfSheet(context, selectedRange) {
  * - lower banner row directly above selection;
  * - up to maxBannerScanRows rows above it.
  */
-async function loadBannerContextForSelectedRange(context, selectedRange, calculationSettings) {
+async function loadBannerContextForSelectedRange(context, selectedRange, calculationSettings, meta = null) {
   const maxBannerScanRows = 5;
 
-  selectedRange.load(["rowIndex", "columnIndex", "columnCount"]);
+  let selectedStartRowIndex, selectedStartColumnIndex, selectedColumnCount;
 
-  await context.sync();
-
-  const selectedStartRowIndex = selectedRange.rowIndex;
-  const selectedStartColumnIndex = selectedRange.columnIndex;
-  const selectedColumnCount = selectedRange.columnCount;
+  if (meta) {
+    selectedStartRowIndex = meta.rowIndex;
+    selectedStartColumnIndex = meta.columnIndex;
+    selectedColumnCount = meta.columnCount;
+  } else {
+    selectedRange.load(["rowIndex", "columnIndex", "columnCount"]);
+    await context.sync();
+    selectedStartRowIndex = selectedRange.rowIndex;
+    selectedStartColumnIndex = selectedRange.columnIndex;
+    selectedColumnCount = selectedRange.columnCount;
+  }
 
   if (selectedStartRowIndex === 0) {
     return {
@@ -632,7 +653,8 @@ export async function interpretSelectedRange(
   selectedRange,
   selectedValues,
   selectedText,
-  calculationSettings
+  calculationSettings,
+  selectedRangeMeta = null
 ) {
   const cleanedValues = removeSignificanceMarkersFromMatrix(selectedValues);
   const normalized = normalizeSelectedRange(cleanedValues, selectedText);
@@ -791,10 +813,19 @@ export async function interpretSelectedRange(
         // Fallback: normalization did not extract label columns (selection
         // excluded the label column). Load labels from the worksheet using the
         // data body range so row alignment matches the normalized values.
+        const dataBodyMeta = selectedRangeMeta
+          ? {
+              rowIndex: selectedRangeMeta.rowIndex + normalized.dataRowOffset,
+              columnIndex: selectedRangeMeta.columnIndex + effectiveDataColOffset,
+              rowCount: valuesForCalculation.length,
+              columnCount: valuesForCalculation[0].length,
+            }
+          : null;
         leftLabelValues = await loadLabelValuesForSelectedRange(
           context,
           dataBodyRange,
-          calculationSettings
+          calculationSettings,
+          dataBodyMeta
         );
       }
     }
@@ -810,8 +841,16 @@ export async function interpretSelectedRange(
       buildRunBannerContext(effectiveBannerContext)
     );
     if (bannerContext === null && calculationSettings.respectBannerStructure) {
+      const dataBodyMeta = selectedRangeMeta
+        ? {
+            rowIndex: selectedRangeMeta.rowIndex + normalized.dataRowOffset,
+            columnIndex: selectedRangeMeta.columnIndex + effectiveDataColOffset,
+            rowCount: valuesForCalculation.length,
+            columnCount: valuesForCalculation[0].length,
+          }
+        : null;
       bannerContext = sanitizeBannerContextForDetection(
-        await loadBannerContextForSelectedRange(context, dataBodyRange, calculationSettings)
+        await loadBannerContextForSelectedRange(context, dataBodyRange, calculationSettings, dataBodyMeta)
       );
     }
 
@@ -883,13 +922,15 @@ export async function interpretSelectedRange(
     leftLabelValues = await loadLabelValuesForSelectedRange(
       context,
       selectedRange,
-      calculationSettings
+      calculationSettings,
+      selectedRangeMeta
     );
   } else {
     leftLabelValues = await loadLabelValuesForSelectedRange(
       context,
       selectedRange,
-      calculationSettings
+      calculationSettings,
+      selectedRangeMeta
     );
     valuesForCalculation = cleanedValues;
     textForCalculation = selectedText;
@@ -903,10 +944,22 @@ export async function interpretSelectedRange(
   // Sanitize immediately so any RIT markers written by a previous Run are
   // stripped before the context is used by either detectBannerStructure (Run)
   // or buildTablePreviewModel (Check).
+  //
+  // When selectedRangeMeta is available (autorun path), compute adjusted meta
+  // for writeTargetRange so the banner loader can skip its own load+sync.
   let bannerContext = null;
   if (calculationSettings.respectBannerStructure) {
+    const bannerColOffset = embeddedLabelCols > 0 ? embeddedLabelCols : leadingEmptyCols;
+    const bannerRangeMeta = selectedRangeMeta
+      ? {
+          rowIndex: selectedRangeMeta.rowIndex,
+          columnIndex: selectedRangeMeta.columnIndex + bannerColOffset,
+          rowCount: selectedRangeMeta.rowCount,
+          columnCount: selectedRangeMeta.columnCount - bannerColOffset,
+        }
+      : null;
     bannerContext = sanitizeBannerContextForDetection(
-      await loadBannerContextForSelectedRange(context, writeTargetRange, calculationSettings)
+      await loadBannerContextForSelectedRange(context, writeTargetRange, calculationSettings, bannerRangeMeta)
     );
   }
 

--- a/src/taskpane/taskpane.js
+++ b/src/taskpane/taskpane.js
@@ -791,12 +791,20 @@ async function runSignificanceForRangeInContext(context, sheetName, rangeAddress
     return { status: "skipped", message: "слишком мало данных", rangeAddress };
   }
 
+  const selectedRangeMeta = {
+    rowIndex: sourceRange.rowIndex,
+    columnIndex: sourceRange.columnIndex,
+    rowCount: sourceRange.rowCount,
+    columnCount: sourceRange.columnCount,
+  };
+
   const interpretation = await interpretSelectedRange(
     context,
     sourceRange,
     selectedValues,
     selectedText,
-    calculationSettings
+    calculationSettings,
+    selectedRangeMeta
   );
 
   if (interpretation.state === "blocked") {


### PR DESCRIPTION
## Summary

- Each of the three range-metadata loaders (`loadLabelsImmediatelyLeftOfSelection`, `loadLabelsFromLeftSideOfSheet`, `loadBannerContextForSelectedRange`) was issuing its own `selectedRange.load([...]) + context.sync()` to read `rowIndex`, `columnIndex`, `rowCount`, `columnCount` — the same properties already synced by `runSignificanceForRangeInContext`'s first round-trip.
- Adds an optional `selectedRangeMeta` argument to `interpretSelectedRange` and the three loaders. When provided, the loaders skip their own load+sync and use the preloaded values directly.
- `runSignificanceForRangeInContext` (autorun path) now builds `selectedRangeMeta` from `sourceRange.*` after its existing sync and passes it through.
- `interpretSelectedRange` computes adjusted metas for embedded-label columns, leading-empty columns (pass-through state), and the normalized `dataBodyRange` (State 2) so all three loaders receive correct values regardless of how the range is partitioned.
- Manual Run, Check, and `checkSelectedRangePreview` callers do not pass meta; all loaders preserve their existing fallback loading path.
- Saves ~2 Office.js round-trips per table in workbook/sheet autorun (1 in label loader, 1 in banner loader). With banner disabled, saves 1 round-trip.

## Expected perf impact

Expected `interpMs` to fall noticeably relative to the #261 baseline.
Benchmark: capture `[RIT perf] runAutoSignificance { perTablePhaseMs }` before and after on the same workbook.

## Affected files
- `src/taskpane/selected-range-interpreter.js` — loader signatures + `interpretSelectedRange` signature
- `src/taskpane/taskpane.js` — `runSignificanceForRangeInContext` passes `selectedRangeMeta`

## Validation
- `npm test` — 302/302 pass
- `npm run build` — clean (pre-existing bundle-size warnings only)
- `git diff --check` — no whitespace issues

## Manual smoke required (human)
- Manual selected-range Run
- Check flows
- Current-table autorun
- Current-sheet autorun
- Workbook autorun
- Run report shape unchanged
- Capture before/after `[RIT perf]` logs for same workbook scenario

## Technical debt
None introduced. No statistical logic touched. No marker semantics changed.

## Performance measurement notes
Cannot capture live Excel measurements in the agent worktree. The code analysis confirms 2 redundant syncs per table per autorun call (1 label, 1 banner). Human owner should capture `perTablePhaseMs.interpMs` before and after merging to confirm the reduction.

Relates to issue #262.
Previous baseline: #261 totalMs ~3135.

🤖 Generated with [Claude Code](https://claude.com/claude-code)