### PR TITLE
Batch banner writes into range ops to cut Office.js command count (#266)

### DIFF
--- a/src/taskpane/taskpane.js
+++ b/src/taskpane/taskpane.js
@@ -3048,10 +3048,22 @@ async function clearBannerMarkersAboveRange(context, targetRange, knownDimension
     return;
   }
 
-  for (const { rowIndex, colIndex, text } of cellWriteQueue) {
-    const cell = targetRange.worksheet.getRangeByIndexes(rowIndex, colIndex, 1, 1);
-
-    cell.values = [[text]];
+  // Batch adjacent same-row writes into range operations.
+  const writesByRow = new Map();
+  for (const item of cellWriteQueue) {
+    if (!writesByRow.has(item.rowIndex)) writesByRow.set(item.rowIndex, []);
+    writesByRow.get(item.rowIndex).push(item);
+  }
+  for (const [rowIndex, items] of writesByRow) {
+    items.sort((a, b) => a.colIndex - b.colIndex);
+    let i = 0;
+    while (i < items.length) {
+      let j = i;
+      while (j + 1 < items.length && items[j + 1].colIndex === items[j].colIndex + 1) j++;
+      const texts = items.slice(i, j + 1).map(x => x.text);
+      targetRange.worksheet.getRangeByIndexes(rowIndex, items[i].colIndex, 1, j - i + 1).values = [texts];
+      i = j + 1;
+    }
   }
 
   await context.sync();
@@ -4901,10 +4913,22 @@ async function writeBannerMarkersAboveSelectedRange(context, selectedRange, calc
     });
   }
 
-  for (const { rowIndex, colIndex, text } of cellWriteQueue) {
-    const cell = selectedRange.worksheet.getRangeByIndexes(rowIndex, colIndex, 1, 1);
-
-    cell.values = [[text]];
+  // Batch adjacent same-row writes into range operations.
+  const writesByRow = new Map();
+  for (const item of cellWriteQueue) {
+    if (!writesByRow.has(item.rowIndex)) writesByRow.set(item.rowIndex, []);
+    writesByRow.get(item.rowIndex).push(item);
+  }
+  for (const [rowIndex, items] of writesByRow) {
+    items.sort((a, b) => a.colIndex - b.colIndex);
+    let i = 0;
+    while (i < items.length) {
+      let j = i;
+      while (j + 1 < items.length && items[j + 1].colIndex === items[j].colIndex + 1) j++;
+      const texts = items.slice(i, j + 1).map(x => x.text);
+      selectedRange.worksheet.getRangeByIndexes(rowIndex, items[i].colIndex, 1, j - i + 1).values = [texts];
+      i = j + 1;
+    }
   }
 
   await context.sync();
@@ -5051,6 +5075,10 @@ async function writeBannerMarkersAboveSelectedRangeUsingBannerStructure(
     }
 
     // Normal case: lower banner cell is non-empty; write in place.
+    if (nextText === currentText) {
+      continue;
+    }
+
     cellWriteQueue.push({
       rowIndex: selectedStartRowIndex - 1,
       colIndex: selectedStartColumnIndex + columnIndex,
@@ -5058,11 +5086,25 @@ async function writeBannerMarkersAboveSelectedRangeUsingBannerStructure(
     });
   }
 
-  for (const { rowIndex, colIndex, text } of cellWriteQueue) {
-    const cell = selectedRange.worksheet.getRangeByIndexes(rowIndex, colIndex, 1, 1);
-
-    cell.numberFormat = [["@"]];
-    cell.values = [[text]];
+  // Batch adjacent same-row writes into range operations to reduce Office.js
+  // command count per sync (N columns → 1-2 range writes per banner row).
+  const writesByRow = new Map();
+  for (const item of cellWriteQueue) {
+    if (!writesByRow.has(item.rowIndex)) writesByRow.set(item.rowIndex, []);
+    writesByRow.get(item.rowIndex).push(item);
+  }
+  for (const [rowIndex, items] of writesByRow) {
+    items.sort((a, b) => a.colIndex - b.colIndex);
+    let i = 0;
+    while (i < items.length) {
+      let j = i;
+      while (j + 1 < items.length && items[j + 1].colIndex === items[j].colIndex + 1) j++;
+      const texts = items.slice(i, j + 1).map(x => x.text);
+      const range = selectedRange.worksheet.getRangeByIndexes(rowIndex, items[i].colIndex, 1, j - i + 1);
+      range.numberFormat = [texts.map(() => "@")];
+      range.values = [texts];
+      i = j + 1;
+    }
   }
 
   await context.sync();
@@ -5437,8 +5479,22 @@ async function clearStaleBannerMarkersLeftOfWriteRange(
     return;
   }
 
-  for (const { rowIndex, colIndex, text } of writeQueue) {
-    worksheet.getRangeByIndexes(rowIndex, colIndex, 1, 1).values = [[text]];
+  // Batch adjacent same-row writes into range operations.
+  const writesByRow = new Map();
+  for (const item of writeQueue) {
+    if (!writesByRow.has(item.rowIndex)) writesByRow.set(item.rowIndex, []);
+    writesByRow.get(item.rowIndex).push(item);
+  }
+  for (const [rowIndex, items] of writesByRow) {
+    items.sort((a, b) => a.colIndex - b.colIndex);
+    let i = 0;
+    while (i < items.length) {
+      let j = i;
+      while (j + 1 < items.length && items[j + 1].colIndex === items[j].colIndex + 1) j++;
+      const texts = items.slice(i, j + 1).map(x => x.text);
+      worksheet.getRangeByIndexes(rowIndex, items[i].colIndex, 1, j - i + 1).values = [texts];
+      i = j + 1;
+    }
   }
 
   await context.sync();


### PR DESCRIPTION
## Summary\n\nTargets the banner write command-count hot path from #266.\n\n- ****: replaced per-cell getRangeByIndexes(1,1) writes with contiguous-column batching that collapses N adjacent writes into one getRangeByIndexes(1, runLen) write per banner row. Also adds the missing nextText===currentText skip in the normal-case branch (unlabeled/Total columns after pre-clear have identical before/after text — the non-banner-structure sibling already had this guard).\n- ****, ****, ****: same write batching.\n\nNo sync-count change. Marker placement and semantics unchanged.\n\n## Files changed\n\n- src/taskpane/taskpane.js\n\n## Test / build\n\n- npm test: 302/302 pass\n- npm run build: clean\n- git diff --check: clean\n\n## Manual smoke (required before merge)\n\n- [ ] Manual selected-range Run with banner letters\n- [ ] Workbook autorun with respectBannerStructure — capture RIT_PERF before/after\n- [ ] Repeated Run — no stale markers\n- [ ] Clear Significance — banner markers removed\n- [ ] Run report shape unchanged\n\n## Assumptions\n\nSync count per table unchanged; improvement from fewer commands per sync (host-side processing). Follow-up: merge pre-clear read with banner-write read to eliminate one sync per table.