### PR TITLE
UX: show immediate running status for all functional handlers

### DIFF
--- a/src/taskpane/taskpane-status.js
+++ b/src/taskpane/taskpane-status.js
@@ -125,6 +125,21 @@ export function formatStatusWithSelectedRangeGuardrails(message, warnings) {
   return appendSelectedRangeGuardrailMessages([message], warnings).join("\n");
 }
 
+export function runningStatusMessage(action, scope) {
+  const prefix = {
+    run:     "Расчёт начат…",
+    clear:   "Очистка начата…",
+    check:   "Проверка начата…",
+    content: "Оглавление создаётся…",
+  }[action];
+  const detail = {
+    table:   "Идёт обработка текущей таблицы.",
+    sheet:   "Идёт обработка таблиц на листе.",
+    workbook:"Идёт обработка таблиц в книге.",
+  }[scope] || "";
+  return detail ? `${prefix} ${detail}` : prefix;
+}
+
 export function buildCheckResolverMessage(resolverResult) {
   if (resolverResult.message) return resolverResult.message;
   switch (resolverResult.status) {

--- a/src/taskpane/taskpane.js
+++ b/src/taskpane/taskpane.js
@@ -56,6 +56,7 @@ import {
   appendSelectedRangeGuardrailMessages,
   formatStatusWithSelectedRangeGuardrails,
   buildCheckResolverMessage,
+  runningStatusMessage,
 } from "./taskpane-status";
 
 import {
@@ -447,6 +448,7 @@ function initActionScopeShell() {
  */
 async function runSignificanceFromSelection() {
   const _t0 = perfNow();
+  setStatusMessage(runningStatusMessage("run", "table"));
   await Excel.run(async (context) => {
     const calculationSettings = readCalculationSettingsFromPanel();
     if (calculationSettings.compareWithPreviousColumn && calculationSettings.compareOnlyWithTotal) {
@@ -1322,7 +1324,7 @@ async function runAutoSignificance() {
     return;
   }
 
-  setStatusMessage("Расчёт начат… Идёт обработка таблиц в книге.");
+  setStatusMessage(runningStatusMessage("run", "workbook"));
 
   // Collect inventory to identify eligible candidates.
   const _tScan = perfNow();
@@ -1626,6 +1628,8 @@ async function runAutoCurrentTableSignificance() {
     return;
   }
 
+  setStatusMessage(runningStatusMessage("run", "table"));
+
   let resolverResult = null;
 
   try {
@@ -1771,6 +1775,7 @@ async function runAutoCurrentTableSignificance() {
  * the arbitrary selected range — the clear target is always the resolver result.
  */
 async function clearAutoCurrentTableSignificance() {
+  setStatusMessage(runningStatusMessage("clear", "table"));
   let resolverResult = null;
 
   try {
@@ -1955,6 +1960,7 @@ async function clearSignificanceForRange(sheetName, rangeAddress) {
  * of running the significance pipeline.
  */
 async function clearAutoSignificance() {
+  setStatusMessage(runningStatusMessage("clear", "workbook"));
   let inventoryResults;
   try {
     await Excel.run(async (context) => {
@@ -2078,7 +2084,7 @@ async function runCurrentSheetSignificance() {
     return;
   }
 
-  setStatusMessage("Расчёт начат… Идёт обработка таблиц на листе.");
+  setStatusMessage(runningStatusMessage("run", "sheet"));
 
   const _tScan = perfNow();
   let inventoryResults;
@@ -2333,6 +2339,7 @@ async function runCurrentSheetSignificance() {
  * collectActiveSheetInventoryResults(). Content sheet is silently ignored.
  */
 async function clearCurrentSheetSignificance() {
+  setStatusMessage(runningStatusMessage("clear", "sheet"));
   let inventoryResults;
   try {
     await Excel.run(async (context) => {
@@ -2484,6 +2491,7 @@ async function checkTableForRange(sheetName, rangeAddress, calculationSettings) 
  */
 async function runCurrentSheetCheck() {
   const calculationSettings = readCalculationSettingsFromPanel();
+  setCheckMessage(runningStatusMessage("check", "sheet"));
 
   let inventoryResults;
   let activeSheetName = "";
@@ -2669,6 +2677,7 @@ async function runCurrentSheetCheck() {
  */
 async function runWorkbookCheck() {
   const calculationSettings = readCalculationSettingsFromPanel();
+  setCheckMessage(runningStatusMessage("check", "workbook"));
 
   let inventoryResults;
   try {
@@ -2820,6 +2829,7 @@ function calculateBlockResults(cleanedValues, calculationBlock, calculationSetti
  * User-facing cleanup button.
  */
 async function clearSignificanceFromSelection() {
+  setStatusMessage(runningStatusMessage("clear"));
   await Excel.run(async (context) => {
     // getSelectedRange() throws a RichApi.Error for non-contiguous (Ctrl+Click
     // multi-area) selections. Catch that error here and surface a user-facing
@@ -3203,6 +3213,7 @@ async function checkSelectedRangePreview(context, sheetName, rangeAddress, setti
  * in which case it writes a single row to the Run report sheet.
  */
 async function runCheckTable() {
+  setCheckMessage(runningStatusMessage("check"));
   await Excel.run(async (context) => {
     const calculationSettings = readCalculationSettingsFromPanel();
 
@@ -3390,6 +3401,7 @@ async function runCheckTable() {
  * to the workbook.
  */
 async function runCheckSelectedRange() {
+  setCheckMessage(runningStatusMessage("check"));
   await Excel.run(async (context) => {
     const calculationSettings = readCalculationSettingsFromPanel();
 
@@ -4523,6 +4535,7 @@ async function writeInventoryContentSheet(context, inventoryResults) {
 }
 
 async function runTableInventory() {
+  setInventoryMessage(runningStatusMessage("content"));
   await Excel.run(async (context) => {
     const _t0 = perfNow();
     const inventoryResults = await collectWorkbookInventoryResults(context, readCalculationSettingsFromPanel());

--- a/src/taskpane/taskpane.js
+++ b/src/taskpane/taskpane.js
@@ -1322,6 +1322,8 @@ async function runAutoSignificance() {
     return;
   }
 
+  setStatusMessage("Расчёт начат… Идёт обработка таблиц в книге.");
+
   // Collect inventory to identify eligible candidates.
   const _tScan = perfNow();
   let inventoryResults;
@@ -2075,6 +2077,8 @@ async function runCurrentSheetSignificance() {
     );
     return;
   }
+
+  setStatusMessage("Расчёт начат… Идёт обработка таблиц на листе.");
 
   const _tScan = perfNow();
   let inventoryResults;


### PR DESCRIPTION
## Summary

Adds `runningStatusMessage(action, scope)` to `taskpane-status.js` to centralize all "started" label strings, then wires one call into every UI handler so the user sees immediate feedback before any async Excel.run work begins.

| Handler | Message shown |
|---|---|
| runSignificanceFromSelection | Расчёт начат… Идёт обработка текущей таблицы. |
| runAutoCurrentTableSignificance | Расчёт начат… Идёт обработка текущей таблицы. |
| runCurrentSheetSignificance | Расчёт начат… Идёт обработка таблиц на листе. |
| runAutoSignificance | Расчёт начат… Идёт обработка таблиц в книге. |
| clearSignificanceFromSelection | Очистка начата… |
| clearAutoCurrentTableSignificance | Очистка начата… Идёт обработка текущей таблицы. |
| clearCurrentSheetSignificance | Очистка начата… Идёт обработка таблиц на листе. |
| clearAutoSignificance | Очистка начата… Идёт обработка таблиц в книге. |
| runCheckTable | Проверка начата… |
| runCheckSelectedRange | Проверка начата… |
| runCurrentSheetCheck | Проверка начата… Идёт обработка таблиц на листе. |
| runWorkbookCheck | Проверка начата… Идёт обработка таблиц в книге. |
| runTableInventory | Оглавление создаётся… |

Each handler's existing final `setStatusMessage` / `setCheckMessage` / `setInventoryMessage` call always overwrites the temporary message on success, empty, or error — no stuck messages possible.

## Files changed

- `src/taskpane/taskpane-status.js` — adds `runningStatusMessage(action, scope)` helper (16 lines)
- `src/taskpane/taskpane.js` — imports helper; one call added per handler (13 handlers × 1 line)

## Build/test result

- `npm test`: 302 pass, 0 fail
- `npm run build`: compiled with 3 pre-existing size warnings, no errors
- `git diff --check`: clean

## Smoke test checklist

- [ ] Manual Run shows "Расчёт начат…" immediately
- [ ] Autorun (current table/sheet/workbook) shows "Расчёт начат…" immediately
- [ ] Clear (selection/table/sheet/workbook) shows "Очистка начата…" immediately
- [ ] Check (table/sheet/workbook) shows "Проверка начата…" immediately
- [ ] Content shows "Оглавление создаётся…" immediately
- [ ] Final status always replaces running status
- [ ] Error/empty case does not leave running status stuck

## Assumptions / limitations

- Strings are hardcoded Russian matching existing convention in both files.
- Check handlers use `setCheckMessage`; inventory uses `setInventoryMessage`; all others use `setStatusMessage` — each temporary message appears in the correct panel.
- No calculation, writer, marker, or report shape changes.
- No technical debt introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)