### PR TITLE
Investigate writer formatting performance

### DIFF
--- a/src/core/excel-writer.js
+++ b/src/core/excel-writer.js
@@ -12,14 +12,19 @@ export function writeCellResultsToSelectedRange(
   selectedText,
   cellResultMatrix,
   detectionResult,
-  calculationSettings
+  calculationSettings,
+  options = {}
 ) {
   const rowCount = cellResultMatrix.length;
   const columnCount = cellResultMatrix[0] ? cellResultMatrix[0].length : 0;
 
   if (!rowCount || !columnCount) {
-    return;
+    return null;
   }
+
+  const shouldCaptureWriterDetails = Boolean(options.captureWriterDetails);
+  const writerDetails = shouldCaptureWriterDetails ? createWriterDetails() : null;
+  const buildMatricesStartedAt = shouldCaptureWriterDetails ? Date.now() : 0;
 
   const rowTypeByIndex = buildDetectedRowTypeByIndexMap(detectionResult);
 
@@ -111,13 +116,34 @@ export function writeCellResultsToSelectedRange(
     fillReasonMask.push(fillReasonRow);
   }
 
+  if (writerDetails) {
+    writerDetails.buildMatricesMs = Date.now() - buildMatricesStartedAt;
+  }
+
   // Main performance win:
   // one values write + one numberFormat write instead of per-cell writes.
+  const numberFormatWriteStartedAt = writerDetails ? Date.now() : 0;
   selectedRange.numberFormat = nextNumberFormats;
-  selectedRange.values = nextValues;
+  if (writerDetails) {
+    writerDetails.numberFormatWriteMs = Date.now() - numberFormatWriteStartedAt;
+  }
 
-  applyGroupedBoldFormatting(selectedRange, boldMask);
-  applyGroupedFillFormatting(selectedRange, fillReasonMask, cellResultMatrix, calculationSettings);
+  const valuesWriteStartedAt = writerDetails ? Date.now() : 0;
+  selectedRange.values = nextValues;
+  if (writerDetails) {
+    writerDetails.valuesWriteMs = Date.now() - valuesWriteStartedAt;
+  }
+
+  applyGroupedBoldFormatting(selectedRange, boldMask, writerDetails);
+  applyGroupedFillFormatting(
+    selectedRange,
+    fillReasonMask,
+    cellResultMatrix,
+    calculationSettings,
+    writerDetails
+  );
+
+  return writerDetails;
 }
 
 /**
@@ -291,9 +317,15 @@ export function resolveNumericOutput(displayString) {
   return { value: parsed.numericValue, format: `0.${"0".repeat(decimalPlaces)}` };
 }
 
-function applyGroupedBoldFormatting(selectedRange, boldMask) {
+function applyGroupedBoldFormatting(selectedRange, boldMask, writerDetails = null) {
+  const formatStartedAt = writerDetails ? Date.now() : 0;
+  const boldRunsByRow = writerDetails ? [] : null;
+  const boldRunSpansByRow = writerDetails ? [] : null;
+
   for (let rowIndex = 0; rowIndex < boldMask.length; rowIndex++) {
     const row = boldMask[rowIndex];
+    let rowRunCount = 0;
+    const rowRunSpans = writerDetails ? [] : null;
 
     let runStart = null;
 
@@ -308,6 +340,11 @@ function applyGroupedBoldFormatting(selectedRange, boldMask) {
       if ((!shouldBeBold || columnIndex === row.length) && runStart !== null) {
         const runEnd = columnIndex - 1;
         const runWidth = runEnd - runStart + 1;
+        rowRunCount += 1;
+
+        if (rowRunSpans) {
+          rowRunSpans.push({ start: runStart, end: runEnd });
+        }
 
         selectedRange
           .getCell(rowIndex, runStart)
@@ -316,6 +353,18 @@ function applyGroupedBoldFormatting(selectedRange, boldMask) {
         runStart = null;
       }
     }
+
+    if (boldRunsByRow) {
+      boldRunsByRow.push(rowRunCount);
+      boldRunSpansByRow.push(rowRunSpans);
+    }
+  }
+
+  if (writerDetails) {
+    writerDetails.boldFormatMs = Date.now() - formatStartedAt;
+    writerDetails.boldRunCountByRow = boldRunsByRow;
+    writerDetails.boldCommandCount = sumCounts(boldRunsByRow);
+    writerDetails.boldRectCommandCountEstimate = estimateRectangleCommandCount(boldRunSpansByRow);
   }
 }
 
@@ -323,10 +372,17 @@ function applyGroupedFillFormatting(
   selectedRange,
   fillReasonMask,
   cellResultMatrix,
-  calculationSettings
+  calculationSettings,
+  writerDetails = null
 ) {
+  const formatStartedAt = writerDetails ? Date.now() : 0;
+  const fillRunsByRow = writerDetails ? [] : null;
+  const fillRunSpansByRow = writerDetails ? [] : null;
+
   for (let rowIndex = 0; rowIndex < fillReasonMask.length; rowIndex++) {
     const row = fillReasonMask[rowIndex];
+    let rowRunCount = 0;
+    const rowRunSpans = writerDetails ? [] : null;
 
     let runStart = null;
     let currentRunColor = "";
@@ -356,6 +412,15 @@ function applyGroupedFillFormatting(
       if (runStart !== null) {
         const runEnd = columnIndex - 1;
         const runWidth = runEnd - runStart + 1;
+        rowRunCount += 1;
+
+        if (rowRunSpans) {
+          rowRunSpans.push({
+            start: runStart,
+            end: runEnd,
+            color: currentRunColor,
+          });
+        }
 
         selectedRange
           .getCell(rowIndex, runStart)
@@ -370,5 +435,67 @@ function applyGroupedFillFormatting(
         currentRunColor = fillColor;
       }
     }
+
+    if (fillRunsByRow) {
+      fillRunsByRow.push(rowRunCount);
+      fillRunSpansByRow.push(rowRunSpans);
+    }
   }
+
+  if (writerDetails) {
+    writerDetails.fillFormatMs = Date.now() - formatStartedAt;
+    writerDetails.fillRunCountByRow = fillRunsByRow;
+    writerDetails.fillCommandCount = sumCounts(fillRunsByRow);
+    writerDetails.fillRectCommandCountEstimate = estimateRectangleCommandCount(fillRunSpansByRow);
+  }
+}
+
+function createWriterDetails() {
+  return {
+    buildMatricesMs: 0,
+    numberFormatWriteMs: 0,
+    valuesWriteMs: 0,
+    boldFormatMs: 0,
+    fillFormatMs: 0,
+    boldCommandCount: 0,
+    fillCommandCount: 0,
+    boldRunCountByRow: [],
+    fillRunCountByRow: [],
+    boldRectCommandCountEstimate: 0,
+    fillRectCommandCountEstimate: 0,
+  };
+}
+
+function sumCounts(counts) {
+  return counts.reduce((sum, count) => sum + count, 0);
+}
+
+function estimateRectangleCommandCount(runSpansByRow) {
+  let rectangleCount = 0;
+  let previousRowSignatureCounts = new Map();
+
+  for (const rowRunSpans of runSpansByRow) {
+    const currentRowSignatureCounts = new Map();
+
+    for (const runSpan of rowRunSpans) {
+      const signature = buildRunSpanSignature(runSpan);
+      const nextCount = (currentRowSignatureCounts.get(signature) || 0) + 1;
+      currentRowSignatureCounts.set(signature, nextCount);
+
+      const previousCount = previousRowSignatureCounts.get(signature) || 0;
+
+      if (nextCount > previousCount) {
+        rectangleCount += 1;
+      }
+    }
+
+    previousRowSignatureCounts = currentRowSignatureCounts;
+  }
+
+  return rectangleCount;
+}
+
+function buildRunSpanSignature(runSpan) {
+  const colorKey = runSpan.color || "";
+  return `${runSpan.start}:${runSpan.end}:${colorKey}`;
 }

--- a/src/taskpane/taskpane.js
+++ b/src/taskpane/taskpane.js
@@ -97,7 +97,7 @@ import {
   getContentRowReference,
 } from "./taskpane-inventory-formatters";
 
-import { perfNow, perfElapsed, perfLog } from "./taskpane-performance";
+import { perfNow, perfElapsed, perfLog, perfEnabled } from "./taskpane-performance";
 
 const SCAN_CELL_LIMIT = 250000;
 const INVENTORY_CONTENT_SHEET_NAME = "Content";
@@ -333,6 +333,48 @@ function initLanguageSelector() {
       updateCheckHints();
     });
   });
+}
+
+function createAggregatedWriterPerfDetails() {
+  return {
+    tablesWithWriterDetails: 0,
+    buildMatricesMs: 0,
+    numberFormatWriteMs: 0,
+    valuesWriteMs: 0,
+    boldFormatMs: 0,
+    fillFormatMs: 0,
+    boldCommandCount: 0,
+    fillCommandCount: 0,
+    boldRectCommandCountEstimate: 0,
+    fillRectCommandCountEstimate: 0,
+    maxBoldCommandCount: 0,
+    maxFillCommandCount: 0,
+  };
+}
+
+function mergeWriterPerfDetails(aggregate, writerDetails) {
+  if (!aggregate || !writerDetails) {
+    return;
+  }
+
+  aggregate.tablesWithWriterDetails += 1;
+  aggregate.buildMatricesMs += writerDetails.buildMatricesMs || 0;
+  aggregate.numberFormatWriteMs += writerDetails.numberFormatWriteMs || 0;
+  aggregate.valuesWriteMs += writerDetails.valuesWriteMs || 0;
+  aggregate.boldFormatMs += writerDetails.boldFormatMs || 0;
+  aggregate.fillFormatMs += writerDetails.fillFormatMs || 0;
+  aggregate.boldCommandCount += writerDetails.boldCommandCount || 0;
+  aggregate.fillCommandCount += writerDetails.fillCommandCount || 0;
+  aggregate.boldRectCommandCountEstimate += writerDetails.boldRectCommandCountEstimate || 0;
+  aggregate.fillRectCommandCountEstimate += writerDetails.fillRectCommandCountEstimate || 0;
+  aggregate.maxBoldCommandCount = Math.max(
+    aggregate.maxBoldCommandCount,
+    writerDetails.boldCommandCount || 0
+  );
+  aggregate.maxFillCommandCount = Math.max(
+    aggregate.maxFillCommandCount,
+    writerDetails.fillCommandCount || 0
+  );
 }
 
 // ─── Action + Scope shell (issue #167 PR1) ───────────────────────────────────
@@ -688,12 +730,13 @@ async function runSignificanceFromSelection() {
     keepMarkersOnlyInAllowedRows(fullCellResultMatrix, allowedMarkerRows);
 
     const _tWrite = perfNow();
-    writeCellResultsToSelectedRange(
+    const writerDetails = writeCellResultsToSelectedRange(
       writeTargetRange,
       textForCalculation,
       fullCellResultMatrix,
       detectionResult,
-      calculationSettings
+      calculationSettings,
+      { captureWriterDetails: perfEnabled() }
     );
 
     const _knownDims = {
@@ -761,6 +804,7 @@ async function runSignificanceFromSelection() {
     perfLog("runSignificanceFromSelection", {
       interpretMs: _tWrite - _tInterp,
       writeMs: perfElapsed(_tWrite),
+      ...(writerDetails ? { writerDetails } : {}),
       totalMs: perfElapsed(_t0),
     });
     setStatusMessage(
@@ -936,12 +980,13 @@ async function runSignificanceForRangeInContext(context, sheetName, rangeAddress
 
   const _pCalc = perfNow();
 
-  writeCellResultsToSelectedRange(
+  const writerDetails = writeCellResultsToSelectedRange(
     writeTargetRange,
     textForCalculation,
     fullCellResultMatrix,
     detectionResult,
-    calculationSettings
+    calculationSettings,
+    { captureWriterDetails: perfEnabled() }
   );
 
   const _knownDims = {
@@ -1004,6 +1049,7 @@ async function runSignificanceForRangeInContext(context, sheetName, rangeAddress
         bannerClearMs: _pBannerClear - _pStaleLeftClear,
         bannerWriteMs: _pBannerWrite - _pBannerClear,
         finalSyncMs: _pWrite - _pBannerWrite,
+        ...(writerDetails ? { writerDetails } : {}),
       },
     } : null,
   };
@@ -1404,7 +1450,20 @@ async function runAutoSignificance() {
   // context), we record that table as an error, exit the shared context, and
   // fall back to per-table Excel.run for any remaining candidates.
   const _tLoop = perfNow();
-  const _perfPhases = { loadMs: 0, interpMs: 0, calcMs: 0, writeMs: 0, writeDetails: { valueWriteMs: 0, staleLeftClearMs: 0, bannerClearMs: 0, bannerWriteMs: 0, finalSyncMs: 0 } };
+  const _perfPhases = {
+    loadMs: 0,
+    interpMs: 0,
+    calcMs: 0,
+    writeMs: 0,
+    writeDetails: {
+      valueWriteMs: 0,
+      staleLeftClearMs: 0,
+      bannerClearMs: 0,
+      bannerWriteMs: 0,
+      finalSyncMs: 0,
+      writerDetails: createAggregatedWriterPerfDetails(),
+    },
+  };
   let _batchEndedAt = 0;
   try {
     await Excel.run(async (context) => {
@@ -1438,6 +1497,10 @@ async function runAutoSignificance() {
               _perfPhases.writeDetails.bannerClearMs += result._phasesMs.writeDetails.bannerClearMs;
               _perfPhases.writeDetails.bannerWriteMs += result._phasesMs.writeDetails.bannerWriteMs;
               _perfPhases.writeDetails.finalSyncMs += result._phasesMs.writeDetails.finalSyncMs;
+              mergeWriterPerfDetails(
+                _perfPhases.writeDetails.writerDetails,
+                result._phasesMs.writeDetails.writerDetails
+              );
             }
           }
           reportRows.push({
@@ -1504,6 +1567,10 @@ async function runAutoSignificance() {
           _perfPhases.writeDetails.bannerClearMs += result._phasesMs.writeDetails.bannerClearMs;
           _perfPhases.writeDetails.bannerWriteMs += result._phasesMs.writeDetails.bannerWriteMs;
           _perfPhases.writeDetails.finalSyncMs += result._phasesMs.writeDetails.finalSyncMs;
+          mergeWriterPerfDetails(
+            _perfPhases.writeDetails.writerDetails,
+            result._phasesMs.writeDetails.writerDetails
+          );
         }
       }
       reportRows.push({
@@ -2159,7 +2226,20 @@ async function runCurrentSheetSignificance() {
   // sync error we record that table as an error, exit the shared context, and
   // continue with per-table Excel.run for any remaining candidates.
   const _tLoop = perfNow();
-  const _perfPhases = { loadMs: 0, interpMs: 0, calcMs: 0, writeMs: 0, writeDetails: { valueWriteMs: 0, staleLeftClearMs: 0, bannerClearMs: 0, bannerWriteMs: 0, finalSyncMs: 0 } };
+  const _perfPhases = {
+    loadMs: 0,
+    interpMs: 0,
+    calcMs: 0,
+    writeMs: 0,
+    writeDetails: {
+      valueWriteMs: 0,
+      staleLeftClearMs: 0,
+      bannerClearMs: 0,
+      bannerWriteMs: 0,
+      finalSyncMs: 0,
+      writerDetails: createAggregatedWriterPerfDetails(),
+    },
+  };
   let _batchEndedAt = 0;
   try {
     await Excel.run(async (context) => {
@@ -2193,6 +2273,10 @@ async function runCurrentSheetSignificance() {
               _perfPhases.writeDetails.bannerClearMs += result._phasesMs.writeDetails.bannerClearMs;
               _perfPhases.writeDetails.bannerWriteMs += result._phasesMs.writeDetails.bannerWriteMs;
               _perfPhases.writeDetails.finalSyncMs += result._phasesMs.writeDetails.finalSyncMs;
+              mergeWriterPerfDetails(
+                _perfPhases.writeDetails.writerDetails,
+                result._phasesMs.writeDetails.writerDetails
+              );
             }
           }
           reportRows.push({
@@ -2259,6 +2343,10 @@ async function runCurrentSheetSignificance() {
           _perfPhases.writeDetails.bannerClearMs += result._phasesMs.writeDetails.bannerClearMs;
           _perfPhases.writeDetails.bannerWriteMs += result._phasesMs.writeDetails.bannerWriteMs;
           _perfPhases.writeDetails.finalSyncMs += result._phasesMs.writeDetails.finalSyncMs;
+          mergeWriterPerfDetails(
+            _perfPhases.writeDetails.writerDetails,
+            result._phasesMs.writeDetails.writerDetails
+          );
         }
       }
       reportRows.push({


### PR DESCRIPTION
## Summary
- add dev-only writerDetails instrumentation to writeCellResultsToSelectedRange()
- capture queued bold/fill command counts, per-row run counts, and rectangle-merge estimates
- thread writer diagnostics through manual-run and autorun RIT_PERF logs without changing output semantics

## Validation
- 
pm test
- 
pm.cmd run build
- git diff --check

## Notes
- This PR intentionally stops at diagnostics-first investigation; it does not change formatting semantics or batching strategy yet.
- 
umberFormatWriteMs and aluesWriteMs reflect JS-side queue time before context.sync(). Real Office write cost still needs to be interpreted alongside inalSyncMs in RIT_PERF logs.
- Manual Excel smoke and before/after workbook perf capture were not run in this environment and still need human verification on a wide-column workbook.

## Issue
- Refs #269