### PR TITLE
Exclude row-label columns from Clear Significance target (#273)

### DIFF
--- a/src/taskpane/selected-range-interpreter.js
+++ b/src/taskpane/selected-range-interpreter.js
@@ -261,7 +261,7 @@ function isEmbeddedUnitColumn(cleanedValues, col, rowCount) {
  * Returns 0 for strict numeric selections so the existing Run/Clear flow is
  * unchanged.
  */
-function detectEmbeddedLabelColumns(cleanedValues) {
+export function detectEmbeddedLabelColumns(cleanedValues) {
   if (!Array.isArray(cleanedValues) || !Array.isArray(cleanedValues[0])) return 0;
   const colCount = cleanedValues[0].length;
   if (colCount < 2) return 0;

--- a/src/taskpane/taskpane.js
+++ b/src/taskpane/taskpane.js
@@ -39,6 +39,7 @@ import { filterWorkbookCandidates } from "../core/batch-candidate-filter";
 
 import {
   interpretSelectedRange,
+  detectEmbeddedLabelColumns,
   detectLeadingEmptyColumns,
 } from "./selected-range-interpreter";
 
@@ -1928,8 +1929,26 @@ async function clearSignificanceForRange(sheetName, rangeAddress) {
       const bodyRowCount = normalized.valuesForCalculation.length;
       let bodyColCount = normalized.valuesForCalculation[0].length;
       let effectiveClearColOffset = normalized.dataColOffset;
+      let textForLeadingEmptyCheck = normalized.textForCalculation;
 
-      const clearLeadingEmptyCols = detectLeadingEmptyColumns(normalized.textForCalculation);
+      // Secondary embedded-label-column check (mirrors interpretSelectedRange
+      // State 2 / clearSignificanceFromSelection).  Protects auto-clear ranges
+      // whose label column has mixed text + numeric-looking values from being
+      // overwritten when normalizeSelectedRange leaves col[0] inside the body.
+      if (normalized.dataColOffset === 0) {
+        const additionalLabelCols = detectEmbeddedLabelColumns(
+          normalized.valuesForCalculation
+        );
+        if (additionalLabelCols > 0) {
+          effectiveClearColOffset += additionalLabelCols;
+          bodyColCount -= additionalLabelCols;
+          textForLeadingEmptyCheck = normalized.textForCalculation.map(
+            (row) => row.slice(additionalLabelCols)
+          );
+        }
+      }
+
+      const clearLeadingEmptyCols = detectLeadingEmptyColumns(textForLeadingEmptyCheck);
       if (clearLeadingEmptyCols > 0) {
         bodyColCount -= clearLeadingEmptyCols;
         effectiveClearColOffset += clearLeadingEmptyCols;
@@ -1943,14 +1962,25 @@ async function clearSignificanceForRange(sheetName, rangeAddress) {
         .getCell(normalized.dataRowOffset, effectiveClearColOffset)
         .getResizedRange(bodyRowCount - 1, bodyColCount - 1);
     } else {
-      const leadingBlankColsForClear = detectLeadingEmptyColumns(selectedText);
+      // Pass-through mirrors interpretSelectedRange / clearSignificanceFromSelection:
+      // prefer detectEmbeddedLabelColumns to keep row labels out of the clear
+      // target on wide tables; fall back to detectLeadingEmptyColumns otherwise.
+      const embeddedLabelColsForClear = detectEmbeddedLabelColumns(cleanedValues);
+      const leadingBlankColsForClear =
+        embeddedLabelColsForClear === 0
+          ? detectLeadingEmptyColumns(selectedText)
+          : 0;
+      const skipLeftCols =
+        embeddedLabelColsForClear > 0
+          ? embeddedLabelColsForClear
+          : leadingBlankColsForClear;
 
-      if (leadingBlankColsForClear > 0) {
+      if (skipLeftCols > 0) {
         clearTargetRange = sourceRange
-          .getCell(0, leadingBlankColsForClear)
+          .getCell(0, skipLeftCols)
           .getResizedRange(
             sourceRange.rowCount - 1,
-            sourceRange.columnCount - leadingBlankColsForClear - 1
+            sourceRange.columnCount - skipLeftCols - 1
           );
       } else {
         clearTargetRange = sourceRange;
@@ -2962,14 +2992,35 @@ async function clearSignificanceFromSelection() {
       const bodyRowCount = normalized.valuesForCalculation.length;
       let bodyColCount = normalized.valuesForCalculation[0].length;
       let effectiveClearColOffset = normalized.dataColOffset;
+      let textForLeadingEmptyCheck = normalized.textForCalculation;
 
-      // Mirror the tertiary strip in interpretSelectedRange State 2: the
-      // normalizer may leave leading all-blank helper columns (e.g. column B
-      // in a mean-only table) inside the normalized body.  Clear must exclude
+      // Secondary embedded-label-column check (mirrors interpretSelectedRange
+      // State 2).  The normalizer leaves the label column inside
+      // valuesForCalculation when col[0] text fraction is uncertain (mix of
+      // text and numeric-looking labels, e.g. "Нет", "1", "2", "BASE").
+      // detectEmbeddedLabelColumns recognises that shape by looking for at
+      // least one genuine text cell in col[0]; without it, Clear's target
+      // would still include the row-label column and overwrite label text.
+      if (normalized.dataColOffset === 0) {
+        const additionalLabelCols = detectEmbeddedLabelColumns(
+          normalized.valuesForCalculation
+        );
+        if (additionalLabelCols > 0) {
+          effectiveClearColOffset += additionalLabelCols;
+          bodyColCount -= additionalLabelCols;
+          textForLeadingEmptyCheck = normalized.textForCalculation.map(
+            (row) => row.slice(additionalLabelCols)
+          );
+        }
+      }
+
+      // Tertiary strip mirrors interpretSelectedRange State 2: the normalizer
+      // may leave leading all-blank helper columns (e.g. column B in a
+      // mean-only table) inside the normalized body.  Clear must exclude
       // those same columns so it does not widen the clear target beyond the
       // real data body.
       const clearLeadingEmptyCols = detectLeadingEmptyColumns(
-        normalized.textForCalculation
+        textForLeadingEmptyCheck
       );
       if (clearLeadingEmptyCols > 0) {
         bodyColCount -= clearLeadingEmptyCols;
@@ -2985,19 +3036,31 @@ async function clearSignificanceFromSelection() {
         .getCell(normalized.dataRowOffset, effectiveClearColOffset)
         .getResizedRange(bodyRowCount - 1, bodyColCount - 1);
     } else {
-      // Pass-through: the selection is a clean numeric-only range.
-      // Detect leading all-blank helper columns and exclude them from the
-      // clear target so that Clear does not remove fill/formatting from helper
-      // cells.  Uses the same detectLeadingEmptyColumns function as Run's
-      // interpretSelectedRange passThrough path.
-      const leadingBlankColsForClear = detectLeadingEmptyColumns(selectedText);
+      // Pass-through.  Mirror interpretSelectedRange pass-through path
+      // (selected-range-interpreter.js): first try detectEmbeddedLabelColumns
+      // (recognises a leftmost column with at least one genuine text cell,
+      // optionally followed by uniform unit columns), and only fall back to
+      // detectLeadingEmptyColumns when no embedded label column was found.
+      // This excludes row labels from the clear target on wide tables whose
+      // col[0] text fraction sits just below the normalizer pass-through gate
+      // (e.g. labels "Нет"/"1"/"2"/"BASE") so the original strict workflow
+      // for pure numeric selections is preserved.
+      const embeddedLabelColsForClear = detectEmbeddedLabelColumns(cleanedValues);
+      const leadingBlankColsForClear =
+        embeddedLabelColsForClear === 0
+          ? detectLeadingEmptyColumns(selectedText)
+          : 0;
+      const skipLeftCols =
+        embeddedLabelColsForClear > 0
+          ? embeddedLabelColsForClear
+          : leadingBlankColsForClear;
 
-      if (leadingBlankColsForClear > 0) {
+      if (skipLeftCols > 0) {
         clearTargetRange = selectedRange
-          .getCell(0, leadingBlankColsForClear)
+          .getCell(0, skipLeftCols)
           .getResizedRange(
             selectedRange.rowCount - 1,
-            selectedRange.columnCount - leadingBlankColsForClear - 1
+            selectedRange.columnCount - skipLeftCols - 1
           );
       } else {
         clearTargetRange = selectedRange;


### PR DESCRIPTION
## Summary

Fixes #273. `Clear Significance` no longer destructively mutates row-label cells on wide/horizontal tables whose label column mixes text and numeric-looking values.

## Root cause

`clearSignificanceFromSelection` and `clearSignificanceForRange` skipped the secondary `detectEmbeddedLabelColumns` check that `interpretSelectedRange` applies in both pass-through and normalized paths. On wide tables whose col[0] holds labels like `Нет`, `1`, `2`, `3 и более детей`, `BASE`, the col[0] text fraction sits around 0.6 — below the 0.7 left-column pass-through gate yet still genuine text. `normalizeSelectedRange` therefore returned State 1 (pass-through), Clear's pass-through branch only consulted `detectLeadingEmptyColumns` (all-blank cols), and the label column stayed inside the clear target. The same gap existed in State 2 when `dataColOffset === 0` (uncertain label split).

Once row labels were in the target:

- `removeSignificanceMarkersFromText` (in `src/core/significance.js`) greedy-stripped trailing characters matching its marker character class. The Russian set is missing `т`, so `детей` → `дет` (strip stops at `т`).
- `format.font.bold = false; format.fill.clear()` ran across the labels.

## Files changed

- `src/taskpane/selected-range-interpreter.js` — export `detectEmbeddedLabelColumns` for reuse.
- `src/taskpane/taskpane.js` — apply the secondary embedded-label-column check inside both Clear functions (pass-through and State 2 branches), and import the newly exported helper.

## Clear-target logic — before vs after

### `clearSignificanceFromSelection` (State 2, `dataColOffset === 0`)

Before:

```js
let effectiveClearColOffset = normalized.dataColOffset;
const clearLeadingEmptyCols = detectLeadingEmptyColumns(normalized.textForCalculation);
```

After:

```js
let effectiveClearColOffset = normalized.dataColOffset;
let textForLeadingEmptyCheck = normalized.textForCalculation;

if (normalized.dataColOffset === 0) {
  const additionalLabelCols = detectEmbeddedLabelColumns(normalized.valuesForCalculation);
  if (additionalLabelCols > 0) {
    effectiveClearColOffset += additionalLabelCols;
    bodyColCount -= additionalLabelCols;
    textForLeadingEmptyCheck = normalized.textForCalculation.map(
      (row) => row.slice(additionalLabelCols)
    );
  }
}

const clearLeadingEmptyCols = detectLeadingEmptyColumns(textForLeadingEmptyCheck);
```

### `clearSignificanceFromSelection` (State 1, pass-through)

Before:

```js
const leadingBlankColsForClear = detectLeadingEmptyColumns(selectedText);
```

After:

```js
const embeddedLabelColsForClear = detectEmbeddedLabelColumns(cleanedValues);
const leadingBlankColsForClear =
  embeddedLabelColsForClear === 0
    ? detectLeadingEmptyColumns(selectedText)
    : 0;
const skipLeftCols =
  embeddedLabelColsForClear > 0
    ? embeddedLabelColsForClear
    : leadingBlankColsForClear;
```

The same two changes are applied to `clearSignificanceForRange` (auto-clear current-table / sheet / workbook).

## Behavior on skipped / uncertain selections

- **State 3 (normalization blocked)**: unchanged — Clear already aborts before any mutation and surfaces `normalized.blockingMessage`. No row labels touched.
- **State 1 / State 2 ambiguous label column**: target is now narrowed by `detectEmbeddedLabelColumns`, matching Run. The clear target excludes label columns even when normalization itself failed to detect them. No additional blocking is introduced — when the data body resolves cleanly via Run's heuristic, Clear proceeds; otherwise the existing block path triggers.
- **Pure numeric selections**: `detectEmbeddedLabelColumns` returns 0 (no genuine text in col 0), so the clear target equals the original selection. Existing strict-selection workflow is unchanged.

## Validation

- `npm test` → 302/302 pass.
- `npm.cmd run build` → succeeds (only pre-existing webpack asset-size warnings, no errors).
- `git diff --check` → clean.

## Manual smoke checklist

- [ ] Wide/horizontal table with row labels on the left → Clear preserves row-label text and formatting; specifically `3 и более детей` and `BASE` remain unchanged.
- [ ] Normal numeric data-body selection → Clear removes RIT markers and formatting from data cells (no regression).
- [ ] Table with banner letters → Clear removes banner markers written by RIT above the data body.
- [ ] Skipped/uncertain/no-blocks wide table → Clear does not mutate row labels; blocking path still surfaces messages.
- [ ] Auto-clear current table / sheet / workbook → no row-label mutation on the same wide tables.

## Limitations

- `removeSignificanceMarkersFromText` itself is unchanged. Its Cyrillic character class is still incomplete (`т` and `ё` missing), so any future regression that lets a label back into the clear target could still produce the same Cyrillic damage. The fix here is narrow on purpose (target narrowing) per the issue guidance; a defensive change to the marker stripper or a fix for the missing letters can be opened as a follow-up under `src/core/significance.js`.
- Wide-table candidate detection / skip behavior is intentionally untouched (#273 scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)