### PR TITLE
Fix three-level banner subgroup grouping

### DIFF
--- a/src/core/banner-detector.js
+++ b/src/core/banner-detector.js
@@ -111,7 +111,8 @@ export function detectBannerStructure(bannerContext, settings = {}) {
   const columnDescriptors = buildColumnDescriptors({
     selectedColumnCount,
     lowerBannerRow: normalizedLowerBannerRow,
-    groupLevel: groupLevelResult.groupLevel,
+    upperScanRows,
+    fallbackGroupLevel: groupLevelResult.groupLevel,
   });
 
   markUpperLevelTotalsForSparseLowerLabels(columnDescriptors, upperScanRows);
@@ -209,22 +210,62 @@ function getLowerBannerRow(bannerContext) {
 /**
  * Builds column descriptors.
  */
-function buildColumnDescriptors({ selectedColumnCount, lowerBannerRow, groupLevel }) {
+function buildColumnDescriptors({
+  selectedColumnCount,
+  lowerBannerRow,
+  upperScanRows = [],
+  fallbackGroupLevel = null,
+}) {
   const descriptors = [];
+  const resolvedUpperRows = buildResolvedUpperBannerRows(
+    upperScanRows,
+    lowerBannerRow,
+    selectedColumnCount
+  );
 
   for (let columnIndex = 0; columnIndex < selectedColumnCount; columnIndex++) {
     const lowerLabel = normalizeRawBannerCellValue(lowerBannerRow[columnIndex]);
     const normalizedLowerLabel = normalizeBannerLabel(lowerLabel);
-
-    const groupLabel = groupLevel
-      ? normalizeRawBannerCellValue(groupLevel.labels[columnIndex])
+    const columnBannerEntries = buildColumnBannerEntries(
+      resolvedUpperRows,
+      lowerLabel,
+      normalizedLowerLabel,
+      columnIndex
+    );
+    const comparisonGroupEntries = deriveComparisonGroupEntries(
+      columnBannerEntries,
+      resolvedUpperRows.length > 0
+    );
+    const effectiveComparisonGroupEntries = shouldClearStandaloneSparseTotalGroupEntries(
+      columnBannerEntries,
+      comparisonGroupEntries,
+      lowerLabel
+    )
+      ? []
+      : comparisonGroupEntries;
+    const fallbackGroupLabel = fallbackGroupLevel
+      ? normalizeRawBannerCellValue(fallbackGroupLevel.labels[columnIndex])
       : DEFAULT_GROUP_LABEL;
-
-    const normalizedGroupLabel = normalizeBannerLabel(groupLabel);
-
-    const comparisonGroupKey = groupLevel
-      ? buildGroupKey(groupLabel, groupLevel.spansByColumnIndex[columnIndex])
-      : DEFAULT_GROUP_KEY;
+    const groupLabel =
+      effectiveComparisonGroupEntries.length > 0
+        ? effectiveComparisonGroupEntries[effectiveComparisonGroupEntries.length - 1].label
+        : fallbackGroupLabel;
+    const comparisonGroupKey =
+      effectiveComparisonGroupEntries.length > 0
+        ? buildHierarchicalGroupKey(effectiveComparisonGroupEntries)
+        : fallbackGroupLevel
+          ? buildGroupKey(
+              fallbackGroupLabel,
+              fallbackGroupLevel.spansByColumnIndex[columnIndex]
+            )
+          : DEFAULT_GROUP_KEY;
+    const comparisonGroupPath = effectiveComparisonGroupEntries.map((entry) => entry.label);
+    const groupLevelRowOffset =
+      effectiveComparisonGroupEntries.length > 0
+        ? effectiveComparisonGroupEntries[effectiveComparisonGroupEntries.length - 1].rowOffset
+        : fallbackGroupLevel
+          ? fallbackGroupLevel.rowOffset
+          : null;
 
     const isTotal = isTotalBannerLabel(normalizedLowerLabel);
 
@@ -234,11 +275,12 @@ function buildColumnDescriptors({ selectedColumnCount, lowerBannerRow, groupLeve
       lowerLabel,
       normalizedLowerLabel,
 
-      bannerPath: groupLevel ? [groupLabel, lowerLabel] : [lowerLabel],
-      displayLabel: groupLevel ? `${groupLabel} / ${lowerLabel}` : lowerLabel,
+      bannerPath: columnBannerEntries.map((entry) => entry.label),
+      displayLabel: formatColumnDisplayLabel(columnBannerEntries, lowerLabel),
 
       comparisonGroupKey,
-      comparisonGroupLabel: groupLevel ? groupLabel : DEFAULT_GROUP_LABEL,
+      comparisonGroupLabel: groupLabel,
+      comparisonGroupPath,
 
       isTotal,
       totalType: isTotal ? TOTAL_TYPE.LOCAL : null,
@@ -248,13 +290,194 @@ function buildColumnDescriptors({ selectedColumnCount, lowerBannerRow, groupLeve
 
       source: {
         lowerLevelRowOffset: 0,
-        groupLevelRowOffset: groupLevel ? groupLevel.rowOffset : null,
+        groupLevelRowOffset,
         mergeArea: null,
       },
     });
   }
 
   return descriptors;
+}
+
+function buildResolvedUpperBannerRows(upperScanRows, lowerBannerRow, selectedColumnCount) {
+  const resolvedRows = [];
+
+  for (let rowIndex = 0; rowIndex < upperScanRows.length; rowIndex++) {
+    const row = normalizeBannerRowLength(upperScanRows[rowIndex], selectedColumnCount);
+    const spans = selectBestResolvedUpperRowSpans(
+      row,
+      lowerBannerRow,
+      selectedColumnCount
+    );
+    const labels = Array(selectedColumnCount).fill("");
+    const spansByColumnIndex = {};
+
+    for (const span of spans) {
+      for (const columnIndex of span.columnIndexes) {
+        labels[columnIndex] = span.label;
+        spansByColumnIndex[columnIndex] = span;
+      }
+    }
+
+    resolvedRows.push({
+      rowOffset: -(rowIndex + 1),
+      labels,
+      spansByColumnIndex,
+    });
+  }
+
+  return resolvedRows;
+}
+
+function selectBestResolvedUpperRowSpans(row, lowerBannerRow, selectedColumnCount) {
+  const repeatedLabelResult = detectRepeatedLabelGroupLevelInRow(row, selectedColumnCount, 0);
+  const repeatedSpans = repeatedLabelResult.groupLevel ? repeatedLabelResult.groupLevel.spans : [];
+  const reconstructedSpans = buildResolvedReconstructedSpans(
+    row,
+    lowerBannerRow,
+    selectedColumnCount
+  );
+
+  if (scoreResolvedUpperRowSpans(repeatedSpans) > scoreResolvedUpperRowSpans(reconstructedSpans)) {
+    return repeatedSpans;
+  }
+
+  return reconstructedSpans;
+}
+
+function buildResolvedReconstructedSpans(row, lowerBannerRow, selectedColumnCount) {
+  const rawSpans = buildReconstructedSpansFromUpperRow(row, lowerBannerRow, selectedColumnCount);
+
+  return mergeAdjacentWaveValueSpans(rawSpans, lowerBannerRow);
+}
+
+function scoreResolvedUpperRowSpans(spans) {
+  if (!spans || spans.length === 0) {
+    return 0;
+  }
+
+  return spans.reduce((score, span) => {
+    if (!span || !span.label) {
+      return score;
+    }
+
+    return span.columnIndexes && span.columnIndexes.length > 1
+      ? score + span.columnIndexes.length
+      : score;
+  }, 0);
+}
+
+function buildColumnBannerEntries(
+  resolvedUpperRows,
+  lowerLabel,
+  normalizedLowerLabel,
+  columnIndex
+) {
+  const entries = [];
+
+  for (let rowIndex = resolvedUpperRows.length - 1; rowIndex >= 0; rowIndex--) {
+    const resolvedRow = resolvedUpperRows[rowIndex];
+    const label = normalizeRawBannerCellValue(resolvedRow.labels[columnIndex]);
+    const normalizedLabel = normalizeBannerLabel(label);
+    const span = resolvedRow.spansByColumnIndex[columnIndex] || null;
+
+    if (!label) {
+      continue;
+    }
+
+    if (
+      lowerLabel &&
+      span &&
+      span.startColumnIndex === span.endColumnIndex
+    ) {
+      continue;
+    }
+
+    const previousEntry = entries[entries.length - 1];
+
+    if (previousEntry && previousEntry.normalizedLabel === normalizedLabel) {
+      continue;
+    }
+
+    entries.push({
+      label,
+      normalizedLabel,
+      rowOffset: resolvedRow.rowOffset,
+      span,
+      source: "upper",
+    });
+  }
+
+  if (lowerLabel) {
+    const previousEntry = entries[entries.length - 1];
+
+    if (!previousEntry || previousEntry.normalizedLabel !== normalizedLowerLabel) {
+      entries.push({
+        label: lowerLabel,
+        normalizedLabel: normalizedLowerLabel,
+        rowOffset: 0,
+        span: {
+          startColumnIndex: columnIndex,
+          endColumnIndex: columnIndex,
+        },
+        source: "lower",
+      });
+    }
+  }
+
+  return entries;
+}
+
+function deriveComparisonGroupEntries(columnBannerEntries, hasUpperBannerRows) {
+  if (!columnBannerEntries || columnBannerEntries.length === 0) {
+    return [];
+  }
+
+  const upperEntries = columnBannerEntries.filter((entry) => entry.source === "upper");
+
+  if (!hasUpperBannerRows || upperEntries.length === 0) {
+    return [];
+  }
+
+  if (columnBannerEntries.length === 1) {
+    return [columnBannerEntries[0]];
+  }
+
+  const candidateAncestorEntries = columnBannerEntries.slice(0, -1);
+  const semanticAncestorEntries = candidateAncestorEntries.filter(
+    (entry) => !isTechnicalWaveOrValueLabel(entry.label)
+  );
+
+  if (semanticAncestorEntries.length > 0) {
+    return semanticAncestorEntries;
+  }
+
+  if (candidateAncestorEntries.length > 0) {
+    return candidateAncestorEntries;
+  }
+
+  return [columnBannerEntries[0]];
+}
+
+function shouldClearStandaloneSparseTotalGroupEntries(
+  columnBannerEntries,
+  comparisonGroupEntries,
+  lowerLabel
+) {
+  return (
+    columnBannerEntries.length === 1 &&
+    !lowerLabel &&
+    comparisonGroupEntries.length === 1 &&
+    isTotalBannerLabel(comparisonGroupEntries[0].normalizedLabel)
+  );
+}
+
+function formatColumnDisplayLabel(columnBannerEntries, lowerLabel) {
+  if (!columnBannerEntries || columnBannerEntries.length === 0) {
+    return lowerLabel;
+  }
+
+  return columnBannerEntries.map((entry) => entry.label).join(" / ");
 }
 
 /**
@@ -279,11 +502,8 @@ function buildGroupsFromColumnDescriptors(
 
       groupsByKey.set(descriptor.comparisonGroupKey, {
         groupKey: descriptor.comparisonGroupKey,
-        label: descriptor.comparisonGroupLabel,
-        bannerPath:
-          descriptor.comparisonGroupLabel === DEFAULT_GROUP_LABEL
-            ? []
-            : [descriptor.comparisonGroupLabel],
+        label: descriptor.comparisonGroupLabel || DEFAULT_GROUP_LABEL,
+        bannerPath: descriptor.comparisonGroupPath || [],
         columnIndexes: [],
         localTotalColumnIndexes: [],
         hasLocalTotal: false,
@@ -749,6 +969,25 @@ function buildGroupKey(groupLabel, span) {
     span.startColumnIndex,
     span.endColumnIndex,
   ].join(":");
+}
+
+function buildHierarchicalGroupKey(groupEntries) {
+  if (!groupEntries || groupEntries.length === 0) {
+    return DEFAULT_GROUP_KEY;
+  }
+
+  return `group:${groupEntries
+    .map((entry) => {
+      const span = entry.span || {};
+
+      return [
+        entry.normalizedLabel || "unknown",
+        entry.rowOffset,
+        span.startColumnIndex ?? "unknown",
+        span.endColumnIndex ?? "unknown",
+      ].join(":");
+    })
+    .join(">")}`;
 }
 
 /**

--- a/tests/core/banner-detector.test.mjs
+++ b/tests/core/banner-detector.test.mjs
@@ -442,6 +442,70 @@ describe("detectBannerStructure - group level selection", () => {
     assert.strictEqual(labelMap.get(2), "a", "first column of second group must get label a");
     assert.strictEqual(labelMap.get(3), "b", "second column of second group must get label b");
   });
+
+  it("keeps real three-level subgroup splits separate when an earlier mixed-depth segment uses vertically merged wave labels", () => {
+    const bannerContext = {
+      selectedColumnCount: 6,
+      lowerBannerRow: ["", "", "w6 (ноябрь 23)", "w7", "w6 (ноябрь 23)", "w7"],
+      upperScanRows: [
+        ["w6 (ноябрь 23)", "w7", "Мужской", "", "Женский", ""],
+        ["Пол", "", "Пол", "", "", ""],
+      ],
+    };
+
+    const result = detectBannerStructure(bannerContext, { autoDetectWaveBanners: false });
+
+    assert.deepStrictEqual(
+      result.groups.map((group) => ({
+        label: group.label,
+        bannerPath: group.bannerPath,
+        columnIndexes: group.columnIndexes,
+      })),
+      [
+        {
+          label: "Пол",
+          bannerPath: ["Пол"],
+          columnIndexes: [0, 1],
+        },
+        {
+          label: "Мужской",
+          bannerPath: ["Пол", "Мужской"],
+          columnIndexes: [2, 3],
+        },
+        {
+          label: "Женский",
+          bannerPath: ["Пол", "Женский"],
+          columnIndexes: [4, 5],
+        },
+      ]
+    );
+
+    const labelMap = buildBannerLocalSignificanceLabelMap(result, {
+      autoDetectWaveBanners: false,
+    });
+
+    assert.deepStrictEqual(
+      Array.from({ length: 6 }, (_, columnIndex) => labelMap.get(columnIndex) || ""),
+      ["a", "b", "a", "b", "a", "b"]
+    );
+
+    const pairs = buildColumnComparisonPairs(
+      6,
+      { respectBannerStructure: true, autoDetectWaveBanners: false },
+      new Set(),
+      result
+    );
+
+    const bannerGroupPairs = pairs
+      .filter((pair) => pair.comparisonType === "bannerGroup")
+      .map((pair) => [pair.firstColumnIndex, pair.secondColumnIndex, pair.groupLabel]);
+
+    assert.deepStrictEqual(bannerGroupPairs, [
+      [0, 1, "Пол"],
+      [2, 3, "Мужской"],
+      [4, 5, "Женский"],
+    ]);
+  });
 });
 
 describe("detectBannerStructure - sparse lower banner totals", () => {


### PR DESCRIPTION
## Summary
Fixes issue #274 by making banner-aware local grouping derive from each column's hierarchical banner path instead of a single banner row for the whole table.

## Root cause
The detector previously chose one upper banner row as the comparison-group level for the entire selection. In mixed-depth real banners, a middle row could be rejected when an earlier vertically merged wave segment exposed single-column labels like w6 (ноябрь 23) that were not recognized as technical wave labels. Detection then fell back to the higher Пол row, so both comparison pairs and local marker labels merged Мужской and Женский into one group.

## Grouping model
Before:
- one global groupLevel row for the whole table;
- comparisonGroupKey came only from that row's label/span;
- mixed two-level + three-level segments could collapse onto the top parent row.

After:
- each column builds a hierarchical banner path from resolved upper rows plus the lower row;
- local comparison-group identity comes from the meaningful ancestor path for that column, while wave/member leaves stay inside the group;
- comparison pairs and banner marker labels still share the same annerStructure.groups model.

Example outcome:
- Пол -> Мужской -> waves and Пол -> Женский -> waves now resolve to separate local groups;
- an earlier mixed-depth Пол -> waves segment still stays intact.

## Files changed
- src/core/banner-detector.js
- 	ests/core/banner-detector.test.mjs

## Tests added/updated
- added regression coverage for a mixed-depth banner with vertically merged wave labels followed by real three-level Пол -> Мужской/Женский -> waves splits;
- existing banner-detector and preview-model regressions still pass, including stripped wave pairs, sparse totals, and global-total cases.

## Validation
- 
pm test ✅
- 
pm run build ✅
- git diff --check ✅

## Manual smoke checklist
- [ ] Wide workbook table with Пол -> Мужской/Женский -> waves
- [ ] espectBannerStructure enabled
- [ ] banner letters enabled
- [ ] Мужской labels restart at 
- [ ] Женский labels restart at 
- [ ] data-cell significance letters match banner letters
- [ ] earlier vertically merged / effectively two-level wave segment still behaves as before
- [ ] Run report shape unchanged

## Known limitations
- This PR stays inside banner grouping / local label semantics only.
- No statistical formulas changed.
- No data-body writer, Clear Significance, generated sheet names, #273, #275, or performance work were touched.

## Assumptions
- Hierarchical local grouping should follow meaningful ancestor banner paths per column, not a single flattened row for the entire selection.
- Single-column helper/prefix rows above a populated lower banner row should not redefine subgroup boundaries.