### PR TITLE
Fix wide table warning and mixed-label eligibility

### DIFF
--- a/src/core/banner-detector.js
+++ b/src/core/banner-detector.js
@@ -111,7 +111,8 @@ export function detectBannerStructure(bannerContext, settings = {}) {
   const columnDescriptors = buildColumnDescriptors({
     selectedColumnCount,
     lowerBannerRow: normalizedLowerBannerRow,
-    groupLevel: groupLevelResult.groupLevel,
+    upperScanRows,
+    fallbackGroupLevel: groupLevelResult.groupLevel,
   });
 
   markUpperLevelTotalsForSparseLowerLabels(columnDescriptors, upperScanRows);
@@ -209,22 +210,62 @@ function getLowerBannerRow(bannerContext) {
 /**
  * Builds column descriptors.
  */
-function buildColumnDescriptors({ selectedColumnCount, lowerBannerRow, groupLevel }) {
+function buildColumnDescriptors({
+  selectedColumnCount,
+  lowerBannerRow,
+  upperScanRows = [],
+  fallbackGroupLevel = null,
+}) {
   const descriptors = [];
+  const resolvedUpperRows = buildResolvedUpperBannerRows(
+    upperScanRows,
+    lowerBannerRow,
+    selectedColumnCount
+  );
 
   for (let columnIndex = 0; columnIndex < selectedColumnCount; columnIndex++) {
     const lowerLabel = normalizeRawBannerCellValue(lowerBannerRow[columnIndex]);
     const normalizedLowerLabel = normalizeBannerLabel(lowerLabel);
-
-    const groupLabel = groupLevel
-      ? normalizeRawBannerCellValue(groupLevel.labels[columnIndex])
+    const columnBannerEntries = buildColumnBannerEntries(
+      resolvedUpperRows,
+      lowerLabel,
+      normalizedLowerLabel,
+      columnIndex
+    );
+    const comparisonGroupEntries = deriveComparisonGroupEntries(
+      columnBannerEntries,
+      resolvedUpperRows.length > 0
+    );
+    const effectiveComparisonGroupEntries = shouldClearStandaloneSparseTotalGroupEntries(
+      columnBannerEntries,
+      comparisonGroupEntries,
+      lowerLabel
+    )
+      ? []
+      : comparisonGroupEntries;
+    const fallbackGroupLabel = fallbackGroupLevel
+      ? normalizeRawBannerCellValue(fallbackGroupLevel.labels[columnIndex])
       : DEFAULT_GROUP_LABEL;
-
-    const normalizedGroupLabel = normalizeBannerLabel(groupLabel);
-
-    const comparisonGroupKey = groupLevel
-      ? buildGroupKey(groupLabel, groupLevel.spansByColumnIndex[columnIndex])
-      : DEFAULT_GROUP_KEY;
+    const groupLabel =
+      effectiveComparisonGroupEntries.length > 0
+        ? effectiveComparisonGroupEntries[effectiveComparisonGroupEntries.length - 1].label
+        : fallbackGroupLabel;
+    const comparisonGroupKey =
+      effectiveComparisonGroupEntries.length > 0
+        ? buildHierarchicalGroupKey(effectiveComparisonGroupEntries)
+        : fallbackGroupLevel
+          ? buildGroupKey(
+              fallbackGroupLabel,
+              fallbackGroupLevel.spansByColumnIndex[columnIndex]
+            )
+          : DEFAULT_GROUP_KEY;
+    const comparisonGroupPath = effectiveComparisonGroupEntries.map((entry) => entry.label);
+    const groupLevelRowOffset =
+      effectiveComparisonGroupEntries.length > 0
+        ? effectiveComparisonGroupEntries[effectiveComparisonGroupEntries.length - 1].rowOffset
+        : fallbackGroupLevel
+          ? fallbackGroupLevel.rowOffset
+          : null;
 
     const isTotal = isTotalBannerLabel(normalizedLowerLabel);
 
@@ -234,11 +275,12 @@ function buildColumnDescriptors({ selectedColumnCount, lowerBannerRow, groupLeve
       lowerLabel,
       normalizedLowerLabel,
 
-      bannerPath: groupLevel ? [groupLabel, lowerLabel] : [lowerLabel],
-      displayLabel: groupLevel ? `${groupLabel} / ${lowerLabel}` : lowerLabel,
+      bannerPath: columnBannerEntries.map((entry) => entry.label),
+      displayLabel: formatColumnDisplayLabel(columnBannerEntries, lowerLabel),
 
       comparisonGroupKey,
-      comparisonGroupLabel: groupLevel ? groupLabel : DEFAULT_GROUP_LABEL,
+      comparisonGroupLabel: groupLabel,
+      comparisonGroupPath,
 
       isTotal,
       totalType: isTotal ? TOTAL_TYPE.LOCAL : null,
@@ -248,13 +290,194 @@ function buildColumnDescriptors({ selectedColumnCount, lowerBannerRow, groupLeve
 
       source: {
         lowerLevelRowOffset: 0,
-        groupLevelRowOffset: groupLevel ? groupLevel.rowOffset : null,
+        groupLevelRowOffset,
         mergeArea: null,
       },
     });
   }
 
   return descriptors;
+}
+
+function buildResolvedUpperBannerRows(upperScanRows, lowerBannerRow, selectedColumnCount) {
+  const resolvedRows = [];
+
+  for (let rowIndex = 0; rowIndex < upperScanRows.length; rowIndex++) {
+    const row = normalizeBannerRowLength(upperScanRows[rowIndex], selectedColumnCount);
+    const spans = selectBestResolvedUpperRowSpans(
+      row,
+      lowerBannerRow,
+      selectedColumnCount
+    );
+    const labels = Array(selectedColumnCount).fill("");
+    const spansByColumnIndex = {};
+
+    for (const span of spans) {
+      for (const columnIndex of span.columnIndexes) {
+        labels[columnIndex] = span.label;
+        spansByColumnIndex[columnIndex] = span;
+      }
+    }
+
+    resolvedRows.push({
+      rowOffset: -(rowIndex + 1),
+      labels,
+      spansByColumnIndex,
+    });
+  }
+
+  return resolvedRows;
+}
+
+function selectBestResolvedUpperRowSpans(row, lowerBannerRow, selectedColumnCount) {
+  const repeatedLabelResult = detectRepeatedLabelGroupLevelInRow(row, selectedColumnCount, 0);
+  const repeatedSpans = repeatedLabelResult.groupLevel ? repeatedLabelResult.groupLevel.spans : [];
+  const reconstructedSpans = buildResolvedReconstructedSpans(
+    row,
+    lowerBannerRow,
+    selectedColumnCount
+  );
+
+  if (scoreResolvedUpperRowSpans(repeatedSpans) > scoreResolvedUpperRowSpans(reconstructedSpans)) {
+    return repeatedSpans;
+  }
+
+  return reconstructedSpans;
+}
+
+function buildResolvedReconstructedSpans(row, lowerBannerRow, selectedColumnCount) {
+  const rawSpans = buildReconstructedSpansFromUpperRow(row, lowerBannerRow, selectedColumnCount);
+
+  return mergeAdjacentWaveValueSpans(rawSpans, lowerBannerRow);
+}
+
+function scoreResolvedUpperRowSpans(spans) {
+  if (!spans || spans.length === 0) {
+    return 0;
+  }
+
+  return spans.reduce((score, span) => {
+    if (!span || !span.label) {
+      return score;
+    }
+
+    return span.columnIndexes && span.columnIndexes.length > 1
+      ? score + span.columnIndexes.length
+      : score;
+  }, 0);
+}
+
+function buildColumnBannerEntries(
+  resolvedUpperRows,
+  lowerLabel,
+  normalizedLowerLabel,
+  columnIndex
+) {
+  const entries = [];
+
+  for (let rowIndex = resolvedUpperRows.length - 1; rowIndex >= 0; rowIndex--) {
+    const resolvedRow = resolvedUpperRows[rowIndex];
+    const label = normalizeRawBannerCellValue(resolvedRow.labels[columnIndex]);
+    const normalizedLabel = normalizeBannerLabel(label);
+    const span = resolvedRow.spansByColumnIndex[columnIndex] || null;
+
+    if (!label) {
+      continue;
+    }
+
+    if (
+      lowerLabel &&
+      span &&
+      span.startColumnIndex === span.endColumnIndex
+    ) {
+      continue;
+    }
+
+    const previousEntry = entries[entries.length - 1];
+
+    if (previousEntry && previousEntry.normalizedLabel === normalizedLabel) {
+      continue;
+    }
+
+    entries.push({
+      label,
+      normalizedLabel,
+      rowOffset: resolvedRow.rowOffset,
+      span,
+      source: "upper",
+    });
+  }
+
+  if (lowerLabel) {
+    const previousEntry = entries[entries.length - 1];
+
+    if (!previousEntry || previousEntry.normalizedLabel !== normalizedLowerLabel) {
+      entries.push({
+        label: lowerLabel,
+        normalizedLabel: normalizedLowerLabel,
+        rowOffset: 0,
+        span: {
+          startColumnIndex: columnIndex,
+          endColumnIndex: columnIndex,
+        },
+        source: "lower",
+      });
+    }
+  }
+
+  return entries;
+}
+
+function deriveComparisonGroupEntries(columnBannerEntries, hasUpperBannerRows) {
+  if (!columnBannerEntries || columnBannerEntries.length === 0) {
+    return [];
+  }
+
+  const upperEntries = columnBannerEntries.filter((entry) => entry.source === "upper");
+
+  if (!hasUpperBannerRows || upperEntries.length === 0) {
+    return [];
+  }
+
+  if (columnBannerEntries.length === 1) {
+    return [columnBannerEntries[0]];
+  }
+
+  const candidateAncestorEntries = columnBannerEntries.slice(0, -1);
+  const semanticAncestorEntries = candidateAncestorEntries.filter(
+    (entry) => !isTechnicalWaveOrValueLabel(entry.label)
+  );
+
+  if (semanticAncestorEntries.length > 0) {
+    return semanticAncestorEntries;
+  }
+
+  if (candidateAncestorEntries.length > 0) {
+    return candidateAncestorEntries;
+  }
+
+  return [columnBannerEntries[0]];
+}
+
+function shouldClearStandaloneSparseTotalGroupEntries(
+  columnBannerEntries,
+  comparisonGroupEntries,
+  lowerLabel
+) {
+  return (
+    columnBannerEntries.length === 1 &&
+    !lowerLabel &&
+    comparisonGroupEntries.length === 1 &&
+    isTotalBannerLabel(comparisonGroupEntries[0].normalizedLabel)
+  );
+}
+
+function formatColumnDisplayLabel(columnBannerEntries, lowerLabel) {
+  if (!columnBannerEntries || columnBannerEntries.length === 0) {
+    return lowerLabel;
+  }
+
+  return columnBannerEntries.map((entry) => entry.label).join(" / ");
 }
 
 /**
@@ -279,11 +502,8 @@ function buildGroupsFromColumnDescriptors(
 
       groupsByKey.set(descriptor.comparisonGroupKey, {
         groupKey: descriptor.comparisonGroupKey,
-        label: descriptor.comparisonGroupLabel,
-        bannerPath:
-          descriptor.comparisonGroupLabel === DEFAULT_GROUP_LABEL
-            ? []
-            : [descriptor.comparisonGroupLabel],
+        label: descriptor.comparisonGroupLabel || DEFAULT_GROUP_LABEL,
+        bannerPath: descriptor.comparisonGroupPath || [],
         columnIndexes: [],
         localTotalColumnIndexes: [],
         hasLocalTotal: false,
@@ -749,6 +969,25 @@ function buildGroupKey(groupLabel, span) {
     span.startColumnIndex,
     span.endColumnIndex,
   ].join(":");
+}
+
+function buildHierarchicalGroupKey(groupEntries) {
+  if (!groupEntries || groupEntries.length === 0) {
+    return DEFAULT_GROUP_KEY;
+  }
+
+  return `group:${groupEntries
+    .map((entry) => {
+      const span = entry.span || {};
+
+      return [
+        entry.normalizedLabel || "unknown",
+        entry.rowOffset,
+        span.startColumnIndex ?? "unknown",
+        span.endColumnIndex ?? "unknown",
+      ].join(":");
+    })
+    .join(">")}`;
 }
 
 /**

--- a/src/core/range-normalizer.js
+++ b/src/core/range-normalizer.js
@@ -125,6 +125,24 @@ function isTextOnlyCell(cell) {
   return !isNumericCell(cell);
 }
 
+function isLikelyOrdinalScaleLabelCell(cell) {
+  if (typeof cell === "number") {
+    return Number.isInteger(cell) && cell >= 0 && cell <= 10;
+  }
+
+  if (typeof cell !== "string") {
+    return false;
+  }
+
+  const trimmed = cell.trim();
+  if (!/^\d+$/.test(trimmed)) {
+    return false;
+  }
+
+  const value = Number(trimmed);
+  return Number.isInteger(value) && value >= 0 && value <= 10;
+}
+
 function cleanStructuralTextCell(cell) {
   if (typeof cell !== "string") {
     return cell;
@@ -474,8 +492,13 @@ function detectLabelColumns(values, bodyStartRow, bodyEndRow, colCount) {
   }
 
   const col0Frac = computeTextFraction(values, bodyStartRow, bodyEndRow, 0, 0);
+  const col0LooksLikeRatingScale = isLikelyRatingScaleLabelColumn(
+    values,
+    bodyStartRow,
+    bodyEndRow
+  );
 
-  if (col0Frac < LABEL_NUMERIC_THRESHOLD) {
+  if (col0Frac < LABEL_NUMERIC_THRESHOLD && !col0LooksLikeRatingScale) {
     if (isExtendedNpsScaleLabelColumn(values, bodyStartRow, bodyEndRow, colCount)) {
       if (colCount >= 3 && isUniformUnitColumn(values, bodyStartRow, bodyEndRow)) {
         return { labelColCount: 2, labelSplitConfidence: "confident" };
@@ -485,7 +508,7 @@ function detectLabelColumns(values, bodyStartRow, bodyEndRow, colCount) {
     return { labelColCount: 0, labelSplitConfidence: "confident" };
   }
 
-  if (col0Frac < LABEL_TEXT_FRACTION_THRESHOLD) {
+  if (col0Frac < LABEL_TEXT_FRACTION_THRESHOLD && !col0LooksLikeRatingScale) {
     if (isExtendedNpsScaleLabelColumn(values, bodyStartRow, bodyEndRow, colCount)) {
       if (colCount >= 3 && isUniformUnitColumn(values, bodyStartRow, bodyEndRow)) {
         return { labelColCount: 2, labelSplitConfidence: "confident" };
@@ -609,6 +632,41 @@ function isExtendedNpsScaleLabelColumn(values, bodyStartRow, bodyEndRow, colCoun
     hasNps &&
     hasBase
   );
+}
+
+function isLikelyRatingScaleLabelColumn(values, bodyStartRow, bodyEndRow) {
+  let totalNonEmpty = 0;
+  let textOnlyCount = 0;
+  let ordinalScaleCount = 0;
+
+  for (let row = bodyStartRow; row <= bodyEndRow; row++) {
+    const rowArr = values[row];
+    if (!rowArr) continue;
+
+    const cell = rowArr[0];
+    if (isCellEmpty(cell)) continue;
+
+    totalNonEmpty++;
+
+    if (isTextOnlyCell(cell)) {
+      textOnlyCount++;
+      continue;
+    }
+
+    if (isLikelyOrdinalScaleLabelCell(cell)) {
+      ordinalScaleCount++;
+    }
+  }
+
+  if (totalNonEmpty === 0) {
+    return false;
+  }
+
+  const labelLikeFraction = (textOnlyCount + ordinalScaleCount) / totalNonEmpty;
+  const allCellsAreLabelLike = textOnlyCount + ordinalScaleCount === totalNonEmpty;
+  const minText = allCellsAreLabelLike ? 1 : 2;
+
+  return textOnlyCount >= minText && ordinalScaleCount >= 3 && labelLikeFraction >= 0.8;
 }
 
 // ─── Body validation ──────────────────────────────────────────────────────────

--- a/src/core/table-inventory-scanner.js
+++ b/src/core/table-inventory-scanner.js
@@ -498,17 +498,17 @@ const ADVISORY_ISSUE_CODES = new Set([
  *                uncertain boundaries; worth checking via Check Table.
  *                Also returned when labelSplitConfidence is "twoColumn" (two-column
  *                row labels with ordinal code + text answer are valid structures).
- * "uncertain"  — table-like but has blocking issues, quality warnings, or an
- *                ambiguous label/data boundary; Check Table may still work but
- *                results should be verified.
+ * "uncertain"  — table-like but has blocking issues or an ambiguous label/data
+ *                boundary; Check Table may still work but results should be
+ *                verified.
  * "rejected"   — no metric rows detected; unlikely to be a RIT research table.
  *
  * This replaces the former canRunSignificance flag which implied Run-readiness.
  * The scanner is a candidate finder only; Check Table is the authoritative step.
  */
-function deriveCandidateStatus({ isLikelyTable, hasBlockingIssues, availabilityWarningCount, labelSplitConfidence }) {
+function deriveCandidateStatus({ isLikelyTable, hasBlockingIssues, labelSplitConfidence }) {
   if (!isLikelyTable) return "rejected";
-  if (hasBlockingIssues || labelSplitConfidence === "uncertain" || availabilityWarningCount > 0) return "uncertain";
+  if (hasBlockingIssues || labelSplitConfidence === "uncertain") return "uncertain";
   return "available";
 }
 
@@ -549,7 +549,6 @@ function buildTableInventoryItem({ band, model, titleInfo, rangeAddress, sheetNa
   const candidateStatus = deriveCandidateStatus({
     isLikelyTable,
     hasBlockingIssues: qualitySummary.hasBlockingIssues,
-    availabilityWarningCount,
     labelSplitConfidence,
   });
 

--- a/tests/core/banner-detector.test.mjs
+++ b/tests/core/banner-detector.test.mjs
@@ -442,6 +442,70 @@ describe("detectBannerStructure - group level selection", () => {
     assert.strictEqual(labelMap.get(2), "a", "first column of second group must get label a");
     assert.strictEqual(labelMap.get(3), "b", "second column of second group must get label b");
   });
+
+  it("keeps real three-level subgroup splits separate when an earlier mixed-depth segment uses vertically merged wave labels", () => {
+    const bannerContext = {
+      selectedColumnCount: 6,
+      lowerBannerRow: ["", "", "w6 (ноябрь 23)", "w7", "w6 (ноябрь 23)", "w7"],
+      upperScanRows: [
+        ["w6 (ноябрь 23)", "w7", "Мужской", "", "Женский", ""],
+        ["Пол", "", "Пол", "", "", ""],
+      ],
+    };
+
+    const result = detectBannerStructure(bannerContext, { autoDetectWaveBanners: false });
+
+    assert.deepStrictEqual(
+      result.groups.map((group) => ({
+        label: group.label,
+        bannerPath: group.bannerPath,
+        columnIndexes: group.columnIndexes,
+      })),
+      [
+        {
+          label: "Пол",
+          bannerPath: ["Пол"],
+          columnIndexes: [0, 1],
+        },
+        {
+          label: "Мужской",
+          bannerPath: ["Пол", "Мужской"],
+          columnIndexes: [2, 3],
+        },
+        {
+          label: "Женский",
+          bannerPath: ["Пол", "Женский"],
+          columnIndexes: [4, 5],
+        },
+      ]
+    );
+
+    const labelMap = buildBannerLocalSignificanceLabelMap(result, {
+      autoDetectWaveBanners: false,
+    });
+
+    assert.deepStrictEqual(
+      Array.from({ length: 6 }, (_, columnIndex) => labelMap.get(columnIndex) || ""),
+      ["a", "b", "a", "b", "a", "b"]
+    );
+
+    const pairs = buildColumnComparisonPairs(
+      6,
+      { respectBannerStructure: true, autoDetectWaveBanners: false },
+      new Set(),
+      result
+    );
+
+    const bannerGroupPairs = pairs
+      .filter((pair) => pair.comparisonType === "bannerGroup")
+      .map((pair) => [pair.firstColumnIndex, pair.secondColumnIndex, pair.groupLabel]);
+
+    assert.deepStrictEqual(bannerGroupPairs, [
+      [0, 1, "Пол"],
+      [2, 3, "Мужской"],
+      [4, 5, "Женский"],
+    ]);
+  });
 });
 
 describe("detectBannerStructure - sparse lower banner totals", () => {

--- a/tests/core/table-inventory-scanner.test.mjs
+++ b/tests/core/table-inventory-scanner.test.mjs
@@ -145,8 +145,9 @@ describe("scanWorksheetForTables", () => {
     // If items.length === 0, the scanner correctly found nothing to over-promise on.
   });
 
-  it("candidate with preview warnings is surfaced as uncertain", () => {
-    // All-100 rows trigger a quality warning in the preview model.
+  it("candidate with preview warnings remains available when there are no blocking issues", () => {
+    // All-100 rows still trigger a quality warning in the preview model, but
+    // warnings alone must not make the candidate unavailable for Check/Autorun.
     const values = [
       ["Label1", 100, 100, 100],
       ["Label2", 100, 100, 100],
@@ -155,14 +156,12 @@ describe("scanWorksheetForTables", () => {
     const items = scanWorksheetForTables({ values, ...OFFSET });
     assert.ok(items.length >= 1, "expected at least one item");
     const item = items[0];
-    // Warnings must be reflected in the candidate status.
-    if (item.warningsCount > 0) {
-      assert.strictEqual(
-        item.candidateStatus,
-        "uncertain",
-        "item with preview warnings must be uncertain, not available"
-      );
-    }
+    assert.ok(item.warningsCount > 0, "expected preview warnings to remain visible");
+    assert.strictEqual(
+      item.candidateStatus,
+      "available",
+      "item with warnings but no blocking issues must remain available"
+    );
   });
 
   it("side-by-side tables in one row band appear as one candidate and expose no canRunSignificance", () => {
@@ -709,9 +708,9 @@ describe("scanWorksheetForTables — preferredBase setting threading", () => {
     );
   });
 
-  it("real availability-affecting warning (SUSPICIOUS_ALL_100) still makes candidate uncertain", () => {
-    // All-100 rows trigger SUSPICIOUS_ALL_100 — a non-advisory warning that should
-    // still downgrade candidateStatus to uncertain.
+  it("SUSPICIOUS_ALL_100 stays visible but does not make candidate uncertain", () => {
+    // Service/test-like all-100 rows should remain a warning for QA, but should
+    // not block a structurally valid table from workbook Check/Autorun.
     const allHundredValues = [
       ["Label1",       100, 100, 100],
       ["Label2",       100, 100, 100],
@@ -724,8 +723,8 @@ describe("scanWorksheetForTables — preferredBase setting threading", () => {
     assert.ok(items[0].warningsCount > 0, "warningsCount must include advisory warnings for display");
     assert.strictEqual(
       items[0].candidateStatus,
-      "uncertain",
-      "SUSPICIOUS_ALL_100 must still make candidateStatus uncertain"
+      "available",
+      "SUSPICIOUS_ALL_100 must remain visible without making candidateStatus uncertain"
     );
   });
 });
@@ -755,9 +754,9 @@ describe("scanWorksheetForTables — advisory issue codes do not affect candidat
     );
   });
 
-  it("BASE_BLANK_VALUES: is NOT advisory and still makes candidateStatus uncertain", () => {
-    // A base row with blank cells → BASE_BLANK_VALUES is a real data-quality warning
-    // that genuinely signals the table may not calculate significance correctly.
+  it("BASE_BLANK_VALUES: warning remains visible without making candidateStatus uncertain", () => {
+    // Partial blank base cells should remain visible to QA, but valid columns are
+    // still runnable so the table must stay available.
     const values = [
       ["Agree",    0.4,  0.6, 0.5],
       ["Disagree", 0.6,  0.4, 0.5],
@@ -771,8 +770,28 @@ describe("scanWorksheetForTables — advisory issue codes do not affect candidat
     );
     assert.strictEqual(
       items[0].candidateStatus,
-      "uncertain",
-      "BASE_BLANK_VALUES must still downgrade candidateStatus to uncertain"
+      "available",
+      "BASE_BLANK_VALUES must remain visible without downgrading candidateStatus"
+    );
+  });
+
+  it("missing row-label warning remains visible without making candidate uncertain", () => {
+    const values = [
+      ["", 10, 20, 30],
+      ["Label2", 40, 50, 60],
+      ["Base", 100, 100, 100],
+    ];
+
+    const items = scanWorksheetForTables({ values, ...OFFSET });
+    assert.strictEqual(items.length, 1);
+    assert.ok(
+      items[0].qualityIssueCodes.some((entry) => entry.code === "MISSING_ROW_LABEL_WITH_DATA"),
+      "MISSING_ROW_LABEL_WITH_DATA must remain visible in diagnostics"
+    );
+    assert.strictEqual(
+      items[0].candidateStatus,
+      "available",
+      "missing-label warnings must not make an otherwise valid candidate uncertain"
     );
   });
 });

--- a/tests/core/table-preview-model.test.mjs
+++ b/tests/core/table-preview-model.test.mjs
@@ -368,6 +368,43 @@ describe("buildTablePreviewModel - normalized full-table regression coverage", (
       `unexpected warning set: ${JSON.stringify(model.warnings)}`
     );
   });
+
+  it("preserves mixed ordinal/text label columns in normalized wide category tables", () => {
+    const rawText = [
+      ["Children age", "", "", ""],
+      ["", "w6", "w7", "w8"],
+      ["0", "10%", "11%", "12%"],
+      ["1", "20%", "21%", "22%"],
+      ["2", "30%", "31%", "32%"],
+      ["3", "15%", "16%", "17%"],
+      ["4", "10%", "9%", "8%"],
+      ["5", "8%", "7%", "6%"],
+      ["6 и более", "7%", "5%", "3%"],
+      ["BASE", "100", "100", "100"],
+    ];
+    const cleanedValues = rawText.map((row, rowIndex) =>
+      rowIndex >= 2 ? ["", ...row.slice(1)] : [...row]
+    );
+
+    const { normalized, model } = buildNormalizedPreviewModel(rawText, cleanedValues);
+    const proportionBlock = findBlock(model, "proportion");
+
+    assert.deepStrictEqual(
+      normalized.leftLabelValues.map((row) => row[0]),
+      ["0", "1", "2", "3", "4", "5", "6 и более", "BASE"]
+    );
+    assert.deepStrictEqual(
+      model.rowDiagnostics.map((row) => row.primaryLabel),
+      ["0", "1", "2", "3", "4", "5", "6 и более", "BASE"]
+    );
+    assert.ok(proportionBlock, "expected a proportion block for mixed ordinal/text labels");
+    assert.deepStrictEqual(proportionBlock.valueRowIndexes, [0, 1, 2, 3, 4, 5, 6]);
+    assert.strictEqual(proportionBlock.baseRowIndex, 7);
+    assert.ok(
+      !warningCodes(model).includes("MISSING_ROW_LABEL_WITH_DATA"),
+      `unexpected warning set: ${JSON.stringify(model.warnings)}`
+    );
+  });
 });
 
 describe("buildTablePreviewModel - explicit base requirement", () => {


### PR DESCRIPTION
## Summary
- stop downgrading structurally valid scanner candidates to uncertain just because preview/check produced warnings
- align selected-range normalization with scanner support for mixed ordinal/text row-label columns so wide category tables keep their embedded labels and still form calculation blocks
- add regression coverage for warning-vs-blocker semantics and normalized mixed-label wide tables

## Root cause
Issue #275 had two separate causes.

1. candidate uncertain
The inventory scanner treated ordinary preview warnings as availability-affecting, and the batch candidate filter then hard-skipped every uncertain candidate during workbook autorun.

2. no calculation blocks
The selected-range normalizer did not recognize some mixed ordinal/text label columns that the scanner already understood. That caused embedded labels to be dropped during normalization, which in turn made preview/run fall back to empty external labels and lose valid proportion/base block assembly.

## What changed
- Warnings remain visible in preview/check diagnostics, but only blocking issues or an uncertain label/data split mark a candidate as uncertain.
- The normalizer now recognizes mixed ordinal/text rating-style label columns using the same shape the scanner already accepts.

## Validation
- npm test
- npm run build
- git diff --check

## Manual smoke
Not run here. Please verify against the real wide workbook:
- workbook Check no longer skips valid wide tables just because they have warnings
- workbook Autorun processes valid wide tables that were previously skipped as candidate uncertain
- mixed numeric/text label tables no longer fall through to no calculation blocks
- warnings still appear in Check/report output

## Constraints
- no statistical formula changes
- no writer/performance/Clear changes
- no banner subgroup rework
