### PR TITLE
Add markers-only result formatting option

### DIFF
--- a/src/core/excel-writer.js
+++ b/src/core/excel-writer.js
@@ -25,6 +25,7 @@ export function writeCellResultsToSelectedRange(
   const shouldCaptureWriterDetails = Boolean(options.captureWriterDetails);
   const writerDetails = shouldCaptureWriterDetails ? createWriterDetails() : null;
   const buildMatricesStartedAt = shouldCaptureWriterDetails ? Date.now() : 0;
+  const shouldApplyVisualFormatting = calculationSettings.resultFormattingLevel !== "markersOnly";
 
   const rowTypeByIndex = buildDetectedRowTypeByIndexMap(detectionResult);
 
@@ -134,14 +135,16 @@ export function writeCellResultsToSelectedRange(
     writerDetails.valuesWriteMs = Date.now() - valuesWriteStartedAt;
   }
 
-  applyGroupedBoldFormatting(selectedRange, boldMask, writerDetails);
-  applyGroupedFillFormatting(
-    selectedRange,
-    fillReasonMask,
-    cellResultMatrix,
-    calculationSettings,
-    writerDetails
-  );
+  if (shouldApplyVisualFormatting) {
+    applyGroupedBoldFormatting(selectedRange, boldMask, writerDetails);
+    applyGroupedFillFormatting(
+      selectedRange,
+      fillReasonMask,
+      cellResultMatrix,
+      calculationSettings,
+      writerDetails
+    );
+  }
 
   return writerDetails;
 }

--- a/src/taskpane/taskpane-settings.js
+++ b/src/taskpane/taskpane-settings.js
@@ -13,6 +13,7 @@ export const SETTINGS_CONTROL_CONFIG = [
   },
 
   { id: "round-cell-values", type: "checked", settingName: "roundCellValues" },
+  { id: "result-formatting-level", type: "value", settingName: "resultFormattingLevel" },
 
   {
     id: "compare-with-previous-column",
@@ -75,6 +76,7 @@ export const DEFAULT_CALCULATION_SETTINGS = {
   oneTailedTest: false,
 
   roundCellValues: false,
+  resultFormattingLevel: "full",
 
   compareWithPreviousColumn: false,
   applyPreviousColumnFill: false,

--- a/src/taskpane/taskpane.html
+++ b/src/taskpane/taskpane.html
@@ -386,6 +386,14 @@
           </div>
 
           <div class="settings-group">
+            <label for="result-formatting-level">Оформление результатов</label>
+            <select id="result-formatting-level">
+              <option value="full" selected>Полное оформление</option>
+              <option value="markersOnly">Только маркеры</option>
+            </select>
+          </div>
+
+          <div class="settings-group">
             <h4 data-i18n="settings.fillsGroup">Заливки</h4>
             <label for="significant-fill-color" data-i18n="settings.significantFillColor">Обычная значимость</label>
             <input type="color" id="significant-fill-color" value="#E2F0D9" />

--- a/src/taskpane/taskpane.js
+++ b/src/taskpane/taskpane.js
@@ -4751,6 +4751,7 @@ function readCalculationSettingsFromPanel() {
     oneTailedTest: oneTailedTestCheckbox ? oneTailedTestCheckbox.checked : false,
 
     roundCellValues: getCheckboxValue("round-cell-values"),
+    resultFormattingLevel: getInputValue("result-formatting-level", "full"),
 
     compareWithPreviousColumn: getCheckboxValue("compare-with-previous-column"),
     applyPreviousColumnFill: getCheckboxValue("apply-previous-column-fill"),


### PR DESCRIPTION
Closes #279

## Summary
- Adds `resultFormattingLevel: "full" | "markersOnly"`.
- Defaults to full formatting to preserve current output.
- Adds UI control under the design/settings area.
- In markers-only mode, writer still writes marker text/number formats but skips grouped bold/fill formatting.

## Validation
- npm test passed, 305/305.
- npm run build passed.
- git diff --check passed.

## Manual smoke pending
- Full formatting visually matches current behavior.
- Markers-only preserves data-cell marker letters and banner letters.
- Clear Significance still removes markers and RIT formatting.
- Current-table, sheet, and workbook autorun work in both modes.
- Wide-workbook RIT_PERF comparison: full vs markersOnly.

## Files changed
- `src/taskpane/taskpane.html`
- `src/taskpane/taskpane.js`
- `src/taskpane/taskpane-settings.js`
- `src/core/excel-writer.js`
