### PR TITLE
Apply body bold/fill via RangeAreas batching in full-formatting mode (#286)

### DIFF
--- a/docs/SPIKE_RANGEAREAS_BATCHING.md
+++ b/docs/SPIKE_RANGEAREAS_BATCHING.md
@@ -202,6 +202,33 @@ Expected effect: full-formatting `writeMs` on the wide workbook drops from
 ~200 s to roughly the markers-only baseline (~10–20 s), with no visual
 semantic change.
 
+### Implementation status
+
+Implemented in issue #286. The writer now runtime-gates on
+`Office.context.requirements.isSetSupported("ExcelApi", "1.9")` once per
+write (`resolveFormattingContext` in [excel-writer.js](../src/core/excel-writer.js)),
+and chooses one of two formatting paths per write:
+
+- `formattingPath: "rangeAreas"` — issues
+  `selectedRange.worksheet.getRanges(chunkAddress).format.font.bold = true`
+  per bold chunk and
+  `…getRanges(chunkAddress).format.fill.color = color` per fill chunk,
+  reusing the spike's `packAddressesIntoChunks` (100 areas / 2,000 chars).
+- `formattingPath: "rowRuns"` — the original per-row-run setter path, kept
+  as a fallback for hosts that do not advertise ExcelApi 1.9 or that fail
+  to provide sheet-absolute anchor coords. No host without ExcelApi 1.9
+  was observed in field use, but the fallback is retained so older hosts
+  remain supported.
+
+Visual semantics (which cells become bold, which fill color is applied)
+are unchanged: both paths consume the same `boldRunSpansByRow` and
+color-grouped `fillRunSpansByRow` data produced by the existing mask walk.
+The new fields `formattingPath`, `boldRangeAreasAppliedCommandEstimate`,
+and `fillRangeAreasAppliedCommandEstimate` are added to `writerDetails`
+(and rolled up in workbook/sheet aggregates) so RIT_PERF logs surface
+which branch ran per table and the actual queued-op count for the
+RangeAreas path.
+
 ## Files touched by this spike
 
 - [src/core/excel-writer.js](../src/core/excel-writer.js) — added pure

--- a/src/core/excel-writer.js
+++ b/src/core/excel-writer.js
@@ -136,17 +136,23 @@ export function writeCellResultsToSelectedRange(
   }
 
   if (shouldApplyVisualFormatting) {
-    applyGroupedBoldFormatting(selectedRange, boldMask, writerDetails);
+    const formattingContext = resolveFormattingContext(selectedRange, options);
+
+    applyGroupedBoldFormatting(selectedRange, boldMask, formattingContext, writerDetails);
     applyGroupedFillFormatting(
       selectedRange,
       fillReasonMask,
       cellResultMatrix,
       calculationSettings,
+      formattingContext,
       writerDetails
     );
 
     if (writerDetails) {
-      populateRangeAreasDiagnostics(writerDetails, selectedRange);
+      writerDetails.formattingPath = shouldUseRangeAreasPath(formattingContext)
+        ? "rangeAreas"
+        : "rowRuns";
+      populateRangeAreasDiagnostics(writerDetails, formattingContext);
     }
   }
 
@@ -155,26 +161,25 @@ export function writeCellResultsToSelectedRange(
 
 /**
  * Diagnostics-only: projects how many queued Office.js operations a chunked
- * `worksheet.getRanges(...)` RangeAreas strategy (ExcelApi 1.9) would use for
- * the bold and fill masks the writer just processed. The writer still issues
- * the existing row-run commands; this is captured purely for #284 comparison.
+ * `worksheet.getRanges(...)` RangeAreas strategy (ExcelApi 1.9) uses for the
+ * bold and fill masks the writer just processed. On the RangeAreas path, the
+ * projection matches the actual queued ops. On the row-run fallback path,
+ * the projection still shows what the chunked path would have done for
+ * before/after comparison.
  *
- * Requires `selectedRange.rowIndex` and `selectedRange.columnIndex` to be
- * loaded. If reading them throws (e.g. property-not-loaded), diagnostics are
- * skipped so this remains a zero-risk side observation.
+ * Requires resolved `anchorRowIndex` / `anchorColumnIndex` from the formatting
+ * context. If neither caller-supplied options nor loaded selectedRange
+ * properties provided them, the projection is skipped silently.
  */
-function populateRangeAreasDiagnostics(writerDetails, selectedRange) {
-  let anchorRowIndex;
-  let anchorColumnIndex;
-
-  try {
-    anchorRowIndex = selectedRange.rowIndex;
-    anchorColumnIndex = selectedRange.columnIndex;
-  } catch (_) {
-    return;
-  }
+function populateRangeAreasDiagnostics(writerDetails, formattingContext) {
+  const anchorRowIndex = formattingContext.anchorRowIndex;
+  const anchorColumnIndex = formattingContext.anchorColumnIndex;
 
   if (typeof anchorRowIndex !== "number" || typeof anchorColumnIndex !== "number") {
+    // No anchor available — drop the internal span arrays anyway so the
+    // RIT_PERF log stays compact on wide workbooks.
+    delete writerDetails._boldRunSpansByRow;
+    delete writerDetails._fillRunSpansByRow;
     return;
   }
 
@@ -198,6 +203,85 @@ function populateRangeAreasDiagnostics(writerDetails, selectedRange) {
   // emitted writerDetails to keep the perf log lean.
   delete writerDetails._boldRunSpansByRow;
   delete writerDetails._fillRunSpansByRow;
+}
+
+/**
+ * Resolves the formatting context for a single writer invocation:
+ *   - whether the host advertises ExcelApi 1.9 (`worksheet.getRanges(...)`);
+ *   - the sheet-absolute anchor row/column of the write range.
+ *
+ * Support is evaluated once per write so the gate cost is paid at most one
+ * time across both bold and fill formatting passes.
+ *
+ * Anchor coords are preferred from caller-supplied options
+ * (`anchorRowIndex` / `anchorColumnIndex`) because the autorun path computes
+ * them from the already-loaded source range and never loads them on the write
+ * target proxy. If options are missing, the writer falls back to reading
+ * `selectedRange.rowIndex` / `selectedRange.columnIndex` (loaded by the
+ * manual selected-range path). Either resolves to numeric coords, or both
+ * stay null and the RangeAreas path is disabled for this write.
+ */
+function resolveFormattingContext(selectedRange, options = {}) {
+  let anchorRowIndex = null;
+  let anchorColumnIndex = null;
+
+  if (typeof options.anchorRowIndex === "number" && typeof options.anchorColumnIndex === "number") {
+    anchorRowIndex = options.anchorRowIndex;
+    anchorColumnIndex = options.anchorColumnIndex;
+  } else {
+    try {
+      const candidateRow = selectedRange.rowIndex;
+      const candidateColumn = selectedRange.columnIndex;
+      if (typeof candidateRow === "number" && typeof candidateColumn === "number") {
+        anchorRowIndex = candidateRow;
+        anchorColumnIndex = candidateColumn;
+      }
+    } catch (_) {
+      // PropertyNotLoaded or similar — RangeAreas path is disabled for this
+      // write and the row-run fallback is used.
+    }
+  }
+
+  return {
+    isExcelApi19Supported: isExcelApi19Supported(),
+    anchorRowIndex,
+    anchorColumnIndex,
+  };
+}
+
+/**
+ * Returns true if the host advertises ExcelApi 1.9 (`worksheet.getRanges(...)`
+ * → `RangeAreas`). Safe to call in test environments without an Office global.
+ */
+function isExcelApi19Supported() {
+  try {
+    if (
+      typeof Office === "undefined" ||
+      !Office ||
+      !Office.context ||
+      !Office.context.requirements ||
+      typeof Office.context.requirements.isSetSupported !== "function"
+    ) {
+      return false;
+    }
+    return Boolean(Office.context.requirements.isSetSupported("ExcelApi", "1.9"));
+  } catch (_) {
+    return false;
+  }
+}
+
+/**
+ * Pure branch-selection helper exported for tests. Returns true when the
+ * writer should issue the chunked `worksheet.getRanges(...)` RangeAreas path
+ * and false when it should fall back to the per-row-run path.
+ */
+export function shouldUseRangeAreasPath(formattingContext) {
+  return Boolean(
+    formattingContext &&
+    formattingContext.isExcelApi19Supported &&
+    typeof formattingContext.anchorRowIndex === "number" &&
+    typeof formattingContext.anchorColumnIndex === "number"
+  );
 }
 
 /**
@@ -371,16 +455,44 @@ export function resolveNumericOutput(displayString) {
   return { value: parsed.numericValue, format: `0.${"0".repeat(decimalPlaces)}` };
 }
 
-function applyGroupedBoldFormatting(selectedRange, boldMask, writerDetails = null) {
+function applyGroupedBoldFormatting(selectedRange, boldMask, formattingContext, writerDetails = null) {
   const formatStartedAt = writerDetails ? Date.now() : 0;
-  const boldRunsByRow = writerDetails ? [] : null;
-  const boldRunSpansByRow = writerDetails ? [] : null;
+
+  // Walk the mask once and materialize per-row spans so both the row-run and
+  // RangeAreas writers can consume the same span data without re-walking.
+  const boldRunSpansByRow = collectBoldRunSpansByRow(boldMask);
+  const boldRunsByRow = boldRunSpansByRow.map((rowSpans) => rowSpans.length);
+
+  const useRangeAreas = shouldUseRangeAreasPath(formattingContext);
+  let appliedCommandEstimate = 0;
+
+  if (useRangeAreas) {
+    appliedCommandEstimate = applyBoldSpansViaRangeAreas(
+      selectedRange,
+      boldRunSpansByRow,
+      formattingContext.anchorRowIndex,
+      formattingContext.anchorColumnIndex
+    );
+  } else {
+    applyBoldSpansViaRowRuns(selectedRange, boldRunSpansByRow);
+  }
+
+  if (writerDetails) {
+    writerDetails.boldFormatMs = Date.now() - formatStartedAt;
+    writerDetails.boldRunCountByRow = boldRunsByRow;
+    writerDetails.boldCommandCount = sumCounts(boldRunsByRow);
+    writerDetails.boldRectCommandCountEstimate = estimateRectangleCommandCount(boldRunSpansByRow);
+    writerDetails._boldRunSpansByRow = boldRunSpansByRow;
+    writerDetails.boldRangeAreasAppliedCommandEstimate = appliedCommandEstimate;
+  }
+}
+
+function collectBoldRunSpansByRow(boldMask) {
+  const out = [];
 
   for (let rowIndex = 0; rowIndex < boldMask.length; rowIndex++) {
     const row = boldMask[rowIndex];
-    let rowRunCount = 0;
-    const rowRunSpans = writerDetails ? [] : null;
-
+    const rowSpans = [];
     let runStart = null;
 
     for (let columnIndex = 0; columnIndex <= row.length; columnIndex++) {
@@ -392,35 +504,56 @@ function applyGroupedBoldFormatting(selectedRange, boldMask, writerDetails = nul
       }
 
       if ((!shouldBeBold || columnIndex === row.length) && runStart !== null) {
-        const runEnd = columnIndex - 1;
-        const runWidth = runEnd - runStart + 1;
-        rowRunCount += 1;
-
-        if (rowRunSpans) {
-          rowRunSpans.push({ start: runStart, end: runEnd });
-        }
-
-        selectedRange
-          .getCell(rowIndex, runStart)
-          .getResizedRange(0, runWidth - 1).format.font.bold = true;
-
+        rowSpans.push({ start: runStart, end: columnIndex - 1 });
         runStart = null;
       }
     }
 
-    if (boldRunsByRow) {
-      boldRunsByRow.push(rowRunCount);
-      boldRunSpansByRow.push(rowRunSpans);
+    out.push(rowSpans);
+  }
+
+  return out;
+}
+
+function applyBoldSpansViaRowRuns(selectedRange, boldRunSpansByRow) {
+  for (let rowIndex = 0; rowIndex < boldRunSpansByRow.length; rowIndex++) {
+    const rowSpans = boldRunSpansByRow[rowIndex];
+    for (const runSpan of rowSpans) {
+      const runWidth = runSpan.end - runSpan.start + 1;
+      selectedRange
+        .getCell(rowIndex, runSpan.start)
+        .getResizedRange(0, runWidth - 1).format.font.bold = true;
+    }
+  }
+}
+
+function applyBoldSpansViaRangeAreas(
+  selectedRange,
+  boldRunSpansByRow,
+  anchorRowIndex,
+  anchorColumnIndex
+) {
+  const addresses = [];
+  for (let rowIndex = 0; rowIndex < boldRunSpansByRow.length; rowIndex++) {
+    const rowSpans = boldRunSpansByRow[rowIndex];
+    for (const runSpan of rowSpans) {
+      addresses.push(runSpanToA1Address(runSpan, rowIndex, anchorRowIndex, anchorColumnIndex));
     }
   }
 
-  if (writerDetails) {
-    writerDetails.boldFormatMs = Date.now() - formatStartedAt;
-    writerDetails.boldRunCountByRow = boldRunsByRow;
-    writerDetails.boldCommandCount = sumCounts(boldRunsByRow);
-    writerDetails.boldRectCommandCountEstimate = estimateRectangleCommandCount(boldRunSpansByRow);
-    writerDetails._boldRunSpansByRow = boldRunSpansByRow;
+  if (addresses.length === 0) {
+    return 0;
   }
+
+  const chunks = packAddressesIntoChunks(addresses);
+  const worksheet = selectedRange.worksheet;
+
+  for (const chunk of chunks) {
+    worksheet.getRanges(chunk.address).format.font.bold = true;
+  }
+
+  // Each chunk costs one getRanges + one .format.font.bold setter.
+  return chunks.length * 2;
 }
 
 function applyGroupedFillFormatting(
@@ -428,16 +561,48 @@ function applyGroupedFillFormatting(
   fillReasonMask,
   cellResultMatrix,
   calculationSettings,
+  formattingContext,
   writerDetails = null
 ) {
   const formatStartedAt = writerDetails ? Date.now() : 0;
-  const fillRunsByRow = writerDetails ? [] : null;
-  const fillRunSpansByRow = writerDetails ? [] : null;
+
+  const fillRunSpansByRow = collectFillRunSpansByRow(
+    fillReasonMask,
+    cellResultMatrix,
+    calculationSettings
+  );
+  const fillRunsByRow = fillRunSpansByRow.map((rowSpans) => rowSpans.length);
+
+  const useRangeAreas = shouldUseRangeAreasPath(formattingContext);
+  let appliedCommandEstimate = 0;
+
+  if (useRangeAreas) {
+    appliedCommandEstimate = applyFillSpansViaRangeAreas(
+      selectedRange,
+      fillRunSpansByRow,
+      formattingContext.anchorRowIndex,
+      formattingContext.anchorColumnIndex
+    );
+  } else {
+    applyFillSpansViaRowRuns(selectedRange, fillRunSpansByRow);
+  }
+
+  if (writerDetails) {
+    writerDetails.fillFormatMs = Date.now() - formatStartedAt;
+    writerDetails.fillRunCountByRow = fillRunsByRow;
+    writerDetails.fillCommandCount = sumCounts(fillRunsByRow);
+    writerDetails.fillRectCommandCountEstimate = estimateRectangleCommandCount(fillRunSpansByRow);
+    writerDetails._fillRunSpansByRow = fillRunSpansByRow;
+    writerDetails.fillRangeAreasAppliedCommandEstimate = appliedCommandEstimate;
+  }
+}
+
+function collectFillRunSpansByRow(fillReasonMask, cellResultMatrix, calculationSettings) {
+  const out = [];
 
   for (let rowIndex = 0; rowIndex < fillReasonMask.length; rowIndex++) {
     const row = fillReasonMask[rowIndex];
-    let rowRunCount = 0;
-    const rowRunSpans = writerDetails ? [] : null;
+    const rowSpans = [];
 
     let runStart = null;
     let currentRunColor = "";
@@ -465,21 +630,11 @@ function applyGroupedFillFormatting(
       }
 
       if (runStart !== null) {
-        const runEnd = columnIndex - 1;
-        const runWidth = runEnd - runStart + 1;
-        rowRunCount += 1;
-
-        if (rowRunSpans) {
-          rowRunSpans.push({
-            start: runStart,
-            end: runEnd,
-            color: currentRunColor,
-          });
-        }
-
-        selectedRange
-          .getCell(rowIndex, runStart)
-          .getResizedRange(0, runWidth - 1).format.fill.color = currentRunColor;
+        rowSpans.push({
+          start: runStart,
+          end: columnIndex - 1,
+          color: currentRunColor,
+        });
 
         runStart = null;
         currentRunColor = "";
@@ -491,19 +646,68 @@ function applyGroupedFillFormatting(
       }
     }
 
-    if (fillRunsByRow) {
-      fillRunsByRow.push(rowRunCount);
-      fillRunSpansByRow.push(rowRunSpans);
+    out.push(rowSpans);
+  }
+
+  return out;
+}
+
+function applyFillSpansViaRowRuns(selectedRange, fillRunSpansByRow) {
+  for (let rowIndex = 0; rowIndex < fillRunSpansByRow.length; rowIndex++) {
+    const rowSpans = fillRunSpansByRow[rowIndex];
+    for (const runSpan of rowSpans) {
+      const runWidth = runSpan.end - runSpan.start + 1;
+      selectedRange
+        .getCell(rowIndex, runSpan.start)
+        .getResizedRange(0, runWidth - 1).format.fill.color = runSpan.color;
+    }
+  }
+}
+
+function applyFillSpansViaRangeAreas(
+  selectedRange,
+  fillRunSpansByRow,
+  anchorRowIndex,
+  anchorColumnIndex
+) {
+  // RangeAreas.format.fill.color is a single uniform value per call, so spans
+  // are grouped by color and chunked independently for each color. Different
+  // colors never share a chunk.
+  const addressesByColor = new Map();
+
+  for (let rowIndex = 0; rowIndex < fillRunSpansByRow.length; rowIndex++) {
+    const rowSpans = fillRunSpansByRow[rowIndex];
+    for (const runSpan of rowSpans) {
+      const color = runSpan.color || "";
+      if (!color) continue;
+
+      const address = runSpanToA1Address(runSpan, rowIndex, anchorRowIndex, anchorColumnIndex);
+
+      if (!addressesByColor.has(color)) {
+        addressesByColor.set(color, []);
+      }
+      addressesByColor.get(color).push(address);
     }
   }
 
-  if (writerDetails) {
-    writerDetails.fillFormatMs = Date.now() - formatStartedAt;
-    writerDetails.fillRunCountByRow = fillRunsByRow;
-    writerDetails.fillCommandCount = sumCounts(fillRunsByRow);
-    writerDetails.fillRectCommandCountEstimate = estimateRectangleCommandCount(fillRunSpansByRow);
-    writerDetails._fillRunSpansByRow = fillRunSpansByRow;
+  if (addressesByColor.size === 0) {
+    return 0;
   }
+
+  let totalChunkCount = 0;
+  const worksheet = selectedRange.worksheet;
+
+  for (const [color, addresses] of addressesByColor) {
+    const chunks = packAddressesIntoChunks(addresses);
+    totalChunkCount += chunks.length;
+
+    for (const chunk of chunks) {
+      worksheet.getRanges(chunk.address).format.fill.color = color;
+    }
+  }
+
+  // Each chunk costs one getRanges + one .format.fill.color setter.
+  return totalChunkCount * 2;
 }
 
 function createWriterDetails() {
@@ -521,6 +725,17 @@ function createWriterDetails() {
     fillRectCommandCountEstimate: 0,
     boldRangeAreas: null,
     fillRangeAreas: null,
+    // formattingPath records which branch of applyGrouped*Formatting actually
+    // ran for this write. "rangeAreas" → chunked `worksheet.getRanges(...)`
+    // path (ExcelApi 1.9). "rowRuns" → per-row-run fallback. null when visual
+    // formatting was skipped (markers-only mode).
+    formattingPath: null,
+    // Actual queued-op estimates for the path the writer took:
+    //   rangeAreas path → chunks * 2 (one getRanges + one setter per chunk).
+    //   rowRuns path    → 0 (the projection in boldRangeAreas/fillRangeAreas
+    //                       still shows the chunked path's count for comparison).
+    boldRangeAreasAppliedCommandEstimate: 0,
+    fillRangeAreasAppliedCommandEstimate: 0,
   };
 }
 
@@ -559,18 +774,19 @@ function buildRunSpanSignature(runSpan) {
 }
 
 /**
- * Spike helpers for issue #284.
+ * Helpers for the chunked RangeAreas formatting path (issues #284 / #286).
  *
- * Diagnostics-only. These helpers convert the row-run mask data the writer
- * already produces into the A1 address strings a chunked
- * `worksheet.getRanges(...)` (RangeAreas, ExcelApi 1.9) call would consume,
- * and estimate how many queued Office.js operations such a strategy would use.
- *
- * The writer itself still issues the original row-run formatting commands.
- * These helpers exist only to populate `writerDetails.boldRangeAreas` and
- * `writerDetails.fillRangeAreas` when RIT_PERF is enabled, so we can compare
- * the projected RangeAreas command count against the live row-run count on
- * real workbooks before committing to a wider writer change.
+ * These helpers convert the row-run mask data the writer produces into the
+ * A1 address strings a `worksheet.getRanges(...)` (RangeAreas, ExcelApi 1.9)
+ * call consumes. They are used both:
+ *   - by the writer's RangeAreas path (`applyBoldSpansViaRangeAreas` /
+ *     `applyFillSpansViaRangeAreas`) when the host advertises ExcelApi 1.9, to
+ *     produce the chunk addresses passed to `worksheet.getRanges(...)`;
+ *   - by `populateRangeAreasDiagnostics` to record the projection in
+ *     `writerDetails.boldRangeAreas` / `writerDetails.fillRangeAreas` for
+ *     RIT_PERF logging. On the RangeAreas path the projection matches the
+ *     actual queued ops; on the row-run fallback it still shows what the
+ *     chunked path would have done for before/after comparison.
  *
  * Pure: no Office.js calls. Anchor coords are passed in as numbers.
  */

--- a/src/taskpane/taskpane.js
+++ b/src/taskpane/taskpane.js
@@ -350,14 +350,22 @@ function createAggregatedWriterPerfDetails() {
     fillRectCommandCountEstimate: 0,
     maxBoldCommandCount: 0,
     maxFillCommandCount: 0,
-    // Spike #284 — diagnostic-only RangeAreas projection rolled up across tables.
+    // #286 — actual formatting path taken by writer per table. null until the
+    // first table sets it. Stays as a single path label when every table used
+    // the same branch; becomes "mixed" if both branches appeared.
+    formattingPath: null,
+    boldRangeAreasAppliedCommandEstimate: 0,
+    fillRangeAreasAppliedCommandEstimate: 0,
+    // Spike #284 — diagnostic RangeAreas projection rolled up across tables.
     // chunkCount / commandCountEstimate / areaCountTotal sum across tables so
     // the workbook log shows projected total queued ops for a chunked
     // `worksheet.getRanges(...)` writer. maxAddressLength is the per-table max
     // so a single oversized chunk is still visible. fillRangeAreas.colorCountMax
     // is the max number of distinct fill colors observed on any one table —
     // summing colors across tables has no meaningful interpretation because
-    // different tables typically share the same 1–2 colors.
+    // different tables typically share the same 1–2 colors. When #286's
+    // RangeAreas writer path is active, these projections match the actual
+    // queued ops the writer issued.
     boldRangeAreas: {
       areaCountTotal: 0,
       chunkCount: 0,
@@ -397,6 +405,21 @@ function mergeWriterPerfDetails(aggregate, writerDetails) {
     aggregate.maxFillCommandCount,
     writerDetails.fillCommandCount || 0
   );
+
+  // #286 — fold formattingPath across tables. Skip when null (markers-only
+  // mode never set a path).
+  if (writerDetails.formattingPath) {
+    if (aggregate.formattingPath === null) {
+      aggregate.formattingPath = writerDetails.formattingPath;
+    } else if (aggregate.formattingPath !== writerDetails.formattingPath) {
+      aggregate.formattingPath = "mixed";
+    }
+  }
+
+  aggregate.boldRangeAreasAppliedCommandEstimate +=
+    writerDetails.boldRangeAreasAppliedCommandEstimate || 0;
+  aggregate.fillRangeAreasAppliedCommandEstimate +=
+    writerDetails.fillRangeAreasAppliedCommandEstimate || 0;
 
   mergeRangeAreasProjection(aggregate.boldRangeAreas, writerDetails.boldRangeAreas);
   mergeFillRangeAreasProjection(aggregate.fillRangeAreas, writerDetails.fillRangeAreas);
@@ -780,13 +803,21 @@ async function runSignificanceFromSelection() {
     keepMarkersOnlyInAllowedRows(fullCellResultMatrix, allowedMarkerRows);
 
     const _tWrite = perfNow();
+    // Pass the sheet-absolute anchor of the write target so the writer can
+    // build A1 addresses for the chunked RangeAreas formatting path
+    // (ExcelApi 1.9). writeTargetRange.rowIndex / .columnIndex were loaded
+    // and synced above.
     const writerDetails = writeCellResultsToSelectedRange(
       writeTargetRange,
       textForCalculation,
       fullCellResultMatrix,
       detectionResult,
       calculationSettings,
-      { captureWriterDetails: perfEnabled() }
+      {
+        captureWriterDetails: perfEnabled(),
+        anchorRowIndex: writeTargetRange.rowIndex,
+        anchorColumnIndex: writeTargetRange.columnIndex,
+      }
     );
 
     const _knownDims = {
@@ -1023,13 +1054,21 @@ async function runSignificanceForRangeInContext(context, sheetName, rangeAddress
 
   const _pCalc = perfNow();
 
+  // Autorun never loads writeTargetRange.rowIndex / .columnIndex on the proxy
+  // (they're computed from the already-loaded sourceRange + offsets to save a
+  // round-trip). Pass them explicitly so the writer can use the chunked
+  // RangeAreas formatting path (ExcelApi 1.9).
   const writerDetails = writeCellResultsToSelectedRange(
     writeTargetRange,
     textForCalculation,
     fullCellResultMatrix,
     detectionResult,
     calculationSettings,
-    { captureWriterDetails: perfEnabled() }
+    {
+      captureWriterDetails: perfEnabled(),
+      anchorRowIndex: targetStartRowIndex,
+      anchorColumnIndex: targetStartColIndex,
+    }
   );
 
   const _knownDims = {

--- a/tests/core/excel-writer-rangeareas.test.mjs
+++ b/tests/core/excel-writer-rangeareas.test.mjs
@@ -7,6 +7,7 @@ import {
   packAddressesIntoChunks,
   buildBoldRangeAreasDiagnostics,
   buildFillRangeAreasDiagnosticsByColor,
+  shouldUseRangeAreasPath,
 } from "../../src/core/excel-writer.js";
 
 describe("columnIndexToA1", () => {
@@ -187,5 +188,81 @@ describe("buildFillRangeAreasDiagnosticsByColor", () => {
     const summary = buildFillRangeAreasDiagnosticsByColor(spansByRow, 0, 0);
     assert.strictEqual(summary.areaCountTotal, 1);
     assert.strictEqual(summary.colorCount, 1);
+  });
+});
+
+describe("shouldUseRangeAreasPath", () => {
+  it("returns true when ExcelApi 1.9 is supported and anchors are numeric", () => {
+    assert.strictEqual(
+      shouldUseRangeAreasPath({
+        isExcelApi19Supported: true,
+        anchorRowIndex: 0,
+        anchorColumnIndex: 0,
+      }),
+      true
+    );
+    assert.strictEqual(
+      shouldUseRangeAreasPath({
+        isExcelApi19Supported: true,
+        anchorRowIndex: 12,
+        anchorColumnIndex: 7,
+      }),
+      true
+    );
+  });
+
+  it("returns false when ExcelApi 1.9 is not supported", () => {
+    assert.strictEqual(
+      shouldUseRangeAreasPath({
+        isExcelApi19Supported: false,
+        anchorRowIndex: 0,
+        anchorColumnIndex: 0,
+      }),
+      false
+    );
+  });
+
+  it("returns false when either anchor coord is missing", () => {
+    assert.strictEqual(
+      shouldUseRangeAreasPath({
+        isExcelApi19Supported: true,
+        anchorRowIndex: null,
+        anchorColumnIndex: 0,
+      }),
+      false
+    );
+    assert.strictEqual(
+      shouldUseRangeAreasPath({
+        isExcelApi19Supported: true,
+        anchorRowIndex: 0,
+        anchorColumnIndex: null,
+      }),
+      false
+    );
+    assert.strictEqual(
+      shouldUseRangeAreasPath({
+        isExcelApi19Supported: true,
+        anchorRowIndex: undefined,
+        anchorColumnIndex: undefined,
+      }),
+      false
+    );
+  });
+
+  it("returns false for a missing or empty formattingContext", () => {
+    assert.strictEqual(shouldUseRangeAreasPath(null), false);
+    assert.strictEqual(shouldUseRangeAreasPath(undefined), false);
+    assert.strictEqual(shouldUseRangeAreasPath({}), false);
+  });
+
+  it("treats non-number anchors as missing", () => {
+    assert.strictEqual(
+      shouldUseRangeAreasPath({
+        isExcelApi19Supported: true,
+        anchorRowIndex: "0",
+        anchorColumnIndex: "0",
+      }),
+      false
+    );
   });
 });


### PR DESCRIPTION
## Summary

Implements the main performance work for issue #286, following the #284 / PR #285 spike.

On hosts that advertise ExcelApi 1.9, the writer now applies body bold and fill via chunked `worksheet.getRanges(...)` calls (RangeAreas) instead of per-row-run `getCell(...).getResizedRange(...)` setters. The row-run path is retained as the fallback branch for hosts without ExcelApi 1.9.

Visual semantics are preserved: both paths consume the same span data produced by unchanged mask walks, so the same cells become bold and receive the same fill colors. Markers-only mode (#282) continues to skip visual formatting entirely.

## Files changed

- `src/core/excel-writer.js` — split each apply function into mask-walk → path-selection → apply; add `resolveFormattingContext` (once-per-write gate + anchor resolution), `isExcelApi19Supported`, and the exported `shouldUseRangeAreasPath` branch helper; add `applyBoldSpansViaRangeAreas` and `applyFillSpansViaRangeAreas` that issue chunked `worksheet.getRanges(...).format.font.bold` / `.format.fill.color`; surface `formattingPath`, `boldRangeAreasAppliedCommandEstimate`, `fillRangeAreasAppliedCommandEstimate` in `writerDetails`.
- `src/taskpane/taskpane.js` — pass `anchorRowIndex` / `anchorColumnIndex` to the writer from both the manual selected-range path (`writeTargetRange.rowIndex` / `.columnIndex`, already loaded) and the autorun path (`targetStartRowIndex` / `targetStartColIndex`, computed from `sourceRange` offsets); aggregate the new path/estimate fields into the workbook/sheet writer-perf rollup.
- `tests/core/excel-writer-rangeareas.test.mjs` — add `shouldUseRangeAreasPath` branch-selection coverage (support flag, anchor coords, null/empty context, non-number coords).
- `docs/SPIKE_RANGEAREAS_BATCHING.md` — record implementation status section pointing back to #286.

## Implementation path

- `resolveFormattingContext(selectedRange, options)` is called once per write inside `writeCellResultsToSelectedRange` and produces `{ isExcelApi19Supported, anchorRowIndex, anchorColumnIndex }`.
- `shouldUseRangeAreasPath(formattingContext)` decides the branch for both bold and fill in the same write.
- RangeAreas path: build A1 addresses from row-run spans via `runSpanToA1Address`, chunk via `packAddressesIntoChunks` (100 areas / 2000 chars caps from PR #285, unchanged), then `selectedRange.worksheet.getRanges(chunk.address).format.font.bold = true` per bold chunk and `…getRanges(chunk.address).format.fill.color = color` per fill chunk (fills grouped by color first so each chunk carries a single uniform color).
- Row-run fallback path: same per-row-run `selectedRange.getCell(...).getResizedRange(...).format.*` setter chain that shipped before this change, fed from the same `boldRunSpansByRow` / `fillRunSpansByRow` data.

## Runtime gate

`Office.context.requirements.isSetSupported("ExcelApi", "1.9")` evaluated once per writer call via `isExcelApi19Supported()` (guarded against missing `Office`/`context`/`requirements` so the writer stays import-safe in tests). The result is folded into `formattingContext` and reused by both bold and fill, so the gate cost is paid at most once per write.

## Fallback behavior

`shouldUseRangeAreasPath` returns false (→ row-run path) when:
- the host does not advertise ExcelApi 1.9 (e.g. Excel 2016 perpetual at sub-1.9 channels);
- `Office.context.requirements.isSetSupported` is missing / throws;
- caller did not supply numeric `anchorRowIndex` / `anchorColumnIndex` and `selectedRange.rowIndex` / `.columnIndex` are not loaded (`PropertyNotLoaded` is caught silently).

In all three cases the writer issues exactly the per-row-run setter chain that shipped before this change. The fallback path is verified by unit tests (`shouldUseRangeAreasPath` returns false for each failure mode) and by the import-safety of `isExcelApi19Supported` (no Office global → returns false → row-run path).

## Validation

- `npm test` → 328 / 328 pass (5 new `shouldUseRangeAreasPath` cases).
- `npm run build` → webpack production build succeeds (3 webpack asset-size warnings, pre-existing).
- `git diff --check` → clean.

## Manual smoke checklist

The human owner needs to perform the smoke pass — none of the items below have been executed in this PR because Excel host runs are not available to this agent:

1. Manual selected-range Run in full formatting on a representative workbook.
2. Current-table autorun in full formatting.
3. Current-sheet / current-workbook autorun in full formatting.
4. Visual diff of full-formatting output vs prior build:
   - same marker letters;
   - same bold cells;
   - same fill colors.
5. Markers-only output unchanged (no bold / no fill written).
6. Repeated full-formatting rerun on the same range: no stale or misplaced formatting.
7. Clear Significance still removes markers and RIT formatting.
8. Wide-workbook RIT_PERF before/after capture (full formatting): `totalMs`, `writeMs`, `boldCommandCount`, `fillCommandCount`, `boldRectCommandCountEstimate`, `fillRectCommandCountEstimate`, `formattingPath`, `boldRangeAreasAppliedCommandEstimate`, `fillRangeAreasAppliedCommandEstimate`, `boldRangeAreas.chunkCount`, `fillRangeAreas.chunkCount`.
9. Fallback path — `Office.context.requirements.isSetSupported("ExcelApi", "1.9")` returning false routes through the row-run setter (covered by `shouldUseRangeAreasPath` unit tests, since no ExcelApi-1.9-unsupported host is currently available for manual capture).

## Wide-workbook RIT_PERF before/after

Pre-implementation baseline from the task brief (issue #286):

| field | value |
|---|---|
| `totalMs` | ~212.3 s |
| `writeMs` | ~200.2 s |
| `boldCommandCount` | 20,056 |
| `fillCommandCount` | 20,056 |
| `boldRectCommandCountEstimate` | 18,278 |
| `fillRectCommandCountEstimate` | 18,278 |

Post-implementation capture is a manual-smoke item (human owner runs Excel). The PR #285 projection had this workbook at ~808 combined queued bold/fill ops on the RangeAreas path; once captured, `formattingPath` should read `"rangeAreas"`, and `boldRangeAreasAppliedCommandEstimate` + `fillRangeAreasAppliedCommandEstimate` should be in that range, with `writeMs` converging toward the markers-only baseline (~20 s).

## Visual semantics

Unchanged. Both branches build their queue from the same `boldRunSpansByRow` and color-grouped `fillRunSpansByRow` data produced by the unchanged mask walks. The chunk-grouping in `applyFillSpansViaRangeAreas` is by color, so different colors never share a chunk. No cells become bold or change fill that did not already do so under the row-run path.

## Markers-only behavior

Unchanged. `shouldApplyVisualFormatting` (driven by `calculationSettings.resultFormattingLevel !== "markersOnly"`) still gates both bold and fill formatting, and `formattingPath` stays `null` for markers-only writes. No bold or fill setter — row-run or RangeAreas — is invoked when markers-only is active.

## Known limitations

- The implementation issues unqualified A1 addresses on `selectedRange.worksheet.getRanges(...)`. The spike concluded this is supported across the host matrix that ships ExcelApi 1.9, but no field measurement on Excel 2016 perpetual at sub-1.9 channels is included here — those hosts route through the row-run fallback by gate, not by address syntax.
- Chunk caps (100 areas / 2,000 chars) are reused from PR #285 unchanged. Larger caps may be possible on some hosts but were not measured here.
- Real-world `writeMs` reduction is a human-owner smoke item; the PR carries no Excel-host measurement.
- `boldRangeAreas.commandCountEstimate` and `fillRangeAreas.commandCountEstimate` continue to ship even on the row-run fallback path (as "what would the chunked path have used") to keep before/after comparisons interpretable.

## Test plan

- [x] `npm test` passes
- [x] `npm run build` passes
- [x] `git diff --check` clean
- [x] `shouldUseRangeAreasPath` unit tests cover support flag, anchor coords, null/empty context, non-number coords
- [ ] Human owner: manual smoke checklist above
- [ ] Human owner: capture wide-workbook RIT_PERF before/after with `formattingPath` / applied estimates

Closes #286.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
