### PR TITLE
Issue #288: relax inventory scan sheet guard

### DIFF
--- a/src/taskpane/taskpane-inventory-scan.js
+++ b/src/taskpane/taskpane-inventory-scan.js
@@ -1,0 +1,79 @@
+const INVENTORY_SCAN_EMERGENCY_CELL_LIMIT = 5000000;
+
+function inventoryScanErrorMessage(error) {
+  const message = error?.message || error;
+  return String(message || "неизвестная ошибка").replace(/\s+/g, " ").trim();
+}
+
+function formatInventorySheetDimensions(sheet) {
+  if (sheet.rowCount && sheet.columnCount) {
+    return `${sheet.rowCount} строк, ${sheet.columnCount} колонок`;
+  }
+
+  if (sheet.rowCount) {
+    return `${sheet.rowCount} строк`;
+  }
+
+  if (sheet.columnCount) {
+    return `${sheet.columnCount} колонок`;
+  }
+
+  return "";
+}
+
+function formatInventorySkippedSheetLine(sheet) {
+  if (sheet.reason === "empty") {
+    return `${sheet.sheetName}: пустой лист.`;
+  }
+
+  if (sheet.reason === "emergencyLimit") {
+    return `${sheet.sheetName}: аварийно пропущен — UsedRange слишком большой (${sheet.rowCount} стр. × ${sheet.columnCount} кол. = ${sheet.cellCount} ячеек, аварийный лимит: ${INVENTORY_SCAN_EMERGENCY_CELL_LIMIT}).`;
+  }
+
+  if (sheet.reason === "scanError") {
+    return `${sheet.sheetName}: ошибка сканирования — ${sheet.message || "неизвестная ошибка"}.`;
+  }
+
+  return `${sheet.sheetName}: пропущен (${sheet.reason || "неизвестная причина"}).`;
+}
+
+function buildInventoryContentSkippedRow(sheet) {
+  if (sheet.reason === "empty") {
+    return [sheet.sheetName, "Skipped", "Пустой лист", "", ""];
+  }
+
+  if (sheet.reason === "emergencyLimit") {
+    return [
+      sheet.sheetName,
+      "Skipped",
+      "Аварийный стоп сканирования",
+      `${sheet.rowCount} строк, ${sheet.columnCount} колонок`,
+      `${sheet.cellCount} ячеек; аварийный лимит ${INVENTORY_SCAN_EMERGENCY_CELL_LIMIT}`,
+    ];
+  }
+
+  if (sheet.reason === "scanError") {
+    return [
+      sheet.sheetName,
+      "Skipped",
+      "Ошибка сканирования листа",
+      formatInventorySheetDimensions(sheet),
+      sheet.message || "неизвестная ошибка",
+    ];
+  }
+
+  return [
+    sheet.sheetName,
+    "Skipped",
+    "Пропущен",
+    "",
+    sheet.reason || "неизвестная причина",
+  ];
+}
+
+export {
+  INVENTORY_SCAN_EMERGENCY_CELL_LIMIT,
+  inventoryScanErrorMessage,
+  formatInventorySkippedSheetLine,
+  buildInventoryContentSkippedRow,
+};

--- a/src/taskpane/taskpane.js
+++ b/src/taskpane/taskpane.js
@@ -98,9 +98,15 @@ import {
   getContentRowReference,
 } from "./taskpane-inventory-formatters";
 
+import {
+  INVENTORY_SCAN_EMERGENCY_CELL_LIMIT,
+  inventoryScanErrorMessage,
+  formatInventorySkippedSheetLine,
+  buildInventoryContentSkippedRow,
+} from "./taskpane-inventory-scan";
+
 import { perfNow, perfElapsed, perfLog, perfEnabled } from "./taskpane-performance";
 
-const SCAN_CELL_LIMIT = 250000;
 const INVENTORY_CONTENT_SHEET_NAME = "Content";
 const RUN_REPORT_SHEET_NAME = "Run report";
 const GENERATED_SHEET_NAMES = new Set([INVENTORY_CONTENT_SHEET_NAME, RUN_REPORT_SHEET_NAME]);
@@ -1456,11 +1462,9 @@ async function runAutoSignificance() {
   const _tScan = perfNow();
   let inventoryResults;
   try {
-    await Excel.run(async (context) => {
-      inventoryResults = await collectWorkbookInventoryResults(context, calculationSettings);
-      // Normalize without inserting backlinks — only needed for resolvedRangeAddress.
-      normalizeBacklinkItems(inventoryResults.sheetResults, false);
-    });
+    inventoryResults = await collectWorkbookInventoryResults(calculationSettings);
+    // Normalize without inserting backlinks — only needed for resolvedRangeAddress.
+    normalizeBacklinkItems(inventoryResults.sheetResults, false);
   } catch (err) {
     setStatusMessage(`Автозапуск: ошибка при сканировании книги — ${err.message || err}`);
     return;
@@ -2139,10 +2143,8 @@ async function clearAutoSignificance() {
   setStatusMessage(runningStatusMessage("clear", "workbook"));
   let inventoryResults;
   try {
-    await Excel.run(async (context) => {
-      inventoryResults = await collectWorkbookInventoryResults(context, readCalculationSettingsFromPanel());
-      normalizeBacklinkItems(inventoryResults.sheetResults, false);
-    });
+    inventoryResults = await collectWorkbookInventoryResults(readCalculationSettingsFromPanel());
+    normalizeBacklinkItems(inventoryResults.sheetResults, false);
   } catch (err) {
     setStatusMessage(`Автоочистка: ошибка при сканировании книги — ${err.message || err}`);
     return;
@@ -2265,10 +2267,8 @@ async function runCurrentSheetSignificance() {
   const _tScan = perfNow();
   let inventoryResults;
   try {
-    await Excel.run(async (context) => {
-      inventoryResults = await collectActiveSheetInventoryResults(context, calculationSettings);
-      normalizeBacklinkItems(inventoryResults.sheetResults, false);
-    });
+    inventoryResults = await collectActiveSheetInventoryResults(calculationSettings);
+    normalizeBacklinkItems(inventoryResults.sheetResults, false);
   } catch (err) {
     setStatusMessage(`Лист — запуск: ошибка при сканировании листа — ${err.message || err}`);
     return;
@@ -2539,10 +2539,8 @@ async function clearCurrentSheetSignificance() {
   setStatusMessage(runningStatusMessage("clear", "sheet"));
   let inventoryResults;
   try {
-    await Excel.run(async (context) => {
-      inventoryResults = await collectActiveSheetInventoryResults(context, readCalculationSettingsFromPanel());
-      normalizeBacklinkItems(inventoryResults.sheetResults, false);
-    });
+    inventoryResults = await collectActiveSheetInventoryResults(readCalculationSettingsFromPanel());
+    normalizeBacklinkItems(inventoryResults.sheetResults, false);
   } catch (err) {
     setStatusMessage(`Лист — очистка: ошибка при сканировании листа — ${err.message || err}`);
     return;
@@ -2694,10 +2692,8 @@ async function runCurrentSheetCheck() {
   let activeSheetName = "";
 
   try {
-    await Excel.run(async (context) => {
-      inventoryResults = await collectActiveSheetInventoryResults(context, calculationSettings);
-      normalizeBacklinkItems(inventoryResults.sheetResults, false);
-    });
+    inventoryResults = await collectActiveSheetInventoryResults(calculationSettings);
+    normalizeBacklinkItems(inventoryResults.sheetResults, false);
   } catch (err) {
     setCheckMessage(
       `Лист — проверка: ошибка при сканировании листа — ${err.message || err}`
@@ -2712,16 +2708,16 @@ async function runCurrentSheetCheck() {
     activeSheetName = inventoryResults.skippedSheets[0].sheetName;
   }
 
-  // Handle empty / too-large active sheet (no candidates found).
+  // Handle empty / skipped active sheet (no candidates found).
   if (inventoryResults.sheetResults.length === 0) {
     const skipped = inventoryResults.skippedSheets || [];
     if (skipped.length > 0 && skipped[0].reason === "empty") {
       setCheckMessage(
         `Лист — проверка (только активный лист): лист «${activeSheetName || "?"}» пустой.`
       );
-    } else if (skipped.length > 0 && skipped[0].reason === "tooLarge") {
+    } else if (skipped.length > 0) {
       setCheckMessage(
-        `Лист — проверка (только активный лист): лист «${activeSheetName || "?"}» слишком большой для сканирования.`
+        `Лист — проверка (только активный лист): ${formatInventorySkippedSheetLine(skipped[0])}`
       );
     } else if (inventoryResults.scannedSheets === 0 && activeSheetName === "") {
       // Active sheet is the Content sheet — silently ignored.
@@ -2878,10 +2874,8 @@ async function runWorkbookCheck() {
 
   let inventoryResults;
   try {
-    await Excel.run(async (context) => {
-      inventoryResults = await collectWorkbookInventoryResults(context, calculationSettings);
-      normalizeBacklinkItems(inventoryResults.sheetResults, false);
-    });
+    inventoryResults = await collectWorkbookInventoryResults(calculationSettings);
+    normalizeBacklinkItems(inventoryResults.sheetResults, false);
   } catch (err) {
     setCheckMessage(`Книга — проверка: ошибка при сканировании — ${err.message || err}`);
     return;
@@ -2939,13 +2933,7 @@ async function runWorkbookCheck() {
     summaryLines.push("");
     summaryLines.push("Пропущенные листы:");
     for (const sheet of skippedSheets) {
-      if (sheet.reason === "empty") {
-        summaryLines.push(`- ${sheet.sheetName}: пустой лист.`);
-      } else {
-        summaryLines.push(
-          `- ${sheet.sheetName}: слишком большой для сканирования (${sheet.rowCount} стр. × ${sheet.columnCount} кол.).`
-        );
-      }
+      summaryLines.push(`- ${formatInventorySkippedSheetLine(sheet)}`);
     }
   }
 
@@ -3769,14 +3757,7 @@ function formatWorkbookInventoryMessage({ scannedSheets, sheetResults, skippedSh
     lines.push("Пропущенные листы:");
 
     skippedSheets.forEach((sheet) => {
-      if (sheet.reason === "empty") {
-        lines.push(`- ${sheet.sheetName}: пустой лист.`);
-        return;
-      }
-
-      lines.push(
-        `- ${sheet.sheetName}: слишком большой для сканирования (${sheet.rowCount} стр. × ${sheet.columnCount} кол. = ${sheet.cellCount} ячеек, лимит: ${SCAN_CELL_LIMIT}).`
-      );
+      lines.push(`- ${formatInventorySkippedSheetLine(sheet)}`);
     });
   }
 
@@ -3786,70 +3767,127 @@ function formatWorkbookInventoryMessage({ scannedSheets, sheetResults, skippedSh
   return lines.join("\n").trimEnd();
 }
 
-async function collectWorkbookInventoryResults(context, settings) {
-  const worksheets = context.workbook.worksheets;
-  worksheets.load("items/name");
+async function listWorkbookInventoryWorksheetNames() {
+  return Excel.run(async (context) => {
+    const worksheets = context.workbook.worksheets;
+    worksheets.load("items/name");
+
+    await context.sync();
+
+    return worksheets.items
+      .map((worksheet) => worksheet.name)
+      .filter((sheetName) => !GENERATED_SHEET_NAMES.has(sheetName));
+  });
+}
+
+async function collectWorksheetInventoryResultWithContext(context, worksheet, sheetName, settings) {
+  const usedRange = worksheet.getUsedRangeOrNullObject();
+  usedRange.load(["isNullObject", "rowIndex", "columnIndex", "rowCount", "columnCount"]);
 
   await context.sync();
 
-  const worksheetEntries = worksheets.items
-    .filter((worksheet) => !GENERATED_SHEET_NAMES.has(worksheet.name))
-    .map((worksheet) => {
-      const usedRange = worksheet.getUsedRangeOrNullObject();
-      usedRange.load(["isNullObject", "rowIndex", "columnIndex", "rowCount", "columnCount"]);
+  if (usedRange.isNullObject) {
+    return {
+      scanned: false,
+      skippedSheet: { sheetName, reason: "empty" },
+    };
+  }
 
-      return { worksheet, usedRange };
-    });
-
-  await context.sync();
-
-  const scannedEntries = [];
-  const skippedSheets = [];
-
-  for (const entry of worksheetEntries) {
-    const { worksheet, usedRange } = entry;
-
-    if (usedRange.isNullObject) {
-      skippedSheets.push({ sheetName: worksheet.name, reason: "empty" });
-      continue;
-    }
-
-    const cellCount = usedRange.rowCount * usedRange.columnCount;
-    if (cellCount > SCAN_CELL_LIMIT) {
-      skippedSheets.push({
-        sheetName: worksheet.name,
-        reason: "tooLarge",
+  const cellCount = usedRange.rowCount * usedRange.columnCount;
+  if (cellCount > INVENTORY_SCAN_EMERGENCY_CELL_LIMIT) {
+    return {
+      scanned: false,
+      skippedSheet: {
+        sheetName,
+        reason: "emergencyLimit",
         rowCount: usedRange.rowCount,
         columnCount: usedRange.columnCount,
         cellCount,
-      });
-      continue;
-    }
-
-    usedRange.load("values");
-    scannedEntries.push(entry);
+      },
+    };
   }
 
-  await context.sync();
+  usedRange.load("values");
 
-  const sheetResults = scannedEntries
-    .map(({ worksheet, usedRange }) => ({
-      sheetName: worksheet.name,
+  try {
+    await context.sync();
+  } catch (error) {
+    return {
+      scanned: false,
+      skippedSheet: {
+        sheetName,
+        reason: "scanError",
+        rowCount: usedRange.rowCount,
+        columnCount: usedRange.columnCount,
+        cellCount,
+        message: inventoryScanErrorMessage(error),
+      },
+    };
+  }
+
+  try {
+    const items = scanWorksheetForTables({
+      values: usedRange.values,
       usedRangeRowOffset: usedRange.rowIndex,
       usedRangeColOffset: usedRange.columnIndex,
-      usedRangeValues: usedRange.values,
-      items: scanWorksheetForTables({
-        values: usedRange.values,
-        usedRangeRowOffset: usedRange.rowIndex,
-        usedRangeColOffset: usedRange.columnIndex,
-        sheetName: worksheet.name,
-        settings: { ...settings, backlinkMarker: BACKLINK_MARKER },
-      }),
-    }))
-    .filter((sheetResult) => sheetResult.items.length > 0);
+      sheetName,
+      settings: { ...settings, backlinkMarker: BACKLINK_MARKER },
+    });
+
+    return {
+      scanned: true,
+      sheetResult: items.length > 0
+        ? {
+            sheetName,
+            usedRangeRowOffset: usedRange.rowIndex,
+            usedRangeColOffset: usedRange.columnIndex,
+            usedRangeValues: usedRange.values,
+            items,
+          }
+        : null,
+    };
+  } catch (error) {
+    return {
+      scanned: false,
+      skippedSheet: {
+        sheetName,
+        reason: "scanError",
+        rowCount: usedRange.rowCount,
+        columnCount: usedRange.columnCount,
+        cellCount,
+        message: inventoryScanErrorMessage(error),
+      },
+    };
+  }
+}
+
+async function collectWorksheetInventoryResultByName(sheetName, settings) {
+  return Excel.run(async (context) => {
+    const worksheet = context.workbook.worksheets.getItem(sheetName);
+    return collectWorksheetInventoryResultWithContext(context, worksheet, sheetName, settings);
+  });
+}
+
+async function collectWorkbookInventoryResults(settings) {
+  const worksheetNames = await listWorkbookInventoryWorksheetNames();
+  const sheetResults = [];
+  const skippedSheets = [];
+  let scannedSheets = 0;
+
+  for (const sheetName of worksheetNames) {
+    const result = await collectWorksheetInventoryResultByName(sheetName, settings);
+    if (result.scanned) {
+      scannedSheets += 1;
+      if (result.sheetResult) {
+        sheetResults.push(result.sheetResult);
+      }
+    } else if (result.skippedSheet) {
+      skippedSheets.push(result.skippedSheet);
+    }
+  }
 
   return {
-    scannedSheets: scannedEntries.length,
+    scannedSheets,
     sheetResults,
     skippedSheets,
   };
@@ -3862,71 +3900,32 @@ async function collectWorkbookInventoryResults(context, settings) {
  * returning the same { scannedSheets, sheetResults, skippedSheets } shape so
  * that filterWorkbookCandidates() and normalizeBacklinkItems() work unchanged.
  */
-async function collectActiveSheetInventoryResults(context, settings) {
-  const worksheet = context.workbook.worksheets.getActiveWorksheet();
-  worksheet.load("name");
+async function collectActiveSheetInventoryResults(settings) {
+  return Excel.run(async (context) => {
+    const worksheet = context.workbook.worksheets.getActiveWorksheet();
+    worksheet.load("name");
 
-  await context.sync();
+    await context.sync();
 
-  if (GENERATED_SHEET_NAMES.has(worksheet.name)) {
-    return { scannedSheets: 0, sheetResults: [], skippedSheets: [] };
-  }
+    if (GENERATED_SHEET_NAMES.has(worksheet.name)) {
+      return { scannedSheets: 0, sheetResults: [], skippedSheets: [] };
+    }
 
-  const usedRange = worksheet.getUsedRangeOrNullObject();
-  usedRange.load(["isNullObject", "rowIndex", "columnIndex", "rowCount", "columnCount"]);
+    const result = await collectWorksheetInventoryResultWithContext(context, worksheet, worksheet.name, settings);
+    if (!result.scanned) {
+      return {
+        scannedSheets: 0,
+        sheetResults: [],
+        skippedSheets: result.skippedSheet ? [result.skippedSheet] : [],
+      };
+    }
 
-  await context.sync();
-
-  if (usedRange.isNullObject) {
     return {
-      scannedSheets: 0,
-      sheetResults: [],
-      skippedSheets: [{ sheetName: worksheet.name, reason: "empty" }],
+      scannedSheets: 1,
+      sheetResults: result.sheetResult ? [result.sheetResult] : [],
+      skippedSheets: [],
     };
-  }
-
-  const cellCount = usedRange.rowCount * usedRange.columnCount;
-  if (cellCount > SCAN_CELL_LIMIT) {
-    return {
-      scannedSheets: 0,
-      sheetResults: [],
-      skippedSheets: [
-        {
-          sheetName: worksheet.name,
-          reason: "tooLarge",
-          rowCount: usedRange.rowCount,
-          columnCount: usedRange.columnCount,
-          cellCount,
-        },
-      ],
-    };
-  }
-
-  usedRange.load("values");
-
-  await context.sync();
-
-  const items = scanWorksheetForTables({
-    values: usedRange.values,
-    usedRangeRowOffset: usedRange.rowIndex,
-    usedRangeColOffset: usedRange.columnIndex,
-    sheetName: worksheet.name,
-    settings: { ...settings, backlinkMarker: BACKLINK_MARKER },
   });
-
-  const sheetResults = items.length > 0
-    ? [
-        {
-          sheetName: worksheet.name,
-          usedRangeRowOffset: usedRange.rowIndex,
-          usedRangeColOffset: usedRange.columnIndex,
-          usedRangeValues: usedRange.values,
-          items,
-        },
-      ]
-    : [];
-
-  return { scannedSheets: 1, sheetResults, skippedSheets: [] };
 }
 
 function buildInventoryContentCandidateRows(sheetResults) {
@@ -4021,19 +4020,7 @@ function buildInventoryContentSkippedRows(skippedSheets) {
     return [];
   }
 
-  return skippedSheets.map((sheet) => {
-    if (sheet.reason === "empty") {
-      return [sheet.sheetName, "Skipped", "Пустой лист", "", ""];
-    }
-
-    return [
-      sheet.sheetName,
-      "Skipped",
-      "Слишком большой для сканирования",
-      `${sheet.rowCount} строк, ${sheet.columnCount} колонок`,
-      `${sheet.cellCount} ячеек; лимит ${SCAN_CELL_LIMIT}`,
-    ];
-  });
+  return skippedSheets.map((sheet) => buildInventoryContentSkippedRow(sheet));
 }
 
 function readContentOutputModeFromPanel() {
@@ -4777,22 +4764,22 @@ async function writeInventoryContentSheet(context, inventoryResults) {
 
 async function runTableInventory() {
   setInventoryMessage(runningStatusMessage("content"));
+  const _t0 = perfNow();
+  const inventoryResults = await collectWorkbookInventoryResults(readCalculationSettingsFromPanel());
+  const _tScan = perfNow();
+  const addBacklinks = readBacklinkSettingFromPanel();
+  const contentMode = readContentOutputModeFromPanel();
+
+  // Always normalize: fixes resolvedRangeAddress for items whose detected range
+  // starts with a generated backlink row (in-range), even when backlinks are OFF.
+  // When backlinks are ON, also predicts the +1 end-row shift for will-insert.
+  normalizeBacklinkItems(inventoryResults.sheetResults, addBacklinks);
+
+  const contentRowMap = addBacklinks
+    ? buildContentRowMap(inventoryResults.sheetResults, contentMode)
+    : null;
+
   await Excel.run(async (context) => {
-    const _t0 = perfNow();
-    const inventoryResults = await collectWorkbookInventoryResults(context, readCalculationSettingsFromPanel());
-    const _tScan = perfNow();
-    const addBacklinks = readBacklinkSettingFromPanel();
-    const contentMode = readContentOutputModeFromPanel();
-
-    // Always normalize: fixes resolvedRangeAddress for items whose detected range
-    // starts with a generated backlink row (in-range), even when backlinks are OFF.
-    // When backlinks are ON, also predicts the +1 end-row shift for will-insert.
-    normalizeBacklinkItems(inventoryResults.sheetResults, addBacklinks);
-
-    const contentRowMap = addBacklinks
-      ? buildContentRowMap(inventoryResults.sheetResults, contentMode)
-      : null;
-
     // Write Content first (hyperlinks use resolvedRangeAddress when available).
     const contentWorksheet = await writeInventoryContentSheet(context, inventoryResults);
 
@@ -4805,20 +4792,20 @@ async function runTableInventory() {
     // Switch to the Content sheet after all writes are done.
     contentWorksheet.activate();
     await context.sync();
-
-    perfLog("runTableInventory", {
-      scanMs: _tScan - _t0,
-      contentWriteMs: perfElapsed(_tScan),
-      totalMs: perfElapsed(_t0),
-    });
-    setInventoryMessage(
-      formatWorkbookInventoryMessage({
-        scannedSheets: inventoryResults.scannedSheets,
-        sheetResults: inventoryResults.sheetResults,
-        skippedSheets: inventoryResults.skippedSheets,
-      })
-    );
   });
+
+  perfLog("runTableInventory", {
+    scanMs: _tScan - _t0,
+    contentWriteMs: perfElapsed(_tScan),
+    totalMs: perfElapsed(_t0),
+  });
+  setInventoryMessage(
+    formatWorkbookInventoryMessage({
+      scannedSheets: inventoryResults.scannedSheets,
+      sheetResults: inventoryResults.sheetResults,
+      skippedSheets: inventoryResults.skippedSheets,
+    })
+  );
 }
 
 /**

--- a/tests/core/taskpane-inventory-scan.test.mjs
+++ b/tests/core/taskpane-inventory-scan.test.mjs
@@ -1,0 +1,64 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  INVENTORY_SCAN_EMERGENCY_CELL_LIMIT,
+  inventoryScanErrorMessage,
+  formatInventorySkippedSheetLine,
+  buildInventoryContentSkippedRow,
+} from "../../src/taskpane/taskpane-inventory-scan.js";
+
+describe("taskpane-inventory-scan", () => {
+  it("formats the emergency limit workbook message as a circuit breaker", () => {
+    const line = formatInventorySkippedSheetLine({
+      sheetName: "Wide sheet",
+      reason: "emergencyLimit",
+      rowCount: 2000,
+      columnCount: 3000,
+      cellCount: 6000000,
+    });
+
+    assert.match(line, /Wide sheet: аварийно пропущен/);
+    assert.match(line, new RegExp(String(INVENTORY_SCAN_EMERGENCY_CELL_LIMIT)));
+    assert.doesNotMatch(line, /слишком большой для сканирования/);
+  });
+
+  it("formats scan errors without falling back to the old too-large wording", () => {
+    const line = formatInventorySkippedSheetLine({
+      sheetName: "Polluted",
+      reason: "scanError",
+      message: "RequestPayloadSizeLimitExceeded",
+    });
+
+    assert.strictEqual(
+      line,
+      "Polluted: ошибка сканирования — RequestPayloadSizeLimitExceeded."
+    );
+  });
+
+  it("builds content rows for scan errors with dimensions and message", () => {
+    const row = buildInventoryContentSkippedRow({
+      sheetName: "Sheet A",
+      reason: "scanError",
+      rowCount: 120,
+      columnCount: 48,
+      message: "host rejected values load",
+    });
+
+    assert.deepStrictEqual(row, [
+      "Sheet A",
+      "Skipped",
+      "Ошибка сканирования листа",
+      "120 строк, 48 колонок",
+      "host rejected values load",
+    ]);
+  });
+
+  it("normalizes Office errors into single-line messages", () => {
+    const message = inventoryScanErrorMessage({
+      message: "First line\nSecond line",
+    });
+
+    assert.strictEqual(message, "First line Second line");
+  });
+});


### PR DESCRIPTION
## Summary
- remove the old 250000-cell inventory skip from workbook and current-sheet scanning
- scan workbook sheets in isolated Excel.run batches so one Office.js sheet-load failure becomes a per-sheet skipped or error reason instead of aborting the whole inventory pass
- keep only a high emergency UsedRange circuit breaker and centralize skipped-sheet wording for Check and Content output

## Files changed
- src/taskpane/taskpane.js
- src/taskpane/taskpane-inventory-scan.js
- tests/core/taskpane-inventory-scan.test.mjs

## SCAN_CELL_LIMIT
- Replaced, not kept.
- SCAN_CELL_LIMIT = 250000 was removed.
- Added INVENTORY_SCAN_EMERGENCY_CELL_LIMIT = 5000000 as a high emergency circuit breaker for pathological polluted UsedRanges.
- Rationale: it is 20x higher than the old product limit, keeps ordinary wide research sheets scannable, and still avoids attempting usedRange.values on obviously hostile near-full-sheet shapes.

## Before / after behavior
- Before: workbook and current-sheet inventory skipped any non-empty sheet whose rowCount * columnCount exceeded 250000, with a sheet-level too-large reason.
- After: workbook and current-sheet inventory attempt to scan large or wide sheets normally.
- After: a sheet is only skipped early for generated-sheet exclusion, empty UsedRange, or the new 5000000-cell emergency circuit breaker.
- After: if usedRange.values load or scan logic fails for a sheet, the sheet is reported with a per-sheet scanError reason instead of aborting the whole workbook scan.

## Validation
- npm test: pass
- npm run build: pass
- git diff --check: pass

## Manual smoke checklist
- [ ] Run workbook Check on the real wide workbook.
- [ ] Confirm the two formerly skipped sheets are scanned.
- [ ] Run workbook Autorun.
- [ ] Confirm valid tables on those sheets are processed or receive table-level skip reasons, not sheet-level tooLarge skip.
- [ ] Run current-sheet Check on one formerly skipped sheet.
- [ ] Run current-sheet Autorun on one formerly skipped sheet.
- [ ] Capture RIT_PERF scanMs and totalMs before and after.
- [ ] Confirm Content and Run report sheets are still ignored.
- [ ] Confirm empty sheets are still skipped or reported as empty.

## Known limitations
- I could not run the required Excel workbook smoke tests from this environment.
- The emergency guard is still cell-count based, so an unusually large legitimate sheet above 5000000 cells will be circuit-broken instead of scanned.
