### PR TITLE
Add banner marker performance diagnostics

### DIFF
--- a/src/taskpane/taskpane-performance.js
+++ b/src/taskpane/taskpane-performance.js
@@ -1,9 +1,13 @@
 // Development-only performance instrumentation for RIT taskpane flows.
 //
-// Enable from DevTools with either:
+// Enable the main performance log from DevTools with either:
 //   window.__RIT_PERF = true
 //   window.__RIT_PERF = "1"
 //   localStorage.setItem('RIT_PERF', '1')
+//
+// Optional nested probes can use their own runtime/storage flags. For example:
+//   window.__RIT_BANNER_VALUES_READ_PROBE = true
+//   localStorage.setItem('RIT_BANNER_VALUES_READ_PROBE', '1')
 //
 // Disable with either:
 //   window.__RIT_PERF = false
@@ -21,17 +25,17 @@
 // All exported functions are no-ops when disabled, adding zero overhead to
 // production runs.
 
-function _readPerfRuntimeFlag() {
+function _readRuntimeFlag(flagName) {
   try {
     if (typeof globalThis === "undefined") return undefined;
-    return globalThis.__RIT_PERF;
+    return globalThis[flagName];
   } catch (_) {
     return undefined;
   }
 }
 
-function _perfRuntimeFlagEnabled() {
-  const runtimeFlag = _readPerfRuntimeFlag();
+function _runtimeFlagEnabled(flagName) {
+  const runtimeFlag = _readRuntimeFlag(flagName);
 
   if (runtimeFlag === true || runtimeFlag === "1") return true;
   if (runtimeFlag === false || runtimeFlag === "0") return false;
@@ -39,24 +43,32 @@ function _perfRuntimeFlagEnabled() {
   return undefined;
 }
 
-function _perfStorageFlagEnabled() {
+function _storageFlagEnabled(storageKey) {
   try {
-    return typeof localStorage !== "undefined" && localStorage.getItem("RIT_PERF") === "1";
+    return typeof localStorage !== "undefined" && localStorage.getItem(storageKey) === "1";
   } catch (_) {
     return false;
   }
 }
 
 function _perfEnabled() {
-  const runtimeEnabled = _perfRuntimeFlagEnabled();
+  const runtimeEnabled = _runtimeFlagEnabled("__RIT_PERF");
 
   if (runtimeEnabled !== undefined) return runtimeEnabled;
 
-  return _perfStorageFlagEnabled();
+  return _storageFlagEnabled("RIT_PERF");
 }
 
 export function perfEnabled() {
   return _perfEnabled();
+}
+
+export function perfFlagEnabled(runtimeFlagName, storageKey = runtimeFlagName) {
+  const runtimeEnabled = _runtimeFlagEnabled(runtimeFlagName);
+
+  if (runtimeEnabled !== undefined) return runtimeEnabled;
+
+  return _storageFlagEnabled(storageKey);
 }
 
 // Returns Date.now() when enabled, 0 otherwise.

--- a/src/taskpane/taskpane.js
+++ b/src/taskpane/taskpane.js
@@ -105,7 +105,7 @@ import {
   buildInventoryContentSkippedRow,
 } from "./taskpane-inventory-scan";
 
-import { perfNow, perfElapsed, perfLog, perfEnabled } from "./taskpane-performance";
+import { perfNow, perfElapsed, perfLog, perfEnabled, perfFlagEnabled } from "./taskpane-performance";
 
 const INVENTORY_CONTENT_SHEET_NAME = "Content";
 const RUN_REPORT_SHEET_NAME = "Run report";
@@ -474,6 +474,10 @@ function createAggregatedBannerPerfDetails() {
     markeredWriteCommands: 0,
     clearOnlyWriteCommands: 0,
     numberFormatCommands: 0,
+    numberFormatCells: 0,
+    valueWriteCells: 0,
+    markeredValueWriteCells: 0,
+    clearOnlyValueWriteCells: 0,
     changedRows: 0,
     avgChangedCellsPerChangedRow: 0,
     maxChangedCellsInRow: 0,
@@ -481,9 +485,17 @@ function createAggregatedBannerPerfDetails() {
     maxChangedRowsPerTable: 0,
     skippedNoOpWrites: 0,
     readSyncMs: 0,
+    readProperty: "text",
+    valuesReadProbeMs: 0,
+    valuesReadProbeTables: 0,
     planMs: 0,
     queueWriteMs: 0,
     syncCount: 0,
+    scanRowsWithAnyText: 0,
+    lowerRowMarkerPlacements: 0,
+    upperRowMarkerPlacements: 0,
+    fallbackMarkerPlacements: 0,
+    markerRowOffsetsUsed: [],
     maxWriteCommands: 0,
     tablesWithOverlappingBannerAreas: 0,
     perSheetBannerTablesMax: 0,
@@ -493,6 +505,7 @@ function createAggregatedBannerPerfDetails() {
     value: {
       areasBySheet: new Map(),
       overlappingTableIds: new Set(),
+      markerRowOffsetsUsed: new Set(),
       nextTableId: 1,
     },
     enumerable: false,
@@ -563,12 +576,31 @@ function mergeBannerPerfDetails(aggregate, bannerDetails, sheetName) {
   aggregate.markeredWriteCommands += bannerDetails.markeredWriteCommands || 0;
   aggregate.clearOnlyWriteCommands += bannerDetails.clearOnlyWriteCommands || 0;
   aggregate.numberFormatCommands += bannerDetails.numberFormatCommands || 0;
+  aggregate.numberFormatCells += bannerDetails.numberFormatCells || 0;
+  aggregate.valueWriteCells += bannerDetails.valueWriteCells || 0;
+  aggregate.markeredValueWriteCells += bannerDetails.markeredValueWriteCells || 0;
+  aggregate.clearOnlyValueWriteCells += bannerDetails.clearOnlyValueWriteCells || 0;
   aggregate.changedRows += bannerDetails.changedRows || 0;
   aggregate.skippedNoOpWrites += bannerDetails.skippedNoOpWrites || 0;
   aggregate.readSyncMs += bannerDetails.readSyncMs || 0;
+  aggregate.valuesReadProbeMs += bannerDetails.valuesReadProbeMs || 0;
+  if (bannerDetails.valuesReadProbeEnabled) {
+    aggregate.valuesReadProbeTables += 1;
+  }
   aggregate.planMs += bannerDetails.planMs || 0;
   aggregate.queueWriteMs += bannerDetails.queueWriteMs || 0;
   aggregate.syncCount += bannerDetails.syncCount || 0;
+  aggregate.scanRowsWithAnyText += bannerDetails.scanRowsWithAnyText || 0;
+  aggregate.lowerRowMarkerPlacements += bannerDetails.lowerRowMarkerPlacements || 0;
+  aggregate.upperRowMarkerPlacements += bannerDetails.upperRowMarkerPlacements || 0;
+  aggregate.fallbackMarkerPlacements += bannerDetails.fallbackMarkerPlacements || 0;
+  const state = aggregate[BANNER_AGGREGATE_STATE];
+  if (state && Array.isArray(bannerDetails.markerRowOffsetsUsed)) {
+    for (const rowOffset of bannerDetails.markerRowOffsetsUsed) {
+      state.markerRowOffsetsUsed.add(rowOffset);
+    }
+    aggregate.markerRowOffsetsUsed = Array.from(state.markerRowOffsetsUsed).sort((a, b) => a - b);
+  }
   if ((bannerDetails.writeCommands || 0) > aggregate.maxWriteCommands) {
     aggregate.maxWriteCommands = bannerDetails.writeCommands;
   }
@@ -5249,17 +5281,42 @@ async function applyBannerMarkerUpdatesForRange(
   await context.sync();
   const readSyncEndMs = perfNow();
   let syncCount = 1;
+  let valuesReadProbeMs = 0;
+  let valuesReadProbeEnabled = false;
 
   const bannerTexts = bannerScanRange.text;
+  if (perfFlagEnabled("__RIT_BANNER_VALUES_READ_PROBE", "RIT_BANNER_VALUES_READ_PROBE")) {
+    const valuesReadRange = writeTargetRange.worksheet.getRangeByIndexes(
+      targetStartRowIndex - totalScanRowCount,
+      scanStartColIndex,
+      totalScanRowCount,
+      scanColCount
+    );
+    valuesReadProbeEnabled = true;
+    const valuesProbeStartMs = Date.now();
+    valuesReadRange.load("values");
+    await context.sync();
+    valuesReadProbeMs = Date.now() - valuesProbeStartMs;
+    syncCount++;
+  }
+  const planStartMs = perfNow();
 
   // Desired-text matrix.  Initialised from current texts, then mutated in
   // place by step 1 (strip RIT markers) and step 3 (place markers).
   const desiredTexts = new Array(totalScanRowCount);
+  let scanRowsWithAnyText = 0;
   for (let r = 0; r < totalScanRowCount; r++) {
     const row = bannerTexts[r] || [];
     const destRow = new Array(scanColCount);
+    let rowHasText = false;
     for (let c = 0; c < scanColCount; c++) {
       destRow[c] = row[c] || "";
+      if (destRow[c] !== "") {
+        rowHasText = true;
+      }
+    }
+    if (rowHasText) {
+      scanRowsWithAnyText++;
     }
     desiredTexts[r] = destRow;
   }
@@ -5308,6 +5365,10 @@ async function applyBannerMarkerUpdatesForRange(
   const dataColOffsetInScan = targetStartColumnIndex - scanStartColIndex;
   const markedCellKeys = new Set();
   let cellsPlanned = 0;
+  let lowerRowMarkerPlacements = 0;
+  let upperRowMarkerPlacements = 0;
+  let fallbackMarkerPlacements = 0;
+  const markerRowOffsetsUsed = new Set();
 
   for (let dataCol = 0; dataCol < targetColumnCount; dataCol++) {
     const label = labelMap.get(dataCol);
@@ -5325,6 +5386,8 @@ async function applyBannerMarkerUpdatesForRange(
     if (lowerStripped !== "") {
       desiredTexts[lowerRowIdx][scanCol] = appendOrReplaceTrailingBannerMarker(lowerStripped, label);
       markedCellKeys.add(`${lowerRowIdx},${scanCol}`);
+      lowerRowMarkerPlacements++;
+      markerRowOffsetsUsed.add(0);
       continue;
     }
 
@@ -5339,6 +5402,8 @@ async function applyBannerMarkerUpdatesForRange(
       if (upperStripped !== "") {
         desiredTexts[r][scanCol] = appendOrReplaceTrailingBannerMarker(upperStripped, label);
         markedCellKeys.add(`${r},${scanCol}`);
+        upperRowMarkerPlacements++;
+        markerRowOffsetsUsed.add(r - lowerRowIdx);
         placed = true;
         break;
       }
@@ -5354,6 +5419,8 @@ async function applyBannerMarkerUpdatesForRange(
       // the use of `useStructure` later when batching writes.
       desiredTexts[lowerRowIdx][scanCol] = appendOrReplaceTrailingBannerMarker("", label);
       markedCellKeys.add(`${lowerRowIdx},${scanCol}`);
+      fallbackMarkerPlacements++;
+      markerRowOffsetsUsed.add(0);
     }
   }
 
@@ -5403,6 +5470,10 @@ async function applyBannerMarkerUpdatesForRange(
   let markeredWriteCommands = 0;
   let clearOnlyWriteCommands = 0;
   let numberFormatCommands = 0;
+  let numberFormatCells = 0;
+  let valueWriteCells = 0;
+  let markeredValueWriteCells = 0;
+  let clearOnlyValueWriteCells = 0;
   let maxRunLength = 0;
 
   if (cellsChanged > 0) {
@@ -5431,10 +5502,12 @@ async function applyBannerMarkerUpdatesForRange(
         if (useStructure && slice[0].markered) {
           range.numberFormat = [texts.map(() => "@")];
           numberFormatCommands++;
+          numberFormatCells += runLength;
         }
         range.values = [texts];
 
         writeCommands++;
+        valueWriteCells += runLength;
         changedCellRuns++;
         if (runLength === 1) {
           oneCellWriteCommands++;
@@ -5443,8 +5516,10 @@ async function applyBannerMarkerUpdatesForRange(
         }
         if (slice[0].markered) {
           markeredWriteCommands++;
+          markeredValueWriteCells += runLength;
         } else {
           clearOnlyWriteCommands++;
+          clearOnlyValueWriteCells += runLength;
         }
         if (runLength > maxRunLength) {
           maxRunLength = runLength;
@@ -5473,6 +5548,10 @@ async function applyBannerMarkerUpdatesForRange(
     markeredWriteCommands,
     clearOnlyWriteCommands,
     numberFormatCommands,
+    numberFormatCells,
+    valueWriteCells,
+    markeredValueWriteCells,
+    clearOnlyValueWriteCells,
     changedRows,
     avgChangedCellsPerChangedRow: changedRows
       ? roundBannerDiagnosticRatio(cellsChanged / changedRows)
@@ -5480,9 +5559,17 @@ async function applyBannerMarkerUpdatesForRange(
     maxChangedCellsInRow,
     skippedNoOpWrites,
     readSyncMs: readSyncEndMs - readSyncStartMs,
-    planMs: queueWriteStartMs - readSyncEndMs,
+    readProperty: "text",
+    valuesReadProbeMs,
+    valuesReadProbeEnabled,
+    planMs: queueWriteStartMs - planStartMs,
     queueWriteMs: queueWriteEndMs - queueWriteStartMs,
     syncCount,
+    scanRowsWithAnyText,
+    lowerRowMarkerPlacements,
+    upperRowMarkerPlacements,
+    fallbackMarkerPlacements,
+    markerRowOffsetsUsed: Array.from(markerRowOffsetsUsed).sort((a, b) => a - b),
   };
 
   Object.defineProperty(details, BANNER_SCAN_AREA_STATS, {

--- a/tests/core/taskpane-performance.test.mjs
+++ b/tests/core/taskpane-performance.test.mjs
@@ -1,0 +1,64 @@
+import { describe, it, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+
+function createLocalStorage(initial = {}) {
+  const store = new Map(Object.entries(initial));
+  return {
+    getItem(key) {
+      return store.has(key) ? store.get(key) : null;
+    },
+    setItem(key, value) {
+      store.set(key, String(value));
+    },
+    removeItem(key) {
+      store.delete(key);
+    },
+  };
+}
+
+async function importPerformanceModule() {
+  return import(
+    new URL(
+      `../../src/taskpane/taskpane-performance.js?test=${Date.now()}-${Math.random()}`,
+      import.meta.url
+    )
+  );
+}
+
+describe("taskpane performance flags", () => {
+  beforeEach(() => {
+    delete globalThis.__RIT_PERF;
+    delete globalThis.__RIT_BANNER_VALUES_READ_PROBE;
+    globalThis.localStorage = createLocalStorage();
+  });
+
+  it("uses runtime flags before localStorage for the main perf flag", async () => {
+    globalThis.localStorage = createLocalStorage({ RIT_PERF: "1" });
+    globalThis.__RIT_PERF = false;
+
+    const { perfEnabled } = await importPerformanceModule();
+
+    assert.equal(perfEnabled(), false);
+  });
+
+  it("reads optional probe flags from runtime and localStorage", async () => {
+    const { perfFlagEnabled } = await importPerformanceModule();
+
+    assert.equal(
+      perfFlagEnabled("__RIT_BANNER_VALUES_READ_PROBE", "RIT_BANNER_VALUES_READ_PROBE"),
+      false
+    );
+
+    globalThis.localStorage.setItem("RIT_BANNER_VALUES_READ_PROBE", "1");
+    assert.equal(
+      perfFlagEnabled("__RIT_BANNER_VALUES_READ_PROBE", "RIT_BANNER_VALUES_READ_PROBE"),
+      true
+    );
+
+    globalThis.__RIT_BANNER_VALUES_READ_PROBE = "0";
+    assert.equal(
+      perfFlagEnabled("__RIT_BANNER_VALUES_READ_PROBE", "RIT_BANNER_VALUES_READ_PROBE"),
+      false
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Adds compact banner-marker diagnostics for the remaining clean-run bottleneck:
  - value-write cells vs number-format cells;
  - markered vs clear-only value-write cells;
  - marker placement row distribution;
  - non-empty scanned banner rows.
- Adds an opt-in values read probe for comparing `Range.text` against `Range.values` on the exact banner scan range without changing default product behavior.
- Adds unit coverage for runtime/localStorage perf probe flags.

## Diagnostics Usage

Default behavior is unchanged. To run the optional values-read probe during RIT perf logging, enable:

```js
window.__RIT_PERF = true;
window.__RIT_BANNER_VALUES_READ_PROBE = true;
```

or persist it with:

```js
localStorage.setItem("RIT_PERF", "1");
localStorage.setItem("RIT_BANNER_VALUES_READ_PROBE", "1");
```

The next wide-workbook run will include `valuesReadProbeMs`, `valuesReadProbeTables`, `numberFormatCells`, `valueWriteCells`, `markerRowOffsetsUsed`, and related placement counters in `bannerDetails`.

## Validation

- `npm test` passes.
- `npm run build` succeeds with existing webpack size warnings.
- `git diff --check` passes.
- `npm run lint` still fails on pre-existing baseline lint/prettier/Office-global issues across unrelated files; no lint-only changes were made.

Closes #293
