### PR TITLE
Add banner write profiling diagnostics

### DIFF
--- a/src/taskpane/taskpane-performance.js
+++ b/src/taskpane/taskpane-performance.js
@@ -5,6 +5,14 @@
 //   window.__RIT_PERF = "1"
 //   localStorage.setItem('RIT_PERF', '1')
 //
+// Optional banner write host-flush profiling:
+//   window.__RIT_BANNER_WRITE_PROFILE = true
+//   localStorage.setItem('RIT_BANNER_WRITE_PROFILE', '1')
+//
+// This intentionally changes banner write flushing while enabled, splitting
+// marker numberFormat and values into separate syncs so their host cost can be
+// measured. It is disabled unless RIT_PERF is also enabled.
+//
 // Disable with either:
 //   window.__RIT_PERF = false
 //   localStorage.removeItem('RIT_PERF')
@@ -55,8 +63,38 @@ function _perfEnabled() {
   return _perfStorageFlagEnabled();
 }
 
+function _bannerWriteProfileRuntimeFlagEnabled() {
+  try {
+    if (typeof globalThis === "undefined") return undefined;
+    const runtimeFlag = globalThis.__RIT_BANNER_WRITE_PROFILE;
+    if (runtimeFlag === true || runtimeFlag === "1") return true;
+    if (runtimeFlag === false || runtimeFlag === "0") return false;
+  } catch (_) {
+    return undefined;
+  }
+
+  return undefined;
+}
+
+function _bannerWriteProfileStorageFlagEnabled() {
+  try {
+    return typeof localStorage !== "undefined" && localStorage.getItem("RIT_BANNER_WRITE_PROFILE") === "1";
+  } catch (_) {
+    return false;
+  }
+}
+
 export function perfEnabled() {
   return _perfEnabled();
+}
+
+export function perfBannerWriteProfileEnabled() {
+  if (!_perfEnabled()) return false;
+
+  const runtimeEnabled = _bannerWriteProfileRuntimeFlagEnabled();
+  if (runtimeEnabled !== undefined) return runtimeEnabled;
+
+  return _bannerWriteProfileStorageFlagEnabled();
 }
 
 // Returns Date.now() when enabled, 0 otherwise.

--- a/src/taskpane/taskpane.js
+++ b/src/taskpane/taskpane.js
@@ -105,7 +105,13 @@ import {
   buildInventoryContentSkippedRow,
 } from "./taskpane-inventory-scan";
 
-import { perfNow, perfElapsed, perfLog, perfEnabled } from "./taskpane-performance";
+import {
+  perfNow,
+  perfElapsed,
+  perfLog,
+  perfEnabled,
+  perfBannerWriteProfileEnabled,
+} from "./taskpane-performance";
 
 const INVENTORY_CONTENT_SHEET_NAME = "Content";
 const RUN_REPORT_SHEET_NAME = "Run report";
@@ -484,6 +490,13 @@ function createAggregatedBannerPerfDetails() {
     planMs: 0,
     queueWriteMs: 0,
     syncCount: 0,
+    writeProfiledTables: 0,
+    numberFormatSyncMs: 0,
+    valueWriteSyncMs: 0,
+    profileSyncCount: 0,
+    numberFormatCells: 0,
+    valueWriteCells: 0,
+    markerRowsUsed: 0,
     maxWriteCommands: 0,
     tablesWithOverlappingBannerAreas: 0,
     perSheetBannerTablesMax: 0,
@@ -569,6 +582,13 @@ function mergeBannerPerfDetails(aggregate, bannerDetails, sheetName) {
   aggregate.planMs += bannerDetails.planMs || 0;
   aggregate.queueWriteMs += bannerDetails.queueWriteMs || 0;
   aggregate.syncCount += bannerDetails.syncCount || 0;
+  aggregate.writeProfiledTables += bannerDetails.writeProfileEnabled ? 1 : 0;
+  aggregate.numberFormatSyncMs += bannerDetails.numberFormatSyncMs || 0;
+  aggregate.valueWriteSyncMs += bannerDetails.valueWriteSyncMs || 0;
+  aggregate.profileSyncCount += bannerDetails.profileSyncCount || 0;
+  aggregate.numberFormatCells += bannerDetails.numberFormatCells || 0;
+  aggregate.valueWriteCells += bannerDetails.valueWriteCells || 0;
+  aggregate.markerRowsUsed += bannerDetails.markerRowsUsed || 0;
   if ((bannerDetails.writeCommands || 0) > aggregate.maxWriteCommands) {
     aggregate.maxWriteCommands = bannerDetails.writeCommands;
   }
@@ -5179,11 +5199,14 @@ function initializeSettingsTabs() {
  * contiguous same-row runs and split by markered/clear-only flag so the
  * legacy "@" number-format behaviour is preserved on marker writes.
  *
- * Sync count: 1 for the banner-area read (also flushes any pending data
- * writes from the caller) and 0 for the writes — the caller is expected to
- * issue its own final `context.sync()` to flush the queued banner writes.
- * This brings per-table banner sync count down from 5–7 (legacy) to 2 when
- * counting the caller's final sync.
+ * Sync count in normal mode: 1 for the banner-area read (also flushes any
+ * pending data writes from the caller) and 0 for the writes — the caller is
+ * expected to issue its own final `context.sync()` to flush queued banner
+ * writes.  This brings per-table banner sync count down from 5–7 (legacy) to
+ * 2 when counting the caller's final sync.
+ *
+ * Development-only banner write profiling can split numberFormat and values
+ * into separate syncs to measure host flush cost. It is disabled by default.
  *
  * Returns null when no banner work was needed.  Otherwise returns a perf
  * details object describing the work performed.
@@ -5403,8 +5426,18 @@ async function applyBannerMarkerUpdatesForRange(
   let markeredWriteCommands = 0;
   let clearOnlyWriteCommands = 0;
   let numberFormatCommands = 0;
+  let numberFormatCells = 0;
+  let valueWriteCells = 0;
+  let markerRowsUsed = 0;
   let maxRunLength = 0;
+  let numberFormatSyncMs = 0;
+  let valueWriteSyncMs = 0;
+  let profileSyncCount = 0;
+  const writeProfileEnabled = perfBannerWriteProfileEnabled();
 
+  const profiledValueWrites = [];
+  const markerRowIndexes = new Set();
+  let queueCommandEndMs = 0;
   if (cellsChanged > 0) {
     const worksheet = writeTargetRange.worksheet;
     for (const [rowIndex, items] of writesByRow) {
@@ -5431,11 +5464,18 @@ async function applyBannerMarkerUpdatesForRange(
         if (useStructure && slice[0].markered) {
           range.numberFormat = [texts.map(() => "@")];
           numberFormatCommands++;
+          numberFormatCells += runLength;
         }
-        range.values = [texts];
+
+        if (writeProfileEnabled) {
+          profiledValueWrites.push({ range, texts });
+        } else {
+          range.values = [texts];
+        }
 
         writeCommands++;
         changedCellRuns++;
+        valueWriteCells += runLength;
         if (runLength === 1) {
           oneCellWriteCommands++;
         } else {
@@ -5443,6 +5483,7 @@ async function applyBannerMarkerUpdatesForRange(
         }
         if (slice[0].markered) {
           markeredWriteCommands++;
+          markerRowIndexes.add(rowIndex);
         } else {
           clearOnlyWriteCommands++;
         }
@@ -5452,11 +5493,32 @@ async function applyBannerMarkerUpdatesForRange(
         i = j + 1;
       }
     }
-    // Intentionally NO context.sync() here.  Caller's final context.sync()
-    // flushes the queued banner writes alongside any other pending ops.
+    markerRowsUsed = markerRowIndexes.size;
+    queueCommandEndMs = perfNow();
+
+    if (writeProfileEnabled) {
+      if (numberFormatCommands > 0) {
+        const numberFormatSyncStartMs = perfNow();
+        await context.sync();
+        numberFormatSyncMs = perfNow() - numberFormatSyncStartMs;
+        syncCount++;
+        profileSyncCount++;
+      }
+
+      const valueWriteSyncStartMs = perfNow();
+      for (const pending of profiledValueWrites) {
+        pending.range.values = [pending.texts];
+      }
+      await context.sync();
+      valueWriteSyncMs = perfNow() - valueWriteSyncStartMs;
+      syncCount++;
+      profileSyncCount++;
+    }
+    // In normal mode, intentionally NO context.sync() here.  Caller's final
+    // context.sync() flushes queued banner writes alongside other pending ops.
   }
 
-  const queueWriteEndMs = perfNow();
+  const queueWriteEndMs = queueCommandEndMs || perfNow();
   const details = {
     rowsScanned: totalScanRowCount,
     cellsRead: totalScanRowCount * scanColCount,
@@ -5483,6 +5545,13 @@ async function applyBannerMarkerUpdatesForRange(
     planMs: queueWriteStartMs - readSyncEndMs,
     queueWriteMs: queueWriteEndMs - queueWriteStartMs,
     syncCount,
+    writeProfileEnabled,
+    numberFormatSyncMs,
+    valueWriteSyncMs,
+    profileSyncCount,
+    numberFormatCells,
+    valueWriteCells,
+    markerRowsUsed,
   };
 
   Object.defineProperty(details, BANNER_SCAN_AREA_STATS, {


### PR DESCRIPTION
## Diagnosis

#292 showed the current benchmark is not dominated by tiny banner writes: clean-run banner writes are already grouped into 141 long row runs, with zero one-cell write commands and very small JS queue time.

The remaining unknown is the Excel host flush split inside clean-run banner writes: the current batched final sync combines marker `numberFormat = "@"` commands and row `values` writes, so the existing RIT_PERF numbers cannot tell which side dominates `bannerWriteMs`.

## Chosen path

Diagnostics-only PR.

This adds an opt-in banner write profiler that is disabled by default. Normal runs keep the same batching and behavior as #290/#292. When both `RIT_PERF` and `RIT_BANNER_WRITE_PROFILE` are enabled, banner marker writes are flushed in two measured steps:

- `numberFormatSyncMs` for queued marker text-format commands
- `valueWriteSyncMs` for queued banner value row writes

New compact banner diagnostics also include:

- `writeProfileEnabled`
- `profileSyncCount`
- `numberFormatCells`
- `valueWriteCells`
- `markerRowsUsed`
- aggregate `writeProfiledTables`

Enable in DevTools with:

```js
localStorage.setItem("RIT_PERF", "1");
localStorage.setItem("RIT_BANNER_WRITE_PROFILE", "1");
```

or for the current taskpane session:

```js
window.__RIT_PERF = true;
window.__RIT_BANNER_WRITE_PROFILE = true;
```

## Files changed

- `src/taskpane/taskpane.js`
- `src/taskpane/taskpane-performance.js`

## Validation results

- `npm test` passes: 332 tests
- `npm run build` succeeds
- `git diff --check` is clean

Build still reports the existing webpack asset-size warnings for `taskpane.js`.

## Manual smoke checklist

Not run in this environment because it requires the corrected 72-table wide Excel workbook.

Recommended smoke:

1. Run normal clean workbook autorun with banner letters and `respectBannerStructure = ON` to confirm default metrics remain comparable.
2. Run with `RIT_BANNER_WRITE_PROFILE=1` and capture `numberFormatSyncMs` vs `valueWriteSyncMs`.
3. Repeated workbook autorun should still show `cellsChanged: 0`, `writeCommands: 0`, and near-zero default `bannerWriteMs` when profiling is off.
4. Confirm visual banner placement, #274 three-level grouping, current-table autorun, manual selected-range Run, Clear Significance, Markers-only, and Full formatting.

## Known limitations and follow-ups

- Profile mode intentionally adds syncs, so it should be used to isolate host costs, not as the new performance baseline.
- This PR does not switch `.text` to `.values`, narrow banner scan rows, skip `numberFormat`, or aggregate banner reads per sheet. Those remain follow-up implementation choices after the profile identifies the dominant host cost.

Refs #293