### PR TITLE
Make banner numberFormat selective: skip @ for non-bare marker text (#296)

### DIFF
--- a/src/taskpane/taskpane.js
+++ b/src/taskpane/taskpane.js
@@ -5401,10 +5401,12 @@ async function applyBannerMarkerUpdatesForRange(
       const absRow = targetStartRowIndex - totalScanRowCount + r;
       const absCol = scanStartColIndex + c;
       if (!writesByRow.has(absRow)) writesByRow.set(absRow, []);
+      const isMarkered = markedCellKeys.has(key);
       writesByRow.get(absRow).push({
         colIndex: absCol,
         text: nxt,
-        markered: markedCellKeys.has(key),
+        markered: isMarkered,
+        needsNF: isMarkered && needsNumberFormatForBannerMarker(nxt),
       });
       cellsChanged++;
     }
@@ -5445,14 +5447,14 @@ async function applyBannerMarkerUpdatesForRange(
       let i = 0;
       while (i < items.length) {
         let j = i;
-        // Group adjacent columns with the same markered flag so the "@"
-        // number format is applied only to marker writes in structure mode —
-        // matches legacy behaviour where clear-only cells were written
-        // without touching numberFormat.
+        // Group adjacent columns with the same markered and needsNF flags so
+        // the "@" number format is applied only to bare-marker cells —
+        // non-bare marker text like "Wave 1 (a)" does not need "@".
         while (
           j + 1 < items.length &&
           items[j + 1].colIndex === items[j].colIndex + 1 &&
-          items[j + 1].markered === items[j].markered
+          items[j + 1].markered === items[j].markered &&
+          items[j + 1].needsNF === items[j].needsNF
         ) {
           j++;
         }
@@ -5461,7 +5463,7 @@ async function applyBannerMarkerUpdatesForRange(
         const range = worksheet.getRangeByIndexes(rowIndex, items[i].colIndex, 1, j - i + 1);
         const runLength = texts.length;
 
-        if (useStructure && slice[0].markered) {
+        if (useStructure && slice[0].markered && slice[0].needsNF) {
           range.numberFormat = [texts.map(() => "@")];
           numberFormatCommands++;
           numberFormatCells += runLength;
@@ -6191,6 +6193,17 @@ function getFirstBannerStructureError(bannerStructure) {
   }
 
   return bannerStructure.messages.find((message) => message.severity === "error") || null;
+}
+
+/**
+ * Returns true when a banner marker write needs numberFormat = "@".
+ *
+ * Only bare-marker cells risk Excel auto-formatting and need the guard.
+ * A cell is "bare" when the only content is the marker itself, e.g. "(a)".
+ * Cells with actual text like "Wave 1 (a)" are already text-safe without "@".
+ */
+function needsNumberFormatForBannerMarker(text) {
+  return removeTrailingBannerMarker(text) === "";
 }
 
 /**


### PR DESCRIPTION
## Diagnosis

#295 profiling on the 72-table wide workbook showed:

| Metric | Value |
|--------|-------|
| numberFormatCommands | 141 |
| numberFormatCells | 31,879 |
| numberFormatSyncMs (profile) | 30,729 ms |
| valueWriteSyncMs (profile) | 1,660 ms |

The dominant clean-run banner write cost is `numberFormat = "@"`, not value writes.

Almost all banner marker text is of the form `Wave 1 (a)`, `Мужской (b)`, etc. — text that Excel already treats as text. The `@` guard is only needed for bare-marker fallback cells where the banner area is empty and the marker is written alone as `(a)`.

## Files changed

- `src/taskpane/taskpane.js`

## Diff summary

**New helper** `needsNumberFormatForBannerMarker(text)`:
- Returns `true` when `removeTrailingBannerMarker(text) === ""` — i.e., the cell contains only a bare marker like `(a)` with no preceding content.
- Returns `false` for normal appended text like `Wave 1 (a)`.

**Write item tagging**: each item in `writesByRow` now carries a `needsNF` flag computed as `isMarkered && needsNumberFormatForBannerMarker(text)`.

**Run grouping**: the adjacency loop now also splits at `needsNF` boundaries, so bare-marker runs and non-bare-marker runs are never merged into the same command.

**Selective `@` application**: changed from `useStructure && slice[0].markered` to `useStructure && slice[0].markered && slice[0].needsNF`. Non-bare marker cells skip the `numberFormat` write entirely.

The `#295` diagnostics (`numberFormatCommands`, `numberFormatCells`, `numberFormatSyncMs`, `valueWriteSyncMs`) are preserved and will now reflect the reduction.

## Selective numberFormat rule

| Written text | needsNF | Why |
|---|---|---|
| `(a)` | true | bare marker — empty cell fallback, needs `@` guard |
| `Wave 1 (a)` | false | has content before marker, already text-safe |
| `Мужской (b)` | false | has content before marker, already text-safe |
| `Ноябрь 23 (c)` | false | has content before marker, already text-safe |

## Build/test result

```
npm test:  332 pass, 0 fail
npm run build:  compiled with 3 warnings (pre-existing size warnings only)
git diff --check:  clean
```

## Before/after RIT_PERF (expected)

**Before** (72-table clean run):
- numberFormatCommands: 141
- numberFormatCells: 31,879
- numberFormatSyncMs (profile): ~30,729 ms

**After** (72-table clean run, expected):
- numberFormatCommands: ~0 (only bare-marker fallback cells)
- numberFormatCells: ~0
- numberFormatSyncMs (profile): ~0 ms
- valueWriteSyncMs and bannerWriteMs unaffected (same value writes)

## Manual smoke checklist

- [ ] Clean workbook autorun with banner letters + respectBannerStructure ON — capture RIT_PERF numberFormatCommands/Cells/SyncMs
- [ ] Profile-mode RIT_PERF: numberFormatSyncMs near 0, valueWriteSyncMs unchanged
- [ ] Repeated autorun: cellsChanged = 0, writeCommands = 0, bannerWriteMs near 0
- [ ] Visual check: banner marker placement matches previous behavior
- [ ] #274 regression: three-level banner grouping still works
- [ ] Current-table autorun with banner letters enabled
- [ ] Manual selected-range Run with banner letters enabled
- [ ] Clear Significance removes banner markers
- [ ] Bare-marker fallback table (empty banner area): markers written as `(a)`, `(b)`, `(c)`; repeated Run does not duplicate; Clear removes them; markers remain text

## Known limitations

- The `@` guard is still applied in structure mode only (no change to non-structure path, which never applied `@`).
- Bare-marker detection uses `removeTrailingBannerMarker(text) === ""` — if a banner cell contains only whitespace before the marker, it is considered bare. This is consistent with how `appendOrReplaceTrailingBannerMarker` trims the text before appending.