### PR TITLE
Improve Clear Significance performance: combined banner pass, no-op body skip (#299)

### DIFF
--- a/src/taskpane/taskpane.js
+++ b/src/taskpane/taskpane.js
@@ -2720,13 +2720,372 @@ async function clearSignificanceForSheetBatched(context, worksheetRef, candidate
 }
 
 /**
+ * Workbook-level staged 4-phase Clear pipeline for all eligible candidates.
+ *
+ * Generalises clearSignificanceForSheetBatched to span multiple worksheets
+ * inside a single Excel.run context.  A single Office.js RequestContext can
+ * queue loads and writes against ranges on any number of worksheets, so the
+ * same 4-phase approach that reduces per-sheet sync count to 4 can be applied
+ * across the whole workbook — reducing total syncs from 4×N_sheets to 4.
+ *
+ *   Phase 1 — sync 1: load values+text for ALL source ranges (all sheets).
+ *   Phase 2 — sync 2: compute clear targets in JS; load values+format+dims.
+ *   Phase 3 — sync 3: queue ALL body writes; load ALL banner scan texts.
+ *   Phase 4 — sync 4: queue ALL banner writes; final flush.
+ *
+ * Must be called inside an Excel.run callback (shared context, no nested run).
+ *
+ * @param {Excel.RequestContext} context
+ * @param {Array<{sheetName: string, rangeAddress: string}>} eligible
+ *   All candidates across all sheets (each carries its own sheetName).
+ * @returns {Promise<{
+ *   results: Array<{status, message, _clearDetails}>,
+ *   batchDiags: {syncPhases, sourceRangesLoaded, targetRangesLoaded, bannerRangesLoaded}
+ * }>}
+ */
+async function clearSignificanceForWorkbookBatched(context, eligible) {
+  const BANNER_UPPER_SCAN_LIMIT = 5;
+
+  // One worksheet proxy per unique sheet — avoids redundant getItem calls.
+  const worksheetRefs = new Map();
+  for (const c of eligible) {
+    if (!worksheetRefs.has(c.sheetName)) {
+      worksheetRefs.set(c.sheetName, context.workbook.worksheets.getItem(c.sheetName));
+    }
+  }
+
+  // ── Per-table record ──────────────────────────────────────────────────────
+  const records = eligible.map((c) => ({
+    sheetName: c.sheetName,
+    rangeAddress: c.rangeAddress,
+    status: "pending", // "pending" | "skipped" | "cleared"
+    message: "",
+    // Phase 1
+    sourceRange: null,
+    // Phase 2 inputs (computed in JS after sync 1)
+    clearTargetRange: null,
+    // Phase 2 outputs (loaded after sync 2)
+    knownDims: null, // { rowIndex, columnIndex, columnCount }
+    // Phase 3 — body
+    bodyCellsRead: 0,
+    bodyCellsChanged: 0,
+    bodyHasValueChange: false,
+    bodyHasFormatChange: false,
+    nextValues: null,
+    nextNumberFormats: null,
+    // Phase 3 — banner scan setup
+    bannerScanRange: null,
+    bannerScanRowCount: 0,
+    bannerScanColCount: 0,
+    bannerStartColIndex: 0,
+    bannerStartRowAbs: 0,
+    // Phase 4 — banner results
+    bannerCellsRead: 0,
+    bannerCellsChanged: 0,
+    bannerWriteCommands: 0,
+  }));
+
+  // ══════════════════════════════════════════════════════════════════════════
+  // PHASE 1 — Load source range values+text for every table (all sheets)
+  // ══════════════════════════════════════════════════════════════════════════
+  for (const rec of records) {
+    const sr = worksheetRefs.get(rec.sheetName).getRange(rec.rangeAddress);
+    sr.load(["values", "text"]);
+    rec.sourceRange = sr;
+  }
+  await context.sync(); // Sync 1
+
+  // ══════════════════════════════════════════════════════════════════════════
+  // PHASE 2 — Compute clear-target ranges in JS; load values+format+dims
+  // ══════════════════════════════════════════════════════════════════════════
+  for (const rec of records) {
+    if (rec.status !== "pending") continue;
+
+    const selectedValues = rec.sourceRange.values;
+    const selectedText = rec.sourceRange.text;
+
+    if (
+      !selectedValues ||
+      selectedValues.length < 1 ||
+      !selectedValues[0] ||
+      selectedValues[0].length < 1
+    ) {
+      rec.status = "skipped";
+      rec.message = "нет данных в диапазоне";
+      continue;
+    }
+
+    const cleanedValues = removeSignificanceMarkersFromMatrix(selectedValues);
+    const normalized = normalizeSelectedRange(cleanedValues, selectedText);
+
+    if (normalized.normalizationNeeded && !normalized.normalizationApplied) {
+      const codes =
+        normalized.blockingReasons && normalized.blockingReasons.length > 0
+          ? ` [${normalized.blockingReasons.join(", ")}]`
+          : "";
+      rec.status = "skipped";
+      rec.message = `${normalized.blockingMessage}${codes}`;
+      continue;
+    }
+
+    let clearTargetRange;
+
+    if (normalized.normalizationNeeded && normalized.normalizationApplied) {
+      const bodyRowCount = normalized.valuesForCalculation.length;
+      let bodyColCount = normalized.valuesForCalculation[0].length;
+      let effectiveClearColOffset = normalized.dataColOffset;
+      let textForLeadingEmptyCheck = normalized.textForCalculation;
+
+      if (normalized.dataColOffset === 0) {
+        const additionalLabelCols = detectEmbeddedLabelColumns(normalized.valuesForCalculation);
+        if (additionalLabelCols > 0) {
+          effectiveClearColOffset += additionalLabelCols;
+          bodyColCount -= additionalLabelCols;
+          textForLeadingEmptyCheck = normalized.textForCalculation.map((row) =>
+            row.slice(additionalLabelCols)
+          );
+        }
+      }
+
+      const clearLeadingEmptyCols = detectLeadingEmptyColumns(textForLeadingEmptyCheck);
+      if (clearLeadingEmptyCols > 0) {
+        bodyColCount -= clearLeadingEmptyCols;
+        effectiveClearColOffset += clearLeadingEmptyCols;
+      }
+
+      if (bodyRowCount < 1 || bodyColCount < 1) {
+        rec.status = "skipped";
+        rec.message = "нет данных после нормализации";
+        continue;
+      }
+
+      clearTargetRange = rec.sourceRange
+        .getCell(normalized.dataRowOffset, effectiveClearColOffset)
+        .getResizedRange(bodyRowCount - 1, bodyColCount - 1);
+    } else {
+      // Pass-through: use JS dimensions — avoids loading unneeded sourceRange properties.
+      const rowCount = selectedValues.length;
+      const colCount = selectedValues[0].length;
+      const embeddedLabelCols = detectEmbeddedLabelColumns(cleanedValues);
+      const leadingBlankCols =
+        embeddedLabelCols === 0 ? detectLeadingEmptyColumns(selectedText) : 0;
+      const skipLeftCols = embeddedLabelCols > 0 ? embeddedLabelCols : leadingBlankCols;
+
+      if (skipLeftCols > 0) {
+        clearTargetRange = rec.sourceRange
+          .getCell(0, skipLeftCols)
+          .getResizedRange(rowCount - 1, colCount - skipLeftCols - 1);
+      } else {
+        clearTargetRange = rec.sourceRange;
+      }
+    }
+
+    rec.clearTargetRange = clearTargetRange;
+    clearTargetRange.load(["values", "numberFormat", "rowIndex", "columnIndex", "columnCount"]);
+  }
+  await context.sync(); // Sync 2
+
+  // ══════════════════════════════════════════════════════════════════════════
+  // PHASE 3 — Body cleanup + queue writes + set up banner reads (all sheets)
+  // ══════════════════════════════════════════════════════════════════════════
+  for (const rec of records) {
+    if (rec.status !== "pending") continue;
+
+    const targetValues = rec.clearTargetRange.values;
+    const targetNumberFormats = rec.clearTargetRange.numberFormat;
+
+    rec.knownDims = {
+      rowIndex: rec.clearTargetRange.rowIndex,
+      columnIndex: rec.clearTargetRange.columnIndex,
+      columnCount: rec.clearTargetRange.columnCount,
+    };
+
+    const nextValues = [];
+    const nextNumberFormats = [];
+    let bodyCellsChanged = 0;
+    let bodyHasValueChange = false;
+    let bodyHasFormatChange = false;
+
+    for (let r = 0; r < targetValues.length; r++) {
+      const valueRow = [];
+      const formatRow = [];
+
+      for (let c = 0; c < targetValues[r].length; c++) {
+        const rawValue = targetValues[r][c];
+        const currentFormat = targetNumberFormats[r][c];
+
+        if (typeof rawValue === "number") {
+          valueRow.push(rawValue);
+          formatRow.push(currentFormat);
+          continue;
+        }
+
+        const cleanedText = removeSignificanceMarkersFromText(rawValue);
+        const resolved = resolveNumericOutput(cleanedText);
+
+        if (resolved !== null) {
+          if (resolved.value !== rawValue) bodyHasValueChange = true;
+          if (resolved.format !== currentFormat) bodyHasFormatChange = true;
+          if (resolved.value !== rawValue || resolved.format !== currentFormat) bodyCellsChanged++;
+          valueRow.push(resolved.value);
+          formatRow.push(resolved.format);
+        } else {
+          if (cleanedText !== rawValue) {
+            bodyHasValueChange = true;
+            bodyCellsChanged++;
+          }
+          valueRow.push(cleanedText);
+          formatRow.push("@");
+        }
+      }
+
+      nextValues.push(valueRow);
+      nextNumberFormats.push(formatRow);
+    }
+
+    rec.bodyCellsRead = targetValues.length * (targetValues[0] ? targetValues[0].length : 0);
+    rec.bodyCellsChanged = bodyCellsChanged;
+    rec.bodyHasValueChange = bodyHasValueChange;
+    rec.bodyHasFormatChange = bodyHasFormatChange;
+    rec.nextValues = nextValues;
+    rec.nextNumberFormats = nextNumberFormats;
+
+    // Queue body writes (only when something actually changed).
+    if (bodyHasFormatChange) rec.clearTargetRange.numberFormat = nextNumberFormats;
+    if (bodyHasValueChange) rec.clearTargetRange.values = nextValues;
+    rec.clearTargetRange.format.font.bold = false;
+    rec.clearTargetRange.format.fill.clear();
+
+    // Queue banner scan load for this table's sheet.
+    const wsRef = worksheetRefs.get(rec.sheetName);
+    const { rowIndex: targetStartRowIndex, columnIndex: targetStartColumnIndex, columnCount: targetColumnCount } =
+      rec.knownDims;
+
+    if (targetStartRowIndex > 0 && targetColumnCount >= 1) {
+      const totalScanRowCount = Math.min(BANNER_UPPER_SCAN_LIMIT + 1, targetStartRowIndex);
+      if (totalScanRowCount >= 1) {
+        const bannerScanRange = wsRef.getRangeByIndexes(
+          targetStartRowIndex - totalScanRowCount,
+          targetStartColumnIndex,
+          totalScanRowCount,
+          targetColumnCount
+        );
+        bannerScanRange.load("text");
+        rec.bannerScanRange = bannerScanRange;
+        rec.bannerScanRowCount = totalScanRowCount;
+        rec.bannerScanColCount = targetColumnCount;
+        rec.bannerStartColIndex = targetStartColumnIndex;
+        rec.bannerStartRowAbs = targetStartRowIndex - totalScanRowCount;
+      }
+    }
+  }
+  await context.sync(); // Sync 3 — flushes ALL body writes; reads ALL banner scan texts
+
+  // ══════════════════════════════════════════════════════════════════════════
+  // PHASE 4 — Diff banner texts; queue banner writes; final flush (all sheets)
+  // ══════════════════════════════════════════════════════════════════════════
+  for (const rec of records) {
+    if (rec.status !== "pending") continue;
+
+    rec.status = "cleared"; // body writes already flushed in sync 3
+
+    if (!rec.bannerScanRange) continue;
+
+    const bannerTexts = rec.bannerScanRange.text;
+    const { bannerScanRowCount, bannerScanColCount, bannerStartColIndex, bannerStartRowAbs } = rec;
+
+    rec.bannerCellsRead = bannerScanRowCount * bannerScanColCount;
+
+    const writesByRow = new Map();
+    let cellsChanged = 0;
+
+    for (let r = 0; r < bannerScanRowCount; r++) {
+      const row = bannerTexts[r] || [];
+      for (let c = 0; c < bannerScanColCount; c++) {
+        const cur = row[c] || "";
+        const nxt = cur && getTrailingBannerMarker(cur) ? removeTrailingBannerMarker(cur) : cur;
+        if (cur === nxt) continue;
+        const absRow = bannerStartRowAbs + r;
+        const absCol = bannerStartColIndex + c;
+        if (!writesByRow.has(absRow)) writesByRow.set(absRow, []);
+        writesByRow.get(absRow).push({ colIndex: absCol, text: nxt });
+        cellsChanged++;
+      }
+    }
+
+    rec.bannerCellsChanged = cellsChanged;
+
+    if (cellsChanged > 0) {
+      const wsRef = worksheetRefs.get(rec.sheetName);
+      let writeCommands = 0;
+      for (const [rowIndex, items] of writesByRow) {
+        items.sort((a, b) => a.colIndex - b.colIndex);
+        let i = 0;
+        while (i < items.length) {
+          let j = i;
+          while (j + 1 < items.length && items[j + 1].colIndex === items[j].colIndex + 1) j++;
+          const texts = items.slice(i, j + 1).map((x) => x.text);
+          wsRef.getRangeByIndexes(rowIndex, items[i].colIndex, 1, j - i + 1).values = [texts];
+          writeCommands++;
+          i = j + 1;
+        }
+      }
+      rec.bannerWriteCommands = writeCommands;
+    }
+  }
+  await context.sync(); // Sync 4 — flushes ALL banner writes (all sheets)
+
+  // ── Build result array and batch-level diagnostics ────────────────────────
+  let targetRangesLoaded = 0;
+  let bannerRangesLoaded = 0;
+  for (const rec of records) {
+    if (rec.clearTargetRange !== null) targetRangesLoaded++;
+    if (rec.bannerScanRange !== null) bannerRangesLoaded++;
+  }
+
+  const results = records.map((rec) => {
+    if (rec.status === "cleared") {
+      return {
+        status: "cleared",
+        message: "очищено",
+        _clearDetails: {
+          bodyCellsRead: rec.bodyCellsRead,
+          bodyCellsChanged: rec.bodyCellsChanged,
+          bannerCellsRead: rec.bannerCellsRead,
+          bannerCellsChanged: rec.bannerCellsChanged,
+          bannerWriteCommands: rec.bannerWriteCommands,
+          totalMs: 0,
+        },
+      };
+    }
+    return { status: rec.status, message: rec.message, _clearDetails: null };
+  });
+
+  return {
+    results,
+    batchDiags: {
+      syncPhases: 4,
+      sourceRangesLoaded: eligible.length,
+      targetRangesLoaded,
+      bannerRangesLoaded,
+    },
+  };
+}
+
+/**
  * Auto-clear: removes significance markers from all "available" inventory
  * candidates in the workbook.
  *
- * Candidates are grouped by sheet. Each sheet's tables are processed in a
- * staged 4-sync batch (clearSignificanceForSheetBatched), reducing total
- * sync count from 4×N_tables to 4×N_sheets.  If the batch fails the full
- * sheet falls back to per-table clearSignificanceForRange.
+ * Attempts a workbook-level staged batch first (1 Excel.run, 4 sync phases
+ * for the whole workbook).  If that fails, falls back to the per-sheet staged
+ * batch (1 Excel.run per sheet, 4 sync phases per sheet).  If a per-sheet
+ * batch also fails, remaining tables on that sheet fall back to per-table
+ * clearSignificanceForRange.
+ *
+ * batchMode in RIT_PERF diagnostics reflects which path actually ran:
+ *   "workbook" — workbook-level batch succeeded (contextRuns: 1, syncPhases: 4)
+ *   "sheet"    — workbook batch failed; per-sheet batches ran
+ *   "fallback" — all batches failed; per-table fallback ran
  */
 async function clearAutoSignificance() {
   const _t0 = perfNow();
@@ -2762,6 +3121,7 @@ async function clearAutoSignificance() {
   let errors = 0;
   let contextRuns = 0;
   let sheetsCleared = 0;
+  let batchMode = "workbook";
   const _clearAggregate = {
     syncPhases: 0,
     sourceRangesLoaded: 0,
@@ -2774,30 +3134,105 @@ async function clearAutoSignificance() {
     bannerWriteCommands: 0,
   };
 
-  // Group by sheet; each sheet is cleared in one staged 4-sync batch.
+  // Always build the by-sheet map so the per-sheet fallback loop has it ready.
   const bySheet = groupCandidatesBySheet(eligible);
 
-  for (const [sheetName, sheetCandidates] of bySheet) {
-    let batchEndedAt = 0;
-    let sheetClearedCount = 0;
-    contextRuns++;
+  // ── ATTEMPT 1: workbook-level staged batch (1 context, 4 syncs total) ──────
+  let _wbResults = null;
+  let _wbBatchDiags = null;
 
-    // Staged 4-phase batch: all N tables on this sheet in 4 syncs total.
-    try {
-      await Excel.run(async (context) => {
-        const worksheetRef = context.workbook.worksheets.getItem(sheetName);
-        const { results: batchResults, sheetDiags } = await clearSignificanceForSheetBatched(
-          context,
-          worksheetRef,
-          sheetCandidates
+  try {
+    await Excel.run(async (context) => {
+      const r = await clearSignificanceForWorkbookBatched(context, eligible);
+      _wbResults = r.results;
+      _wbBatchDiags = r.batchDiags;
+    });
+    contextRuns = 1;
+  } catch (_wbErr) {
+    // Workbook-level batch failed; fall through to per-sheet staged batching.
+    batchMode = "sheet";
+  }
+
+  if (_wbResults !== null) {
+    // Workbook batch succeeded — process results.
+    _clearAggregate.syncPhases += _wbBatchDiags.syncPhases;
+    _clearAggregate.sourceRangesLoaded += _wbBatchDiags.sourceRangesLoaded;
+    _clearAggregate.targetRangesLoaded += _wbBatchDiags.targetRangesLoaded;
+    _clearAggregate.bannerRangesLoaded += _wbBatchDiags.bannerRangesLoaded;
+
+    const sheetClearedSet = new Set();
+    for (let _i = 0; _i < _wbResults.length; _i++) {
+      const result = _wbResults[_i];
+      const candidate = eligible[_i];
+      if (result.status === "cleared") {
+        cleared++;
+        sheetClearedSet.add(candidate.sheetName);
+        accumulateClearDetails(_clearAggregate, result._clearDetails);
+      } else if (result.status === "skipped") {
+        skipped++;
+        detailLines.push(
+          `- ${candidate.sheetName} ${candidate.rangeAddress}: пропущено — ${result.message}`
         );
-        _clearAggregate.syncPhases += sheetDiags.syncPhases;
-        _clearAggregate.sourceRangesLoaded += sheetDiags.sourceRangesLoaded;
-        _clearAggregate.targetRangesLoaded += sheetDiags.targetRangesLoaded;
-        _clearAggregate.bannerRangesLoaded += sheetDiags.bannerRangesLoaded;
-        for (let _si = 0; _si < batchResults.length; _si++) {
-          const result = batchResults[_si];
-          const candidate = sheetCandidates[_si];
+      } else {
+        errors++;
+        detailLines.push(
+          `- ${candidate.sheetName} ${candidate.rangeAddress}: ошибка — ${result.message}`
+        );
+      }
+    }
+    sheetsCleared = sheetClearedSet.size;
+  } else {
+    // ── FALLBACK: per-sheet staged batching ────────────────────────────────
+    for (const [sheetName, sheetCandidates] of bySheet) {
+      let batchEndedAt = 0;
+      let sheetClearedCount = 0;
+      contextRuns++;
+
+      // Staged 4-phase batch: all N tables on this sheet in 4 syncs total.
+      try {
+        await Excel.run(async (context) => {
+          const worksheetRef = context.workbook.worksheets.getItem(sheetName);
+          const { results: batchResults, sheetDiags } = await clearSignificanceForSheetBatched(
+            context,
+            worksheetRef,
+            sheetCandidates
+          );
+          _clearAggregate.syncPhases += sheetDiags.syncPhases;
+          _clearAggregate.sourceRangesLoaded += sheetDiags.sourceRangesLoaded;
+          _clearAggregate.targetRangesLoaded += sheetDiags.targetRangesLoaded;
+          _clearAggregate.bannerRangesLoaded += sheetDiags.bannerRangesLoaded;
+          for (let _si = 0; _si < batchResults.length; _si++) {
+            const result = batchResults[_si];
+            const candidate = sheetCandidates[_si];
+            if (result.status === "cleared") {
+              cleared++;
+              sheetClearedCount++;
+              accumulateClearDetails(_clearAggregate, result._clearDetails);
+            } else if (result.status === "skipped") {
+              skipped++;
+              detailLines.push(
+                `- ${sheetName} ${candidate.rangeAddress}: пропущено — ${result.message}`
+              );
+            } else {
+              errors++;
+              detailLines.push(
+                `- ${sheetName} ${candidate.rangeAddress}: ошибка — ${result.message}`
+              );
+            }
+          }
+          batchEndedAt = sheetCandidates.length;
+        });
+      } catch (_batchErr) {
+        // Per-sheet batch failed; fall back to per-table for all candidates on this sheet.
+        if (batchMode === "sheet") batchMode = "fallback";
+      }
+
+      for (let _fi = batchEndedAt; _fi < sheetCandidates.length; _fi++) {
+        const candidate = sheetCandidates[_fi];
+        contextRuns++;
+        _clearAggregate.syncPhases += 4; // per-table fallback: 4 syncs each
+        try {
+          const result = await clearSignificanceForRange(sheetName, candidate.rangeAddress);
           if (result.status === "cleared") {
             cleared++;
             sheetClearedCount++;
@@ -2813,43 +3248,16 @@ async function clearAutoSignificance() {
               `- ${sheetName} ${candidate.rangeAddress}: ошибка — ${result.message}`
             );
           }
-        }
-        batchEndedAt = sheetCandidates.length;
-      });
-    } catch (_batchErr) {
-      // Staged batch failed; fall back to per-table for all candidates on this sheet.
-    }
-
-    for (let _fi = batchEndedAt; _fi < sheetCandidates.length; _fi++) {
-      const candidate = sheetCandidates[_fi];
-      contextRuns++;
-      _clearAggregate.syncPhases += 4; // per-table fallback: 4 syncs each
-      try {
-        const result = await clearSignificanceForRange(sheetName, candidate.rangeAddress);
-        if (result.status === "cleared") {
-          cleared++;
-          sheetClearedCount++;
-          accumulateClearDetails(_clearAggregate, result._clearDetails);
-        } else if (result.status === "skipped") {
-          skipped++;
-          detailLines.push(
-            `- ${sheetName} ${candidate.rangeAddress}: пропущено — ${result.message}`
-          );
-        } else {
+        } catch (err) {
           errors++;
           detailLines.push(
-            `- ${sheetName} ${candidate.rangeAddress}: ошибка — ${result.message}`
+            `- ${sheetName} ${candidate.rangeAddress}: ошибка — ${err.message || "неизвестная ошибка"}`
           );
         }
-      } catch (err) {
-        errors++;
-        detailLines.push(
-          `- ${sheetName} ${candidate.rangeAddress}: ошибка — ${err.message || "неизвестная ошибка"}`
-        );
       }
-    }
 
-    if (sheetClearedCount > 0) sheetsCleared++;
+      if (sheetClearedCount > 0) sheetsCleared++;
+    }
   }
 
   const summaryLines = [
@@ -2864,6 +3272,7 @@ async function clearAutoSignificance() {
   }
 
   perfLog("clearAutoSignificance", {
+    batchMode,
     tablesCleared: cleared,
     sheetsCleared,
     contextRuns,

--- a/src/taskpane/taskpane.js
+++ b/src/taskpane/taskpane.js
@@ -2396,8 +2396,10 @@ function accumulateClearDetails(aggregate, details) {
  * @param {Excel.RequestContext} context
  * @param {Excel.Worksheet} worksheetRef  Worksheet proxy for this sheet.
  * @param {Array<{rangeAddress: string}>} candidates  Tables on this sheet.
- * @returns {Promise<Array<{status, message, _clearDetails}>>}
- *   One result per candidate, in the same order.
+ * @returns {Promise<{
+ *   results: Array<{status, message, _clearDetails}>,
+ *   sheetDiags: {syncPhases, sourceRangesLoaded, targetRangesLoaded, bannerRangesLoaded}
+ * }>}
  */
 async function clearSignificanceForSheetBatched(context, worksheetRef, candidates) {
   const BANNER_UPPER_SCAN_LIMIT = 5;
@@ -2680,8 +2682,15 @@ async function clearSignificanceForSheetBatched(context, worksheetRef, candidate
   }
   await context.sync(); // Sync 4 — flushes ALL banner writes
 
-  // ── Build result array ────────────────────────────────────────────────────
-  return records.map((rec) => {
+  // ── Build result array and sheet-level diagnostics ───────────────────────
+  let targetRangesLoaded = 0;
+  let bannerRangesLoaded = 0;
+  for (const rec of records) {
+    if (rec.clearTargetRange !== null) targetRangesLoaded++;
+    if (rec.bannerScanRange !== null) bannerRangesLoaded++;
+  }
+
+  const results = records.map((rec) => {
     if (rec.status === "cleared") {
       return {
         status: "cleared",
@@ -2698,6 +2707,16 @@ async function clearSignificanceForSheetBatched(context, worksheetRef, candidate
     }
     return { status: rec.status, message: rec.message, _clearDetails: null };
   });
+
+  return {
+    results,
+    sheetDiags: {
+      syncPhases: 4,
+      sourceRangesLoaded: candidates.length,
+      targetRangesLoaded,
+      bannerRangesLoaded,
+    },
+  };
 }
 
 /**
@@ -2742,7 +2761,12 @@ async function clearAutoSignificance() {
   let cleared = 0;
   let errors = 0;
   let contextRuns = 0;
+  let sheetsCleared = 0;
   const _clearAggregate = {
+    syncPhases: 0,
+    sourceRangesLoaded: 0,
+    targetRangesLoaded: 0,
+    bannerRangesLoaded: 0,
     bodyCellsRead: 0,
     bodyCellsChanged: 0,
     bannerCellsRead: 0,
@@ -2755,22 +2779,28 @@ async function clearAutoSignificance() {
 
   for (const [sheetName, sheetCandidates] of bySheet) {
     let batchEndedAt = 0;
+    let sheetClearedCount = 0;
     contextRuns++;
 
     // Staged 4-phase batch: all N tables on this sheet in 4 syncs total.
     try {
       await Excel.run(async (context) => {
         const worksheetRef = context.workbook.worksheets.getItem(sheetName);
-        const batchResults = await clearSignificanceForSheetBatched(
+        const { results: batchResults, sheetDiags } = await clearSignificanceForSheetBatched(
           context,
           worksheetRef,
           sheetCandidates
         );
+        _clearAggregate.syncPhases += sheetDiags.syncPhases;
+        _clearAggregate.sourceRangesLoaded += sheetDiags.sourceRangesLoaded;
+        _clearAggregate.targetRangesLoaded += sheetDiags.targetRangesLoaded;
+        _clearAggregate.bannerRangesLoaded += sheetDiags.bannerRangesLoaded;
         for (let _si = 0; _si < batchResults.length; _si++) {
           const result = batchResults[_si];
           const candidate = sheetCandidates[_si];
           if (result.status === "cleared") {
             cleared++;
+            sheetClearedCount++;
             accumulateClearDetails(_clearAggregate, result._clearDetails);
           } else if (result.status === "skipped") {
             skipped++;
@@ -2793,10 +2823,12 @@ async function clearAutoSignificance() {
     for (let _fi = batchEndedAt; _fi < sheetCandidates.length; _fi++) {
       const candidate = sheetCandidates[_fi];
       contextRuns++;
+      _clearAggregate.syncPhases += 4; // per-table fallback: 4 syncs each
       try {
         const result = await clearSignificanceForRange(sheetName, candidate.rangeAddress);
         if (result.status === "cleared") {
           cleared++;
+          sheetClearedCount++;
           accumulateClearDetails(_clearAggregate, result._clearDetails);
         } else if (result.status === "skipped") {
           skipped++;
@@ -2816,6 +2848,8 @@ async function clearAutoSignificance() {
         );
       }
     }
+
+    if (sheetClearedCount > 0) sheetsCleared++;
   }
 
   const summaryLines = [
@@ -2831,10 +2865,18 @@ async function clearAutoSignificance() {
 
   perfLog("clearAutoSignificance", {
     tablesCleared: cleared,
+    sheetsCleared,
     contextRuns,
     sheetCount: bySheet.size,
-    batchSyncPhases: 4,
-    ...(cleared > 0 ? { clearAggregate: _clearAggregate } : {}),
+    syncPhases: _clearAggregate.syncPhases,
+    sourceRangesLoaded: _clearAggregate.sourceRangesLoaded,
+    targetRangesLoaded: _clearAggregate.targetRangesLoaded,
+    bannerRangesLoaded: _clearAggregate.bannerRangesLoaded,
+    bodyCellsRead: _clearAggregate.bodyCellsRead,
+    bodyCellsChanged: _clearAggregate.bodyCellsChanged,
+    bannerCellsRead: _clearAggregate.bannerCellsRead,
+    bannerCellsChanged: _clearAggregate.bannerCellsChanged,
+    bannerWriteCommands: _clearAggregate.bannerWriteCommands,
     totalMs: perfElapsed(_t0),
   });
   setStatusMessage(summaryLines.join("\n"));
@@ -3210,7 +3252,12 @@ async function clearCurrentSheetSignificance() {
   let cleared = 0;
   let errors = 0;
   let contextRuns = 0;
+  let sheetsCleared = 0;
   const _clearAggregate = {
+    syncPhases: 0,
+    sourceRangesLoaded: 0,
+    targetRangesLoaded: 0,
+    bannerRangesLoaded: 0,
     bodyCellsRead: 0,
     bodyCellsChanged: 0,
     bannerCellsRead: 0,
@@ -3223,22 +3270,28 @@ async function clearCurrentSheetSignificance() {
 
   for (const [sheetName, sheetCandidates] of bySheet) {
     let batchEndedAt = 0;
+    let sheetClearedCount = 0;
     contextRuns++;
 
     // Staged 4-phase batch: all N tables on this sheet in 4 syncs total.
     try {
       await Excel.run(async (context) => {
         const worksheetRef = context.workbook.worksheets.getItem(sheetName);
-        const batchResults = await clearSignificanceForSheetBatched(
+        const { results: batchResults, sheetDiags } = await clearSignificanceForSheetBatched(
           context,
           worksheetRef,
           sheetCandidates
         );
+        _clearAggregate.syncPhases += sheetDiags.syncPhases;
+        _clearAggregate.sourceRangesLoaded += sheetDiags.sourceRangesLoaded;
+        _clearAggregate.targetRangesLoaded += sheetDiags.targetRangesLoaded;
+        _clearAggregate.bannerRangesLoaded += sheetDiags.bannerRangesLoaded;
         for (let _si = 0; _si < batchResults.length; _si++) {
           const result = batchResults[_si];
           const candidate = sheetCandidates[_si];
           if (result.status === "cleared") {
             cleared++;
+            sheetClearedCount++;
             accumulateClearDetails(_clearAggregate, result._clearDetails);
           } else if (result.status === "skipped") {
             skipped++;
@@ -3261,10 +3314,12 @@ async function clearCurrentSheetSignificance() {
     for (let _fi = batchEndedAt; _fi < sheetCandidates.length; _fi++) {
       const candidate = sheetCandidates[_fi];
       contextRuns++;
+      _clearAggregate.syncPhases += 4; // per-table fallback: 4 syncs each
       try {
         const result = await clearSignificanceForRange(sheetName, candidate.rangeAddress);
         if (result.status === "cleared") {
           cleared++;
+          sheetClearedCount++;
           accumulateClearDetails(_clearAggregate, result._clearDetails);
         } else if (result.status === "skipped") {
           skipped++;
@@ -3284,6 +3339,8 @@ async function clearCurrentSheetSignificance() {
         );
       }
     }
+
+    if (sheetClearedCount > 0) sheetsCleared++;
   }
 
   const summaryLines = [
@@ -3299,10 +3356,18 @@ async function clearCurrentSheetSignificance() {
 
   perfLog("clearCurrentSheetSignificance", {
     tablesCleared: cleared,
+    sheetsCleared,
     contextRuns,
     sheetCount: bySheet.size,
-    batchSyncPhases: 4,
-    ...(cleared > 0 ? { clearAggregate: _clearAggregate } : {}),
+    syncPhases: _clearAggregate.syncPhases,
+    sourceRangesLoaded: _clearAggregate.sourceRangesLoaded,
+    targetRangesLoaded: _clearAggregate.targetRangesLoaded,
+    bannerRangesLoaded: _clearAggregate.bannerRangesLoaded,
+    bodyCellsRead: _clearAggregate.bodyCellsRead,
+    bodyCellsChanged: _clearAggregate.bodyCellsChanged,
+    bannerCellsRead: _clearAggregate.bannerCellsRead,
+    bannerCellsChanged: _clearAggregate.bannerCellsChanged,
+    bannerWriteCommands: _clearAggregate.bannerWriteCommands,
     totalMs: perfElapsed(_t0),
   });
   setStatusMessage(summaryLines.join("\n"));

--- a/src/taskpane/taskpane.js
+++ b/src/taskpane/taskpane.js
@@ -2238,8 +2238,8 @@ async function clearSignificanceForRangeInContext(context, sheetName, rangeAddre
       clearTargetRange = sourceRange
         .getCell(0, skipLeftCols)
         .getResizedRange(
-          sourceRange.rowCount - 1,
-          sourceRange.columnCount - skipLeftCols - 1
+          selectedValues.length - 1,
+          selectedValues[0].length - skipLeftCols - 1
         );
     } else {
       clearTargetRange = sourceRange;
@@ -2380,14 +2380,334 @@ function accumulateClearDetails(aggregate, details) {
 }
 
 /**
+ * Staged 4-phase Clear pipeline for all tables on one sheet.
+ *
+ * Reduces sync count from 4×N (per-table serial) to 4 (whole-sheet batch) by
+ * loading and writing all N tables across four single round-trips:
+ *
+ *   Phase 1 — sync 1: load source range values+text for every table.
+ *   Phase 2 — sync 2: compute clear-target ranges in JS; load values+format+dims.
+ *   Phase 3 — sync 3: queue body writes; load banner scan text for every table.
+ *                     Single flush covers all body writes + all banner reads.
+ *   Phase 4 — sync 4: diff banner texts, queue banner writes, final flush.
+ *
+ * Must be called inside an Excel.run callback (shared context, no nested run).
+ *
+ * @param {Excel.RequestContext} context
+ * @param {Excel.Worksheet} worksheetRef  Worksheet proxy for this sheet.
+ * @param {Array<{rangeAddress: string}>} candidates  Tables on this sheet.
+ * @returns {Promise<Array<{status, message, _clearDetails}>>}
+ *   One result per candidate, in the same order.
+ */
+async function clearSignificanceForSheetBatched(context, worksheetRef, candidates) {
+  const BANNER_UPPER_SCAN_LIMIT = 5;
+
+  // ── Per-table record ──────────────────────────────────────────────────────
+  const records = candidates.map((c) => ({
+    rangeAddress: c.rangeAddress,
+    status: "pending", // "pending" | "skipped" | "cleared"
+    message: "",
+    // Phase 1
+    sourceRange: null,
+    // Phase 2 inputs (computed in JS after sync 1)
+    clearTargetRange: null,
+    // Phase 2 outputs (loaded after sync 2)
+    knownDims: null, // { rowIndex, columnIndex, columnCount }
+    // Phase 3 — body
+    bodyCellsRead: 0,
+    bodyCellsChanged: 0,
+    bodyHasValueChange: false,
+    bodyHasFormatChange: false,
+    nextValues: null,
+    nextNumberFormats: null,
+    // Phase 3 — banner scan setup
+    bannerScanRange: null,
+    bannerScanRowCount: 0,
+    bannerScanColCount: 0,
+    bannerStartColIndex: 0,
+    bannerStartRowAbs: 0,
+    // Phase 4 — banner results
+    bannerCellsRead: 0,
+    bannerCellsChanged: 0,
+    bannerWriteCommands: 0,
+  }));
+
+  // ══════════════════════════════════════════════════════════════════════════
+  // PHASE 1 — Load source range values+text for every table
+  // ══════════════════════════════════════════════════════════════════════════
+  for (const rec of records) {
+    const sr = worksheetRef.getRange(rec.rangeAddress);
+    sr.load(["values", "text"]);
+    rec.sourceRange = sr;
+  }
+  await context.sync(); // Sync 1
+
+  // ══════════════════════════════════════════════════════════════════════════
+  // PHASE 2 — Compute clear-target ranges in JS; load values+format+dims
+  // ══════════════════════════════════════════════════════════════════════════
+  for (const rec of records) {
+    if (rec.status !== "pending") continue;
+
+    const selectedValues = rec.sourceRange.values;
+    const selectedText = rec.sourceRange.text;
+
+    if (
+      !selectedValues ||
+      selectedValues.length < 1 ||
+      !selectedValues[0] ||
+      selectedValues[0].length < 1
+    ) {
+      rec.status = "skipped";
+      rec.message = "нет данных в диапазоне";
+      continue;
+    }
+
+    const cleanedValues = removeSignificanceMarkersFromMatrix(selectedValues);
+    const normalized = normalizeSelectedRange(cleanedValues, selectedText);
+
+    if (normalized.normalizationNeeded && !normalized.normalizationApplied) {
+      const codes =
+        normalized.blockingReasons && normalized.blockingReasons.length > 0
+          ? ` [${normalized.blockingReasons.join(", ")}]`
+          : "";
+      rec.status = "skipped";
+      rec.message = `${normalized.blockingMessage}${codes}`;
+      continue;
+    }
+
+    let clearTargetRange;
+
+    if (normalized.normalizationNeeded && normalized.normalizationApplied) {
+      const bodyRowCount = normalized.valuesForCalculation.length;
+      let bodyColCount = normalized.valuesForCalculation[0].length;
+      let effectiveClearColOffset = normalized.dataColOffset;
+      let textForLeadingEmptyCheck = normalized.textForCalculation;
+
+      if (normalized.dataColOffset === 0) {
+        const additionalLabelCols = detectEmbeddedLabelColumns(normalized.valuesForCalculation);
+        if (additionalLabelCols > 0) {
+          effectiveClearColOffset += additionalLabelCols;
+          bodyColCount -= additionalLabelCols;
+          textForLeadingEmptyCheck = normalized.textForCalculation.map((row) =>
+            row.slice(additionalLabelCols)
+          );
+        }
+      }
+
+      const clearLeadingEmptyCols = detectLeadingEmptyColumns(textForLeadingEmptyCheck);
+      if (clearLeadingEmptyCols > 0) {
+        bodyColCount -= clearLeadingEmptyCols;
+        effectiveClearColOffset += clearLeadingEmptyCols;
+      }
+
+      if (bodyRowCount < 1 || bodyColCount < 1) {
+        rec.status = "skipped";
+        rec.message = "нет данных после нормализации";
+        continue;
+      }
+
+      clearTargetRange = rec.sourceRange
+        .getCell(normalized.dataRowOffset, effectiveClearColOffset)
+        .getResizedRange(bodyRowCount - 1, bodyColCount - 1);
+    } else {
+      // Pass-through: use JS dimensions — avoids loading sourceRange.rowCount/columnCount.
+      const rowCount = selectedValues.length;
+      const colCount = selectedValues[0].length;
+      const embeddedLabelCols = detectEmbeddedLabelColumns(cleanedValues);
+      const leadingBlankCols =
+        embeddedLabelCols === 0 ? detectLeadingEmptyColumns(selectedText) : 0;
+      const skipLeftCols = embeddedLabelCols > 0 ? embeddedLabelCols : leadingBlankCols;
+
+      if (skipLeftCols > 0) {
+        clearTargetRange = rec.sourceRange
+          .getCell(0, skipLeftCols)
+          .getResizedRange(rowCount - 1, colCount - skipLeftCols - 1);
+      } else {
+        clearTargetRange = rec.sourceRange;
+      }
+    }
+
+    rec.clearTargetRange = clearTargetRange;
+    clearTargetRange.load(["values", "numberFormat", "rowIndex", "columnIndex", "columnCount"]);
+  }
+  await context.sync(); // Sync 2
+
+  // ══════════════════════════════════════════════════════════════════════════
+  // PHASE 3 — Body cleanup + queue writes + set up banner reads
+  // ══════════════════════════════════════════════════════════════════════════
+  for (const rec of records) {
+    if (rec.status !== "pending") continue;
+
+    const targetValues = rec.clearTargetRange.values;
+    const targetNumberFormats = rec.clearTargetRange.numberFormat;
+
+    rec.knownDims = {
+      rowIndex: rec.clearTargetRange.rowIndex,
+      columnIndex: rec.clearTargetRange.columnIndex,
+      columnCount: rec.clearTargetRange.columnCount,
+    };
+
+    const nextValues = [];
+    const nextNumberFormats = [];
+    let bodyCellsChanged = 0;
+    let bodyHasValueChange = false;
+    let bodyHasFormatChange = false;
+
+    for (let r = 0; r < targetValues.length; r++) {
+      const valueRow = [];
+      const formatRow = [];
+
+      for (let c = 0; c < targetValues[r].length; c++) {
+        const rawValue = targetValues[r][c];
+        const currentFormat = targetNumberFormats[r][c];
+
+        if (typeof rawValue === "number") {
+          valueRow.push(rawValue);
+          formatRow.push(currentFormat);
+          continue;
+        }
+
+        const cleanedText = removeSignificanceMarkersFromText(rawValue);
+        const resolved = resolveNumericOutput(cleanedText);
+
+        if (resolved !== null) {
+          if (resolved.value !== rawValue) bodyHasValueChange = true;
+          if (resolved.format !== currentFormat) bodyHasFormatChange = true;
+          if (resolved.value !== rawValue || resolved.format !== currentFormat) bodyCellsChanged++;
+          valueRow.push(resolved.value);
+          formatRow.push(resolved.format);
+        } else {
+          if (cleanedText !== rawValue) {
+            bodyHasValueChange = true;
+            bodyCellsChanged++;
+          }
+          valueRow.push(cleanedText);
+          formatRow.push("@");
+        }
+      }
+
+      nextValues.push(valueRow);
+      nextNumberFormats.push(formatRow);
+    }
+
+    rec.bodyCellsRead = targetValues.length * (targetValues[0] ? targetValues[0].length : 0);
+    rec.bodyCellsChanged = bodyCellsChanged;
+    rec.bodyHasValueChange = bodyHasValueChange;
+    rec.bodyHasFormatChange = bodyHasFormatChange;
+    rec.nextValues = nextValues;
+    rec.nextNumberFormats = nextNumberFormats;
+
+    // Queue body writes (only when something actually changed).
+    if (bodyHasFormatChange) rec.clearTargetRange.numberFormat = nextNumberFormats;
+    if (bodyHasValueChange) rec.clearTargetRange.values = nextValues;
+    rec.clearTargetRange.format.font.bold = false;
+    rec.clearTargetRange.format.fill.clear();
+
+    // Queue banner scan load (uses sheet row index, so no banner sync needed).
+    const { rowIndex: targetStartRowIndex, columnIndex: targetStartColumnIndex, columnCount: targetColumnCount } =
+      rec.knownDims;
+
+    if (targetStartRowIndex > 0 && targetColumnCount >= 1) {
+      const totalScanRowCount = Math.min(BANNER_UPPER_SCAN_LIMIT + 1, targetStartRowIndex);
+      if (totalScanRowCount >= 1) {
+        const bannerScanRange = worksheetRef.getRangeByIndexes(
+          targetStartRowIndex - totalScanRowCount,
+          targetStartColumnIndex,
+          totalScanRowCount,
+          targetColumnCount
+        );
+        bannerScanRange.load("text");
+        rec.bannerScanRange = bannerScanRange;
+        rec.bannerScanRowCount = totalScanRowCount;
+        rec.bannerScanColCount = targetColumnCount;
+        rec.bannerStartColIndex = targetStartColumnIndex;
+        rec.bannerStartRowAbs = targetStartRowIndex - totalScanRowCount;
+      }
+    }
+  }
+  await context.sync(); // Sync 3 — flushes ALL body writes; reads ALL banner scan texts
+
+  // ══════════════════════════════════════════════════════════════════════════
+  // PHASE 4 — Diff banner texts; queue banner writes; final flush
+  // ══════════════════════════════════════════════════════════════════════════
+  for (const rec of records) {
+    if (rec.status !== "pending") continue;
+
+    rec.status = "cleared"; // body writes already flushed in sync 3
+
+    if (!rec.bannerScanRange) continue;
+
+    const bannerTexts = rec.bannerScanRange.text;
+    const { bannerScanRowCount, bannerScanColCount, bannerStartColIndex, bannerStartRowAbs } = rec;
+
+    rec.bannerCellsRead = bannerScanRowCount * bannerScanColCount;
+
+    const writesByRow = new Map();
+    let cellsChanged = 0;
+
+    for (let r = 0; r < bannerScanRowCount; r++) {
+      const row = bannerTexts[r] || [];
+      for (let c = 0; c < bannerScanColCount; c++) {
+        const cur = row[c] || "";
+        const nxt = cur && getTrailingBannerMarker(cur) ? removeTrailingBannerMarker(cur) : cur;
+        if (cur === nxt) continue;
+        const absRow = bannerStartRowAbs + r;
+        const absCol = bannerStartColIndex + c;
+        if (!writesByRow.has(absRow)) writesByRow.set(absRow, []);
+        writesByRow.get(absRow).push({ colIndex: absCol, text: nxt });
+        cellsChanged++;
+      }
+    }
+
+    rec.bannerCellsChanged = cellsChanged;
+
+    if (cellsChanged > 0) {
+      let writeCommands = 0;
+      for (const [rowIndex, items] of writesByRow) {
+        items.sort((a, b) => a.colIndex - b.colIndex);
+        let i = 0;
+        while (i < items.length) {
+          let j = i;
+          while (j + 1 < items.length && items[j + 1].colIndex === items[j].colIndex + 1) j++;
+          const texts = items.slice(i, j + 1).map((x) => x.text);
+          worksheetRef.getRangeByIndexes(rowIndex, items[i].colIndex, 1, j - i + 1).values = [texts];
+          writeCommands++;
+          i = j + 1;
+        }
+      }
+      rec.bannerWriteCommands = writeCommands;
+    }
+  }
+  await context.sync(); // Sync 4 — flushes ALL banner writes
+
+  // ── Build result array ────────────────────────────────────────────────────
+  return records.map((rec) => {
+    if (rec.status === "cleared") {
+      return {
+        status: "cleared",
+        message: "очищено",
+        _clearDetails: {
+          bodyCellsRead: rec.bodyCellsRead,
+          bodyCellsChanged: rec.bodyCellsChanged,
+          bannerCellsRead: rec.bannerCellsRead,
+          bannerCellsChanged: rec.bannerCellsChanged,
+          bannerWriteCommands: rec.bannerWriteCommands,
+          totalMs: 0,
+        },
+      };
+    }
+    return { status: rec.status, message: rec.message, _clearDetails: null };
+  });
+}
+
+/**
  * Auto-clear: removes significance markers from all "available" inventory
  * candidates in the workbook.
  *
- * Candidates are grouped by sheet so all tables on the same worksheet are
- * processed inside a single Excel.run context, amortising per-context
- * initialisation overhead.  If a sync error corrupts the shared context for a
- * sheet, remaining tables on that sheet fall back to per-table
- * clearSignificanceForRange (each with its own Excel.run).
+ * Candidates are grouped by sheet. Each sheet's tables are processed in a
+ * staged 4-sync batch (clearSignificanceForSheetBatched), reducing total
+ * sync count from 4×N_tables to 4×N_sheets.  If the batch fails the full
+ * sheet falls back to per-table clearSignificanceForRange.
  */
 async function clearAutoSignificance() {
   const _t0 = perfNow();
@@ -2430,52 +2750,44 @@ async function clearAutoSignificance() {
     bannerWriteCommands: 0,
   };
 
-  // Group by sheet so each sheet's tables share one Excel.run context.
+  // Group by sheet; each sheet is cleared in one staged 4-sync batch.
   const bySheet = groupCandidatesBySheet(eligible);
 
   for (const [sheetName, sheetCandidates] of bySheet) {
     let batchEndedAt = 0;
     contextRuns++;
 
-    // Attempt to clear all tables on this sheet in a single Excel.run.
+    // Staged 4-phase batch: all N tables on this sheet in 4 syncs total.
     try {
       await Excel.run(async (context) => {
-        for (let _si = 0; _si < sheetCandidates.length; _si++) {
+        const worksheetRef = context.workbook.worksheets.getItem(sheetName);
+        const batchResults = await clearSignificanceForSheetBatched(
+          context,
+          worksheetRef,
+          sheetCandidates
+        );
+        for (let _si = 0; _si < batchResults.length; _si++) {
+          const result = batchResults[_si];
           const candidate = sheetCandidates[_si];
-          try {
-            const result = await clearSignificanceForRangeInContext(
-              context,
-              sheetName,
-              candidate.rangeAddress
+          if (result.status === "cleared") {
+            cleared++;
+            accumulateClearDetails(_clearAggregate, result._clearDetails);
+          } else if (result.status === "skipped") {
+            skipped++;
+            detailLines.push(
+              `- ${sheetName} ${candidate.rangeAddress}: пропущено — ${result.message}`
             );
-            if (result.status === "cleared") {
-              cleared++;
-              accumulateClearDetails(_clearAggregate, result._clearDetails);
-            } else if (result.status === "skipped") {
-              skipped++;
-              detailLines.push(
-                `- ${sheetName} ${candidate.rangeAddress}: пропущено — ${result.message}`
-              );
-            } else {
-              errors++;
-              detailLines.push(
-                `- ${sheetName} ${candidate.rangeAddress}: ошибка — ${result.message}`
-              );
-            }
-            batchEndedAt = _si + 1;
-          } catch (err) {
+          } else {
             errors++;
             detailLines.push(
-              `- ${sheetName} ${candidate.rangeAddress}: ошибка — ${err.message || "неизвестная ошибка"}`
+              `- ${sheetName} ${candidate.rangeAddress}: ошибка — ${result.message}`
             );
-            batchEndedAt = _si + 1;
-            throw err; // shared context may be corrupted; exit batch
           }
         }
         batchEndedAt = sheetCandidates.length;
       });
     } catch (_batchErr) {
-      // Shared context aborted; fall back to per-table for any remaining candidates.
+      // Staged batch failed; fall back to per-table for all candidates on this sheet.
     }
 
     for (let _fi = batchEndedAt; _fi < sheetCandidates.length; _fi++) {
@@ -2521,6 +2833,7 @@ async function clearAutoSignificance() {
     tablesCleared: cleared,
     contextRuns,
     sheetCount: bySheet.size,
+    batchSyncPhases: 4,
     ...(cleared > 0 ? { clearAggregate: _clearAggregate } : {}),
     totalMs: perfElapsed(_t0),
   });
@@ -2905,52 +3218,44 @@ async function clearCurrentSheetSignificance() {
     bannerWriteCommands: 0,
   };
 
-  // Group by sheet — for the sheet-scoped flow this is typically one sheet,
-  // but grouping keeps the logic consistent with clearAutoSignificance.
+  // Group by sheet; each sheet is cleared in one staged 4-sync batch.
   const bySheet = groupCandidatesBySheet(eligible);
 
   for (const [sheetName, sheetCandidates] of bySheet) {
     let batchEndedAt = 0;
     contextRuns++;
 
+    // Staged 4-phase batch: all N tables on this sheet in 4 syncs total.
     try {
       await Excel.run(async (context) => {
-        for (let _si = 0; _si < sheetCandidates.length; _si++) {
+        const worksheetRef = context.workbook.worksheets.getItem(sheetName);
+        const batchResults = await clearSignificanceForSheetBatched(
+          context,
+          worksheetRef,
+          sheetCandidates
+        );
+        for (let _si = 0; _si < batchResults.length; _si++) {
+          const result = batchResults[_si];
           const candidate = sheetCandidates[_si];
-          try {
-            const result = await clearSignificanceForRangeInContext(
-              context,
-              sheetName,
-              candidate.rangeAddress
+          if (result.status === "cleared") {
+            cleared++;
+            accumulateClearDetails(_clearAggregate, result._clearDetails);
+          } else if (result.status === "skipped") {
+            skipped++;
+            detailLines.push(
+              `- ${sheetName} ${candidate.rangeAddress}: пропущено — ${result.message}`
             );
-            if (result.status === "cleared") {
-              cleared++;
-              accumulateClearDetails(_clearAggregate, result._clearDetails);
-            } else if (result.status === "skipped") {
-              skipped++;
-              detailLines.push(
-                `- ${sheetName} ${candidate.rangeAddress}: пропущено — ${result.message}`
-              );
-            } else {
-              errors++;
-              detailLines.push(
-                `- ${sheetName} ${candidate.rangeAddress}: ошибка — ${result.message}`
-              );
-            }
-            batchEndedAt = _si + 1;
-          } catch (err) {
+          } else {
             errors++;
             detailLines.push(
-              `- ${sheetName} ${candidate.rangeAddress}: ошибка — ${err.message || "неизвестная ошибка"}`
+              `- ${sheetName} ${candidate.rangeAddress}: ошибка — ${result.message}`
             );
-            batchEndedAt = _si + 1;
-            throw err;
           }
         }
         batchEndedAt = sheetCandidates.length;
       });
     } catch (_batchErr) {
-      // Shared context aborted; fall back to per-table for any remaining candidates.
+      // Staged batch failed; fall back to per-table for all candidates on this sheet.
     }
 
     for (let _fi = batchEndedAt; _fi < sheetCandidates.length; _fi++) {
@@ -2996,6 +3301,7 @@ async function clearCurrentSheetSignificance() {
     tablesCleared: cleared,
     contextRuns,
     sheetCount: bySheet.size,
+    batchSyncPhases: 4,
     ...(cleared > 0 ? { clearAggregate: _clearAggregate } : {}),
     totalMs: perfElapsed(_t0),
   });

--- a/src/taskpane/taskpane.js
+++ b/src/taskpane/taskpane.js
@@ -2143,207 +2143,251 @@ async function clearAutoCurrentTableSignificance() {
 }
 
 /**
+ * Inner clear-significance pipeline for a single named range, using a
+ * caller-supplied Office.js RequestContext.
+ *
+ * Extracted so workbook/sheet batch clears can share one Excel.run context
+ * across all tables on the same worksheet, amortising per-context initialisation
+ * overhead.  Callers that need a self-contained execution unit use
+ * clearSignificanceForRange below, which wraps this in its own Excel.run.
+ *
+ * Returns { status, message, _clearDetails }.
+ * status: "cleared" | "skipped"
+ * _clearDetails is always populated on a "cleared" result; null on "skipped".
+ */
+async function clearSignificanceForRangeInContext(context, sheetName, rangeAddress) {
+  const _t0 = perfNow();
+  const worksheet = context.workbook.worksheets.getItem(sheetName);
+  const sourceRange = worksheet.getRange(rangeAddress);
+
+  sourceRange.load(["values", "text"]);
+
+  await context.sync();
+
+  const selectedValues = sourceRange.values;
+  const selectedText = sourceRange.text;
+
+  if (!selectedValues || selectedValues.length < 1 || !selectedValues[0] || selectedValues[0].length < 1) {
+    return { status: "skipped", message: "нет данных в диапазоне", _clearDetails: null };
+  }
+
+  const cleanedValues = removeSignificanceMarkersFromMatrix(selectedValues);
+  const normalized = normalizeSelectedRange(cleanedValues, selectedText);
+
+  if (normalized.normalizationNeeded && !normalized.normalizationApplied) {
+    const codes =
+      normalized.blockingReasons && normalized.blockingReasons.length > 0
+        ? ` [${normalized.blockingReasons.join(", ")}]`
+        : "";
+    return { status: "skipped", message: `${normalized.blockingMessage}${codes}`, _clearDetails: null };
+  }
+
+  let clearTargetRange;
+
+  if (normalized.normalizationNeeded && normalized.normalizationApplied) {
+    const bodyRowCount = normalized.valuesForCalculation.length;
+    let bodyColCount = normalized.valuesForCalculation[0].length;
+    let effectiveClearColOffset = normalized.dataColOffset;
+    let textForLeadingEmptyCheck = normalized.textForCalculation;
+
+    // Secondary embedded-label-column check (mirrors interpretSelectedRange
+    // State 2 / clearSignificanceFromSelection).  Protects auto-clear ranges
+    // whose label column has mixed text + numeric-looking values from being
+    // overwritten when normalizeSelectedRange leaves col[0] inside the body.
+    if (normalized.dataColOffset === 0) {
+      const additionalLabelCols = detectEmbeddedLabelColumns(
+        normalized.valuesForCalculation
+      );
+      if (additionalLabelCols > 0) {
+        effectiveClearColOffset += additionalLabelCols;
+        bodyColCount -= additionalLabelCols;
+        textForLeadingEmptyCheck = normalized.textForCalculation.map(
+          (row) => row.slice(additionalLabelCols)
+        );
+      }
+    }
+
+    const clearLeadingEmptyCols = detectLeadingEmptyColumns(textForLeadingEmptyCheck);
+    if (clearLeadingEmptyCols > 0) {
+      bodyColCount -= clearLeadingEmptyCols;
+      effectiveClearColOffset += clearLeadingEmptyCols;
+    }
+
+    if (bodyRowCount < 1 || bodyColCount < 1) {
+      return { status: "skipped", message: "нет данных после нормализации", _clearDetails: null };
+    }
+
+    clearTargetRange = sourceRange
+      .getCell(normalized.dataRowOffset, effectiveClearColOffset)
+      .getResizedRange(bodyRowCount - 1, bodyColCount - 1);
+  } else {
+    // Pass-through mirrors interpretSelectedRange / clearSignificanceFromSelection:
+    // prefer detectEmbeddedLabelColumns to keep row labels out of the clear
+    // target on wide tables; fall back to detectLeadingEmptyColumns otherwise.
+    const embeddedLabelColsForClear = detectEmbeddedLabelColumns(cleanedValues);
+    const leadingBlankColsForClear =
+      embeddedLabelColsForClear === 0
+        ? detectLeadingEmptyColumns(selectedText)
+        : 0;
+    const skipLeftCols =
+      embeddedLabelColsForClear > 0
+        ? embeddedLabelColsForClear
+        : leadingBlankColsForClear;
+
+    if (skipLeftCols > 0) {
+      clearTargetRange = sourceRange
+        .getCell(0, skipLeftCols)
+        .getResizedRange(
+          sourceRange.rowCount - 1,
+          sourceRange.columnCount - skipLeftCols - 1
+        );
+    } else {
+      clearTargetRange = sourceRange;
+    }
+  }
+
+  clearTargetRange.load(["values", "numberFormat", "rowIndex", "columnIndex", "columnCount"]);
+
+  await context.sync();
+
+  const targetValues = clearTargetRange.values;
+  const targetNumberFormats = clearTargetRange.numberFormat;
+  const _knownDims = {
+    rowIndex: clearTargetRange.rowIndex,
+    columnIndex: clearTargetRange.columnIndex,
+    columnCount: clearTargetRange.columnCount,
+  };
+
+  const nextValues = [];
+  const nextNumberFormats = [];
+  let bodyCellsChanged = 0;
+  let bodyHasValueChange = false;
+  let bodyHasFormatChange = false;
+
+  for (let rowIndex = 0; rowIndex < targetValues.length; rowIndex++) {
+    const valueRow = [];
+    const formatRow = [];
+
+    for (let columnIndex = 0; columnIndex < targetValues[rowIndex].length; columnIndex++) {
+      const rawValue = targetValues[rowIndex][columnIndex];
+      const currentFormat = targetNumberFormats[rowIndex][columnIndex];
+
+      if (typeof rawValue === "number") {
+        valueRow.push(rawValue);
+        formatRow.push(currentFormat);
+        continue;
+      }
+
+      const cleanedText = removeSignificanceMarkersFromText(rawValue);
+      const resolved = resolveNumericOutput(cleanedText);
+
+      if (resolved !== null) {
+        if (resolved.value !== rawValue) bodyHasValueChange = true;
+        if (resolved.format !== currentFormat) bodyHasFormatChange = true;
+        if (resolved.value !== rawValue || resolved.format !== currentFormat) bodyCellsChanged++;
+        valueRow.push(resolved.value);
+        formatRow.push(resolved.format);
+      } else {
+        if (cleanedText !== rawValue) { bodyHasValueChange = true; bodyCellsChanged++; }
+        valueRow.push(cleanedText);
+        formatRow.push("@");
+      }
+    }
+
+    nextValues.push(valueRow);
+    nextNumberFormats.push(formatRow);
+  }
+
+  // Only write body data when something actually changed, avoiding a full
+  // matrix write on a re-clear of an already-clean workbook.
+  if (bodyHasFormatChange) clearTargetRange.numberFormat = nextNumberFormats;
+  if (bodyHasValueChange) clearTargetRange.values = nextValues;
+
+  clearTargetRange.format.font.bold = false;
+  clearTargetRange.format.fill.clear();
+
+  // No body sync here — deferred to the banner read sync inside
+  // clearBannerMarkerUpdatesForRange, which flushes all queued writes.
+  const bannerDetails = await clearBannerMarkerUpdatesForRange(context, clearTargetRange, _knownDims);
+
+  await context.sync();
+
+  const bodyCellsRead = targetValues.length * (targetValues[0] ? targetValues[0].length : 0);
+
+  return {
+    status: "cleared",
+    message: "очищено",
+    _clearDetails: {
+      bodyCellsRead,
+      bodyCellsChanged,
+      bannerCellsRead: bannerDetails ? bannerDetails.cellsRead : 0,
+      bannerCellsChanged: bannerDetails ? bannerDetails.cellsChanged : 0,
+      bannerWriteCommands: bannerDetails ? bannerDetails.writeCommands : 0,
+      totalMs: perfElapsed(_t0),
+    },
+  };
+}
+
+/**
  * Clears significance markers for a single named range on a named sheet.
  *
- * Mirrors the clear path of clearSignificanceFromSelection() without touching
- * the Excel selection UI state. Returns a compact result object so the caller
- * can aggregate per-table outcomes.
+ * Thin wrapper around clearSignificanceForRangeInContext that provides its own
+ * Excel.run context.  Used by clearAutoCurrentTableSignificance and as a
+ * per-table fallback when the shared-context batch in sheet/workbook clear
+ * encounters an Office.js error that corrupts the shared context.
  *
- * Returns { status, message }.
+ * Returns { status, message, _clearDetails }.
  * status: "cleared" | "skipped" | "error"
  */
 async function clearSignificanceForRange(sheetName, rangeAddress) {
   const _t0 = perfNow();
-  return await Excel.run(async (context) => {
-    const worksheet = context.workbook.worksheets.getItem(sheetName);
-    const sourceRange = worksheet.getRange(rangeAddress);
-
-    sourceRange.load(["values", "text"]);
-
-    await context.sync();
-
-    const selectedValues = sourceRange.values;
-    const selectedText = sourceRange.text;
-
-    if (!selectedValues || selectedValues.length < 1 || !selectedValues[0] || selectedValues[0].length < 1) {
-      return { status: "skipped", message: "нет данных в диапазоне" };
-    }
-
-    const cleanedValues = removeSignificanceMarkersFromMatrix(selectedValues);
-    const normalized = normalizeSelectedRange(cleanedValues, selectedText);
-
-    if (normalized.normalizationNeeded && !normalized.normalizationApplied) {
-      const codes =
-        normalized.blockingReasons && normalized.blockingReasons.length > 0
-          ? ` [${normalized.blockingReasons.join(", ")}]`
-          : "";
-      return { status: "skipped", message: `${normalized.blockingMessage}${codes}` };
-    }
-
-    let clearTargetRange;
-
-    if (normalized.normalizationNeeded && normalized.normalizationApplied) {
-      const bodyRowCount = normalized.valuesForCalculation.length;
-      let bodyColCount = normalized.valuesForCalculation[0].length;
-      let effectiveClearColOffset = normalized.dataColOffset;
-      let textForLeadingEmptyCheck = normalized.textForCalculation;
-
-      // Secondary embedded-label-column check (mirrors interpretSelectedRange
-      // State 2 / clearSignificanceFromSelection).  Protects auto-clear ranges
-      // whose label column has mixed text + numeric-looking values from being
-      // overwritten when normalizeSelectedRange leaves col[0] inside the body.
-      if (normalized.dataColOffset === 0) {
-        const additionalLabelCols = detectEmbeddedLabelColumns(
-          normalized.valuesForCalculation
-        );
-        if (additionalLabelCols > 0) {
-          effectiveClearColOffset += additionalLabelCols;
-          bodyColCount -= additionalLabelCols;
-          textForLeadingEmptyCheck = normalized.textForCalculation.map(
-            (row) => row.slice(additionalLabelCols)
-          );
-        }
-      }
-
-      const clearLeadingEmptyCols = detectLeadingEmptyColumns(textForLeadingEmptyCheck);
-      if (clearLeadingEmptyCols > 0) {
-        bodyColCount -= clearLeadingEmptyCols;
-        effectiveClearColOffset += clearLeadingEmptyCols;
-      }
-
-      if (bodyRowCount < 1 || bodyColCount < 1) {
-        return { status: "skipped", message: "нет данных после нормализации" };
-      }
-
-      clearTargetRange = sourceRange
-        .getCell(normalized.dataRowOffset, effectiveClearColOffset)
-        .getResizedRange(bodyRowCount - 1, bodyColCount - 1);
-    } else {
-      // Pass-through mirrors interpretSelectedRange / clearSignificanceFromSelection:
-      // prefer detectEmbeddedLabelColumns to keep row labels out of the clear
-      // target on wide tables; fall back to detectLeadingEmptyColumns otherwise.
-      const embeddedLabelColsForClear = detectEmbeddedLabelColumns(cleanedValues);
-      const leadingBlankColsForClear =
-        embeddedLabelColsForClear === 0
-          ? detectLeadingEmptyColumns(selectedText)
-          : 0;
-      const skipLeftCols =
-        embeddedLabelColsForClear > 0
-          ? embeddedLabelColsForClear
-          : leadingBlankColsForClear;
-
-      if (skipLeftCols > 0) {
-        clearTargetRange = sourceRange
-          .getCell(0, skipLeftCols)
-          .getResizedRange(
-            sourceRange.rowCount - 1,
-            sourceRange.columnCount - skipLeftCols - 1
-          );
-      } else {
-        clearTargetRange = sourceRange;
-      }
-    }
-
-    clearTargetRange.load(["values", "numberFormat", "rowIndex", "columnIndex", "columnCount"]);
-
-    await context.sync();
-
-    const targetValues = clearTargetRange.values;
-    const targetNumberFormats = clearTargetRange.numberFormat;
-    const _knownDims = {
-      rowIndex: clearTargetRange.rowIndex,
-      columnIndex: clearTargetRange.columnIndex,
-      columnCount: clearTargetRange.columnCount,
-    };
-
-    const nextValues = [];
-    const nextNumberFormats = [];
-    let bodyCellsChanged = 0;
-    let bodyHasValueChange = false;
-    let bodyHasFormatChange = false;
-
-    for (let rowIndex = 0; rowIndex < targetValues.length; rowIndex++) {
-      const valueRow = [];
-      const formatRow = [];
-
-      for (let columnIndex = 0; columnIndex < targetValues[rowIndex].length; columnIndex++) {
-        const rawValue = targetValues[rowIndex][columnIndex];
-        const currentFormat = targetNumberFormats[rowIndex][columnIndex];
-
-        if (typeof rawValue === "number") {
-          valueRow.push(rawValue);
-          formatRow.push(currentFormat);
-          continue;
-        }
-
-        const cleanedText = removeSignificanceMarkersFromText(rawValue);
-        const resolved = resolveNumericOutput(cleanedText);
-
-        if (resolved !== null) {
-          if (resolved.value !== rawValue) bodyHasValueChange = true;
-          if (resolved.format !== currentFormat) bodyHasFormatChange = true;
-          if (resolved.value !== rawValue || resolved.format !== currentFormat) bodyCellsChanged++;
-          valueRow.push(resolved.value);
-          formatRow.push(resolved.format);
-        } else {
-          if (cleanedText !== rawValue) { bodyHasValueChange = true; bodyCellsChanged++; }
-          valueRow.push(cleanedText);
-          formatRow.push("@");
-        }
-      }
-
-      nextValues.push(valueRow);
-      nextNumberFormats.push(formatRow);
-    }
-
-    // Only write body data when something actually changed, avoiding a full
-    // matrix write on a re-clear of an already-clean workbook.
-    if (bodyHasFormatChange) clearTargetRange.numberFormat = nextNumberFormats;
-    if (bodyHasValueChange) clearTargetRange.values = nextValues;
-
-    clearTargetRange.format.font.bold = false;
-    clearTargetRange.format.fill.clear();
-
-    // No body sync here — deferred to the banner read sync inside
-    // clearBannerMarkerUpdatesForRange, which flushes all queued writes.
-    const bannerDetails = await clearBannerMarkerUpdatesForRange(context, clearTargetRange, _knownDims);
-
-    await context.sync();
-
-    const bodyCellsRead = targetValues.length * (targetValues[0] ? targetValues[0].length : 0);
+  const result = await Excel.run((context) =>
+    clearSignificanceForRangeInContext(context, sheetName, rangeAddress)
+  );
+  if (result._clearDetails) {
     perfLog("clearSignificanceForRange", {
       rangeAddress,
-      bodyCellsRead,
-      bodyCellsChanged,
-      bodyHasValueChange,
-      bodyHasFormatChange,
-      bannerDetails: bannerDetails || null,
+      ...result._clearDetails,
       totalMs: perfElapsed(_t0),
     });
+  }
+  return result;
+}
 
-    return {
-      status: "cleared",
-      message: "очищено",
-      ...(perfEnabled() ? {
-        _clearDetails: {
-          bodyCellsRead,
-          bodyCellsChanged,
-          bannerCellsRead: bannerDetails ? bannerDetails.cellsRead : 0,
-          bannerCellsChanged: bannerDetails ? bannerDetails.cellsChanged : 0,
-          bannerWriteCommands: bannerDetails ? bannerDetails.writeCommands : 0,
-          totalMs: perfElapsed(_t0),
-        },
-      } : {}),
-    };
-  });
+/**
+ * Groups an array of candidate objects by their sheetName property.
+ * Returns a Map<sheetName, candidate[]> preserving insertion order.
+ */
+function groupCandidatesBySheet(candidates) {
+  const map = new Map();
+  for (const c of candidates) {
+    if (!map.has(c.sheetName)) map.set(c.sheetName, []);
+    map.get(c.sheetName).push(c);
+  }
+  return map;
+}
+
+/**
+ * Accumulates _clearDetails from a single table result into a running aggregate.
+ */
+function accumulateClearDetails(aggregate, details) {
+  if (!aggregate || !details) return;
+  aggregate.bodyCellsRead += details.bodyCellsRead || 0;
+  aggregate.bodyCellsChanged += details.bodyCellsChanged || 0;
+  aggregate.bannerCellsRead += details.bannerCellsRead || 0;
+  aggregate.bannerCellsChanged += details.bannerCellsChanged || 0;
+  aggregate.bannerWriteCommands += details.bannerWriteCommands || 0;
 }
 
 /**
  * Auto-clear: removes significance markers from all "available" inventory
  * candidates in the workbook.
  *
- * Mirrors runAutoSignificance() but calls clearSignificanceForRange() instead
- * of running the significance pipeline.
+ * Candidates are grouped by sheet so all tables on the same worksheet are
+ * processed inside a single Excel.run context, amortising per-context
+ * initialisation overhead.  If a sync error corrupts the shared context for a
+ * sheet, remaining tables on that sheet fall back to per-table
+ * clearSignificanceForRange (each with its own Excel.run).
  */
 async function clearAutoSignificance() {
   const _t0 = perfNow();
@@ -2377,6 +2421,7 @@ async function clearAutoSignificance() {
 
   let cleared = 0;
   let errors = 0;
+  let contextRuns = 0;
   const _clearAggregate = {
     bodyCellsRead: 0,
     bodyCellsChanged: 0,
@@ -2385,35 +2430,79 @@ async function clearAutoSignificance() {
     bannerWriteCommands: 0,
   };
 
-  for (const candidate of eligible) {
-    try {
-      const result = await clearSignificanceForRange(candidate.sheetName, candidate.rangeAddress);
+  // Group by sheet so each sheet's tables share one Excel.run context.
+  const bySheet = groupCandidatesBySheet(eligible);
 
-      if (result.status === "cleared") {
-        cleared++;
-        if (result._clearDetails) {
-          _clearAggregate.bodyCellsRead += result._clearDetails.bodyCellsRead || 0;
-          _clearAggregate.bodyCellsChanged += result._clearDetails.bodyCellsChanged || 0;
-          _clearAggregate.bannerCellsRead += result._clearDetails.bannerCellsRead || 0;
-          _clearAggregate.bannerCellsChanged += result._clearDetails.bannerCellsChanged || 0;
-          _clearAggregate.bannerWriteCommands += result._clearDetails.bannerWriteCommands || 0;
+  for (const [sheetName, sheetCandidates] of bySheet) {
+    let batchEndedAt = 0;
+    contextRuns++;
+
+    // Attempt to clear all tables on this sheet in a single Excel.run.
+    try {
+      await Excel.run(async (context) => {
+        for (let _si = 0; _si < sheetCandidates.length; _si++) {
+          const candidate = sheetCandidates[_si];
+          try {
+            const result = await clearSignificanceForRangeInContext(
+              context,
+              sheetName,
+              candidate.rangeAddress
+            );
+            if (result.status === "cleared") {
+              cleared++;
+              accumulateClearDetails(_clearAggregate, result._clearDetails);
+            } else if (result.status === "skipped") {
+              skipped++;
+              detailLines.push(
+                `- ${sheetName} ${candidate.rangeAddress}: пропущено — ${result.message}`
+              );
+            } else {
+              errors++;
+              detailLines.push(
+                `- ${sheetName} ${candidate.rangeAddress}: ошибка — ${result.message}`
+              );
+            }
+            batchEndedAt = _si + 1;
+          } catch (err) {
+            errors++;
+            detailLines.push(
+              `- ${sheetName} ${candidate.rangeAddress}: ошибка — ${err.message || "неизвестная ошибка"}`
+            );
+            batchEndedAt = _si + 1;
+            throw err; // shared context may be corrupted; exit batch
+          }
         }
-      } else if (result.status === "skipped") {
-        skipped++;
-        detailLines.push(
-          `- ${candidate.sheetName} ${candidate.rangeAddress}: пропущено — ${result.message}`
-        );
-      } else {
+        batchEndedAt = sheetCandidates.length;
+      });
+    } catch (_batchErr) {
+      // Shared context aborted; fall back to per-table for any remaining candidates.
+    }
+
+    for (let _fi = batchEndedAt; _fi < sheetCandidates.length; _fi++) {
+      const candidate = sheetCandidates[_fi];
+      contextRuns++;
+      try {
+        const result = await clearSignificanceForRange(sheetName, candidate.rangeAddress);
+        if (result.status === "cleared") {
+          cleared++;
+          accumulateClearDetails(_clearAggregate, result._clearDetails);
+        } else if (result.status === "skipped") {
+          skipped++;
+          detailLines.push(
+            `- ${sheetName} ${candidate.rangeAddress}: пропущено — ${result.message}`
+          );
+        } else {
+          errors++;
+          detailLines.push(
+            `- ${sheetName} ${candidate.rangeAddress}: ошибка — ${result.message}`
+          );
+        }
+      } catch (err) {
         errors++;
         detailLines.push(
-          `- ${candidate.sheetName} ${candidate.rangeAddress}: ошибка — ${result.message}`
+          `- ${sheetName} ${candidate.rangeAddress}: ошибка — ${err.message || "неизвестная ошибка"}`
         );
       }
-    } catch (err) {
-      errors++;
-      detailLines.push(
-        `- ${candidate.sheetName} ${candidate.rangeAddress}: ошибка — ${err.message || "неизвестная ошибка"}`
-      );
     }
   }
 
@@ -2430,6 +2519,8 @@ async function clearAutoSignificance() {
 
   perfLog("clearAutoSignificance", {
     tablesCleared: cleared,
+    contextRuns,
+    sheetCount: bySheet.size,
     ...(cleared > 0 ? { clearAggregate: _clearAggregate } : {}),
     totalMs: perfElapsed(_t0),
   });
@@ -2769,8 +2860,9 @@ async function runCurrentSheetSignificance() {
  * Current-sheet clear: removes significance markers from all "available"
  * inventory candidates on the active worksheet only.
  *
- * Mirrors clearAutoSignificance() but scans only the active sheet via
- * collectActiveSheetInventoryResults(). Content sheet is silently ignored.
+ * Mirrors clearAutoSignificance() — all tables on the same sheet share one
+ * Excel.run context, with per-table fallback on context corruption.
+ * Content sheet is silently ignored.
  */
 async function clearCurrentSheetSignificance() {
   const _t0 = perfNow();
@@ -2804,6 +2896,7 @@ async function clearCurrentSheetSignificance() {
 
   let cleared = 0;
   let errors = 0;
+  let contextRuns = 0;
   const _clearAggregate = {
     bodyCellsRead: 0,
     bodyCellsChanged: 0,
@@ -2812,35 +2905,79 @@ async function clearCurrentSheetSignificance() {
     bannerWriteCommands: 0,
   };
 
-  for (const candidate of eligible) {
-    try {
-      const result = await clearSignificanceForRange(candidate.sheetName, candidate.rangeAddress);
+  // Group by sheet — for the sheet-scoped flow this is typically one sheet,
+  // but grouping keeps the logic consistent with clearAutoSignificance.
+  const bySheet = groupCandidatesBySheet(eligible);
 
-      if (result.status === "cleared") {
-        cleared++;
-        if (result._clearDetails) {
-          _clearAggregate.bodyCellsRead += result._clearDetails.bodyCellsRead || 0;
-          _clearAggregate.bodyCellsChanged += result._clearDetails.bodyCellsChanged || 0;
-          _clearAggregate.bannerCellsRead += result._clearDetails.bannerCellsRead || 0;
-          _clearAggregate.bannerCellsChanged += result._clearDetails.bannerCellsChanged || 0;
-          _clearAggregate.bannerWriteCommands += result._clearDetails.bannerWriteCommands || 0;
+  for (const [sheetName, sheetCandidates] of bySheet) {
+    let batchEndedAt = 0;
+    contextRuns++;
+
+    try {
+      await Excel.run(async (context) => {
+        for (let _si = 0; _si < sheetCandidates.length; _si++) {
+          const candidate = sheetCandidates[_si];
+          try {
+            const result = await clearSignificanceForRangeInContext(
+              context,
+              sheetName,
+              candidate.rangeAddress
+            );
+            if (result.status === "cleared") {
+              cleared++;
+              accumulateClearDetails(_clearAggregate, result._clearDetails);
+            } else if (result.status === "skipped") {
+              skipped++;
+              detailLines.push(
+                `- ${sheetName} ${candidate.rangeAddress}: пропущено — ${result.message}`
+              );
+            } else {
+              errors++;
+              detailLines.push(
+                `- ${sheetName} ${candidate.rangeAddress}: ошибка — ${result.message}`
+              );
+            }
+            batchEndedAt = _si + 1;
+          } catch (err) {
+            errors++;
+            detailLines.push(
+              `- ${sheetName} ${candidate.rangeAddress}: ошибка — ${err.message || "неизвестная ошибка"}`
+            );
+            batchEndedAt = _si + 1;
+            throw err;
+          }
         }
-      } else if (result.status === "skipped") {
-        skipped++;
-        detailLines.push(
-          `- ${candidate.sheetName} ${candidate.rangeAddress}: пропущено — ${result.message}`
-        );
-      } else {
+        batchEndedAt = sheetCandidates.length;
+      });
+    } catch (_batchErr) {
+      // Shared context aborted; fall back to per-table for any remaining candidates.
+    }
+
+    for (let _fi = batchEndedAt; _fi < sheetCandidates.length; _fi++) {
+      const candidate = sheetCandidates[_fi];
+      contextRuns++;
+      try {
+        const result = await clearSignificanceForRange(sheetName, candidate.rangeAddress);
+        if (result.status === "cleared") {
+          cleared++;
+          accumulateClearDetails(_clearAggregate, result._clearDetails);
+        } else if (result.status === "skipped") {
+          skipped++;
+          detailLines.push(
+            `- ${sheetName} ${candidate.rangeAddress}: пропущено — ${result.message}`
+          );
+        } else {
+          errors++;
+          detailLines.push(
+            `- ${sheetName} ${candidate.rangeAddress}: ошибка — ${result.message}`
+          );
+        }
+      } catch (err) {
         errors++;
         detailLines.push(
-          `- ${candidate.sheetName} ${candidate.rangeAddress}: ошибка — ${result.message}`
+          `- ${sheetName} ${candidate.rangeAddress}: ошибка — ${err.message || "неизвестная ошибка"}`
         );
       }
-    } catch (err) {
-      errors++;
-      detailLines.push(
-        `- ${candidate.sheetName} ${candidate.rangeAddress}: ошибка — ${err.message || "неизвестная ошибка"}`
-      );
     }
   }
 
@@ -2857,6 +2994,8 @@ async function clearCurrentSheetSignificance() {
 
   perfLog("clearCurrentSheetSignificance", {
     tablesCleared: cleared,
+    contextRuns,
+    sheetCount: bySheet.size,
     ...(cleared > 0 ? { clearAggregate: _clearAggregate } : {}),
     totalMs: perfElapsed(_t0),
   });

--- a/src/taskpane/taskpane.js
+++ b/src/taskpane/taskpane.js
@@ -2153,6 +2153,7 @@ async function clearAutoCurrentTableSignificance() {
  * status: "cleared" | "skipped" | "error"
  */
 async function clearSignificanceForRange(sheetName, rangeAddress) {
+  const _t0 = perfNow();
   return await Excel.run(async (context) => {
     const worksheet = context.workbook.worksheets.getItem(sheetName);
     const sourceRange = worksheet.getRange(rangeAddress);
@@ -2243,15 +2244,23 @@ async function clearSignificanceForRange(sheetName, rangeAddress) {
       }
     }
 
-    clearTargetRange.load(["values", "numberFormat", "rowCount", "columnCount"]);
+    clearTargetRange.load(["values", "numberFormat", "rowIndex", "columnIndex", "columnCount"]);
 
     await context.sync();
 
     const targetValues = clearTargetRange.values;
     const targetNumberFormats = clearTargetRange.numberFormat;
+    const _knownDims = {
+      rowIndex: clearTargetRange.rowIndex,
+      columnIndex: clearTargetRange.columnIndex,
+      columnCount: clearTargetRange.columnCount,
+    };
 
     const nextValues = [];
     const nextNumberFormats = [];
+    let bodyCellsChanged = 0;
+    let bodyHasValueChange = false;
+    let bodyHasFormatChange = false;
 
     for (let rowIndex = 0; rowIndex < targetValues.length; rowIndex++) {
       const valueRow = [];
@@ -2259,10 +2268,11 @@ async function clearSignificanceForRange(sheetName, rangeAddress) {
 
       for (let columnIndex = 0; columnIndex < targetValues[rowIndex].length; columnIndex++) {
         const rawValue = targetValues[rowIndex][columnIndex];
+        const currentFormat = targetNumberFormats[rowIndex][columnIndex];
 
         if (typeof rawValue === "number") {
           valueRow.push(rawValue);
-          formatRow.push(targetNumberFormats[rowIndex][columnIndex]);
+          formatRow.push(currentFormat);
           continue;
         }
 
@@ -2270,9 +2280,13 @@ async function clearSignificanceForRange(sheetName, rangeAddress) {
         const resolved = resolveNumericOutput(cleanedText);
 
         if (resolved !== null) {
+          if (resolved.value !== rawValue) bodyHasValueChange = true;
+          if (resolved.format !== currentFormat) bodyHasFormatChange = true;
+          if (resolved.value !== rawValue || resolved.format !== currentFormat) bodyCellsChanged++;
           valueRow.push(resolved.value);
           formatRow.push(resolved.format);
         } else {
+          if (cleanedText !== rawValue) { bodyHasValueChange = true; bodyCellsChanged++; }
           valueRow.push(cleanedText);
           formatRow.push("@");
         }
@@ -2282,17 +2296,45 @@ async function clearSignificanceForRange(sheetName, rangeAddress) {
       nextNumberFormats.push(formatRow);
     }
 
-    clearTargetRange.numberFormat = nextNumberFormats;
-    clearTargetRange.values = nextValues;
+    // Only write body data when something actually changed, avoiding a full
+    // matrix write on a re-clear of an already-clean workbook.
+    if (bodyHasFormatChange) clearTargetRange.numberFormat = nextNumberFormats;
+    if (bodyHasValueChange) clearTargetRange.values = nextValues;
 
     clearTargetRange.format.font.bold = false;
     clearTargetRange.format.fill.clear();
 
+    // No body sync here — deferred to the banner read sync inside
+    // clearBannerMarkerUpdatesForRange, which flushes all queued writes.
+    const bannerDetails = await clearBannerMarkerUpdatesForRange(context, clearTargetRange, _knownDims);
+
     await context.sync();
 
-    await clearBannerMarkersAboveRange(context, clearTargetRange);
+    const bodyCellsRead = targetValues.length * (targetValues[0] ? targetValues[0].length : 0);
+    perfLog("clearSignificanceForRange", {
+      rangeAddress,
+      bodyCellsRead,
+      bodyCellsChanged,
+      bodyHasValueChange,
+      bodyHasFormatChange,
+      bannerDetails: bannerDetails || null,
+      totalMs: perfElapsed(_t0),
+    });
 
-    return { status: "cleared", message: "очищено" };
+    return {
+      status: "cleared",
+      message: "очищено",
+      ...(perfEnabled() ? {
+        _clearDetails: {
+          bodyCellsRead,
+          bodyCellsChanged,
+          bannerCellsRead: bannerDetails ? bannerDetails.cellsRead : 0,
+          bannerCellsChanged: bannerDetails ? bannerDetails.cellsChanged : 0,
+          bannerWriteCommands: bannerDetails ? bannerDetails.writeCommands : 0,
+          totalMs: perfElapsed(_t0),
+        },
+      } : {}),
+    };
   });
 }
 
@@ -2304,6 +2346,7 @@ async function clearSignificanceForRange(sheetName, rangeAddress) {
  * of running the significance pipeline.
  */
 async function clearAutoSignificance() {
+  const _t0 = perfNow();
   setStatusMessage(runningStatusMessage("clear", "workbook"));
   let inventoryResults;
   try {
@@ -2334,6 +2377,13 @@ async function clearAutoSignificance() {
 
   let cleared = 0;
   let errors = 0;
+  const _clearAggregate = {
+    bodyCellsRead: 0,
+    bodyCellsChanged: 0,
+    bannerCellsRead: 0,
+    bannerCellsChanged: 0,
+    bannerWriteCommands: 0,
+  };
 
   for (const candidate of eligible) {
     try {
@@ -2341,6 +2391,13 @@ async function clearAutoSignificance() {
 
       if (result.status === "cleared") {
         cleared++;
+        if (result._clearDetails) {
+          _clearAggregate.bodyCellsRead += result._clearDetails.bodyCellsRead || 0;
+          _clearAggregate.bodyCellsChanged += result._clearDetails.bodyCellsChanged || 0;
+          _clearAggregate.bannerCellsRead += result._clearDetails.bannerCellsRead || 0;
+          _clearAggregate.bannerCellsChanged += result._clearDetails.bannerCellsChanged || 0;
+          _clearAggregate.bannerWriteCommands += result._clearDetails.bannerWriteCommands || 0;
+        }
       } else if (result.status === "skipped") {
         skipped++;
         detailLines.push(
@@ -2371,6 +2428,11 @@ async function clearAutoSignificance() {
     summaryLines.push("", ...detailLines);
   }
 
+  perfLog("clearAutoSignificance", {
+    tablesCleared: cleared,
+    ...(cleared > 0 ? { clearAggregate: _clearAggregate } : {}),
+    totalMs: perfElapsed(_t0),
+  });
   setStatusMessage(summaryLines.join("\n"));
 }
 
@@ -2711,6 +2773,7 @@ async function runCurrentSheetSignificance() {
  * collectActiveSheetInventoryResults(). Content sheet is silently ignored.
  */
 async function clearCurrentSheetSignificance() {
+  const _t0 = perfNow();
   setStatusMessage(runningStatusMessage("clear", "sheet"));
   let inventoryResults;
   try {
@@ -2741,6 +2804,13 @@ async function clearCurrentSheetSignificance() {
 
   let cleared = 0;
   let errors = 0;
+  const _clearAggregate = {
+    bodyCellsRead: 0,
+    bodyCellsChanged: 0,
+    bannerCellsRead: 0,
+    bannerCellsChanged: 0,
+    bannerWriteCommands: 0,
+  };
 
   for (const candidate of eligible) {
     try {
@@ -2748,6 +2818,13 @@ async function clearCurrentSheetSignificance() {
 
       if (result.status === "cleared") {
         cleared++;
+        if (result._clearDetails) {
+          _clearAggregate.bodyCellsRead += result._clearDetails.bodyCellsRead || 0;
+          _clearAggregate.bodyCellsChanged += result._clearDetails.bodyCellsChanged || 0;
+          _clearAggregate.bannerCellsRead += result._clearDetails.bannerCellsRead || 0;
+          _clearAggregate.bannerCellsChanged += result._clearDetails.bannerCellsChanged || 0;
+          _clearAggregate.bannerWriteCommands += result._clearDetails.bannerWriteCommands || 0;
+        }
       } else if (result.status === "skipped") {
         skipped++;
         detailLines.push(
@@ -2778,6 +2855,11 @@ async function clearCurrentSheetSignificance() {
     summaryLines.push("", ...detailLines);
   }
 
+  perfLog("clearCurrentSheetSignificance", {
+    tablesCleared: cleared,
+    ...(cleared > 0 ? { clearAggregate: _clearAggregate } : {}),
+    totalMs: perfElapsed(_t0),
+  });
   setStatusMessage(summaryLines.join("\n"));
 }
 
@@ -3189,6 +3271,7 @@ function calculateBlockResults(cleanedValues, calculationBlock, calculationSetti
  * User-facing cleanup button.
  */
 async function clearSignificanceFromSelection() {
+  const _t0 = perfNow();
   setStatusMessage(runningStatusMessage("clear"));
   await Excel.run(async (context) => {
     // getSelectedRange() throws a RichApi.Error for non-contiguous (Ctrl+Click
@@ -3318,15 +3401,23 @@ async function clearSignificanceFromSelection() {
       }
     }
 
-    clearTargetRange.load(["values", "numberFormat"]);
+    clearTargetRange.load(["values", "numberFormat", "rowIndex", "columnIndex", "columnCount"]);
 
     await context.sync();
 
     const targetValues = clearTargetRange.values;
     const targetNumberFormats = clearTargetRange.numberFormat;
+    const _knownDims = {
+      rowIndex: clearTargetRange.rowIndex,
+      columnIndex: clearTargetRange.columnIndex,
+      columnCount: clearTargetRange.columnCount,
+    };
 
     const nextValues = [];
     const nextNumberFormats = [];
+    let bodyCellsChanged = 0;
+    let bodyHasValueChange = false;
+    let bodyHasFormatChange = false;
 
     for (let rowIndex = 0; rowIndex < targetValues.length; rowIndex++) {
       const valueRow = [];
@@ -3334,10 +3425,11 @@ async function clearSignificanceFromSelection() {
 
       for (let columnIndex = 0; columnIndex < targetValues[rowIndex].length; columnIndex++) {
         const rawValue = targetValues[rowIndex][columnIndex];
+        const currentFormat = targetNumberFormats[rowIndex][columnIndex];
 
         if (typeof rawValue === "number") {
           valueRow.push(rawValue);
-          formatRow.push(targetNumberFormats[rowIndex][columnIndex]);
+          formatRow.push(currentFormat);
           continue;
         }
 
@@ -3345,9 +3437,13 @@ async function clearSignificanceFromSelection() {
         const resolved = resolveNumericOutput(cleanedText);
 
         if (resolved !== null) {
+          if (resolved.value !== rawValue) bodyHasValueChange = true;
+          if (resolved.format !== currentFormat) bodyHasFormatChange = true;
+          if (resolved.value !== rawValue || resolved.format !== currentFormat) bodyCellsChanged++;
           valueRow.push(resolved.value);
           formatRow.push(resolved.format);
         } else {
+          if (cleanedText !== rawValue) { bodyHasValueChange = true; bodyCellsChanged++; }
           valueRow.push(cleanedText);
           formatRow.push("@");
         }
@@ -3357,16 +3453,28 @@ async function clearSignificanceFromSelection() {
       nextNumberFormats.push(formatRow);
     }
 
-    clearTargetRange.numberFormat = nextNumberFormats;
-    clearTargetRange.values = nextValues;
+    // Only write body data when something actually changed, avoiding a full
+    // matrix write on a re-clear of an already-clean workbook.
+    if (bodyHasFormatChange) clearTargetRange.numberFormat = nextNumberFormats;
+    if (bodyHasValueChange) clearTargetRange.values = nextValues;
 
     clearTargetRange.format.font.bold = false;
     clearTargetRange.format.fill.clear();
 
+    // No body sync here — deferred to the banner read sync inside
+    // clearBannerMarkerUpdatesForRange, which flushes all queued writes.
+    const bannerDetails = await clearBannerMarkerUpdatesForRange(context, clearTargetRange, _knownDims);
+
     await context.sync();
 
-    await clearBannerMarkersAboveRange(context, clearTargetRange);
-
+    perfLog("clearSignificanceFromSelection", {
+      bodyCellsRead: targetValues.length * (targetValues[0] ? targetValues[0].length : 0),
+      bodyCellsChanged,
+      bodyHasValueChange,
+      bodyHasFormatChange,
+      bannerDetails: bannerDetails || null,
+      totalMs: perfElapsed(_t0),
+    });
     setStatusMessage(t("status.clearDone"));
   });
 }
@@ -3485,6 +3593,141 @@ async function clearBannerMarkersAboveRange(context, targetRange, knownDimension
   }
 
   await context.sync();
+}
+
+/**
+ * Combined clear-only banner pass for Clear Significance.
+ *
+ * Clear-only analog of applyBannerMarkerUpdatesForRange — reads the banner scan
+ * area once (flushing any pending body writes queued by the caller), strips all
+ * RIT trailing markers in-memory, diffs against the original texts, and queues
+ * writes only for cells that actually changed.  No marker placement, no
+ * numberFormat writes.
+ *
+ * Sync behaviour: issues 1 context.sync() to read the banner area (and flush
+ * pending writes).  Queued banner writes are NOT flushed here — the caller must
+ * issue its own final context.sync().  When cellsChanged === 0, no writes are
+ * queued and the caller's final sync is a cheap no-op.
+ *
+ * Returns null when targetStartRowIndex === 0 or targetColumnCount < 1.
+ * Otherwise returns a compact diagnostics object.
+ *
+ * @param {Excel.RequestContext} context
+ * @param {Excel.Range} targetRange  The clear-target range (data body).
+ * @param {{ rowIndex, columnIndex, columnCount }} [knownDimensions]
+ *   Pre-loaded sheet coordinates of targetRange.  When provided, skips the
+ *   extra load+sync that would otherwise be needed to resolve them.
+ */
+async function clearBannerMarkerUpdatesForRange(context, targetRange, knownDimensions) {
+  const BANNER_UPPER_SCAN_LIMIT = 5;
+  const BANNER_SCAN_ROW_COUNT = BANNER_UPPER_SCAN_LIMIT + 1;
+
+  let targetStartRowIndex, targetStartColumnIndex, targetColumnCount;
+  if (knownDimensions) {
+    targetStartRowIndex = knownDimensions.rowIndex;
+    targetStartColumnIndex = knownDimensions.columnIndex;
+    targetColumnCount = knownDimensions.columnCount;
+  } else {
+    targetRange.load(["rowIndex", "columnIndex", "columnCount"]);
+    await context.sync();
+    targetStartRowIndex = targetRange.rowIndex;
+    targetStartColumnIndex = targetRange.columnIndex;
+    targetColumnCount = targetRange.columnCount;
+  }
+
+  if (targetStartRowIndex === 0 || targetColumnCount < 1) {
+    return null;
+  }
+
+  const totalScanRowCount = Math.min(BANNER_SCAN_ROW_COUNT, targetStartRowIndex);
+  if (totalScanRowCount < 1) {
+    return null;
+  }
+
+  const scanStartColIndex = targetStartColumnIndex;
+  const scanColCount = targetColumnCount;
+
+  const bannerScanRange = targetRange.worksheet.getRangeByIndexes(
+    targetStartRowIndex - totalScanRowCount,
+    scanStartColIndex,
+    totalScanRowCount,
+    scanColCount
+  );
+
+  const readSyncStartMs = perfNow();
+  bannerScanRange.load("text");
+  // This sync also flushes any pending body writes queued by the caller.
+  await context.sync();
+  const readSyncEndMs = perfNow();
+  let syncCount = 1;
+
+  const bannerTexts = bannerScanRange.text;
+
+  // Strip RIT trailing markers from every cell.  Keeps non-RIT parenthesised
+  // text (e.g. "Wave (quarter)") intact — getTrailingBannerMarker only matches
+  // single-character significance labels.
+  const desiredTexts = new Array(totalScanRowCount);
+  for (let r = 0; r < totalScanRowCount; r++) {
+    const row = bannerTexts[r] || [];
+    const destRow = new Array(scanColCount);
+    for (let c = 0; c < scanColCount; c++) {
+      const txt = row[c] || "";
+      destRow[c] = (txt && getTrailingBannerMarker(txt)) ? removeTrailingBannerMarker(txt) : txt;
+    }
+    desiredTexts[r] = destRow;
+  }
+
+  // Diff against original texts and queue only changed cells.
+  const writesByRow = new Map();
+  let cellsChanged = 0;
+
+  for (let r = 0; r < totalScanRowCount; r++) {
+    for (let c = 0; c < scanColCount; c++) {
+      const cur = (bannerTexts[r] && bannerTexts[r][c]) || "";
+      const nxt = desiredTexts[r][c] || "";
+      if (cur === nxt) continue;
+      const absRow = targetStartRowIndex - totalScanRowCount + r;
+      const absCol = scanStartColIndex + c;
+      if (!writesByRow.has(absRow)) writesByRow.set(absRow, []);
+      writesByRow.get(absRow).push({ colIndex: absCol, text: nxt });
+      cellsChanged++;
+    }
+  }
+
+  const changedRows = writesByRow.size;
+  const queueWriteStartMs = perfNow();
+  let writeCommands = 0;
+
+  if (cellsChanged > 0) {
+    const worksheet = targetRange.worksheet;
+    for (const [rowIndex, items] of writesByRow) {
+      items.sort((a, b) => a.colIndex - b.colIndex);
+      let i = 0;
+      while (i < items.length) {
+        let j = i;
+        while (j + 1 < items.length && items[j + 1].colIndex === items[j].colIndex + 1) j++;
+        const texts = items.slice(i, j + 1).map((x) => x.text);
+        worksheet.getRangeByIndexes(rowIndex, items[i].colIndex, 1, j - i + 1).values = [texts];
+        writeCommands++;
+        i = j + 1;
+      }
+    }
+    // Intentionally no context.sync() here — caller's final sync flushes queued writes.
+  }
+
+  const queueWriteEndMs = perfNow();
+
+  return {
+    rowsScanned: totalScanRowCount,
+    cellsRead: totalScanRowCount * scanColCount,
+    cellsChanged,
+    writeCommands,
+    changedRows,
+    readSyncMs: readSyncEndMs - readSyncStartMs,
+    planMs: queueWriteStartMs - readSyncEndMs,
+    queueWriteMs: queueWriteEndMs - queueWriteStartMs,
+    syncCount,
+  };
 }
 
 /**


### PR DESCRIPTION
## Summary

This PR implements two rounds of Clear Significance performance improvements.

---

### Commit 1 — Combined banner pass, no-op body skip, diagnostics

- **`clearBannerMarkerUpdatesForRange()`** — clear-only analog of `applyBannerMarkerUpdatesForRange`. One banner-read sync (also flushes pending body writes); diff; write only changed cells; no marker placement, no numberFormat writes. Reduces per-table sync count from 5–6 to 4.
- **No-op body-write skipping** — tracks `bodyHasValueChange` / `bodyHasFormatChange`; skips full-matrix `values` / `numberFormat` writes entirely when nothing changed (re-clear of clean workbook).
- **Dimension load fold** — `rowIndex`/`columnIndex`/`columnCount` loaded alongside `values`/`numberFormat` in one sync so the banner function needs no extra dimension-load sync.
- **RIT_PERF diagnostics** — `perfLog` in all Clear paths; per-table `_clearDetails` in return values; aggregate `clearAggregate` in auto-clear loops.

### Commit 2 — Batched sheet-level clear (one Excel.run per sheet)

- **`clearSignificanceForRangeInContext(context, sheetName, rangeAddress)`** — extracted inner pipeline (no `Excel.run` wrapper, always returns `_clearDetails`).
- **`clearSignificanceForRange()`** — thin wrapper: own `Excel.run` + `perfLog`; used by current-table clear and as per-table fallback on batch context errors.
- **`groupCandidatesBySheet()` / `accumulateClearDetails()`** — small helpers.
- **`clearAutoSignificance()` / `clearCurrentSheetSignificance()`** — replaced per-table loops with batched-by-sheet loops (one `Excel.run` per sheet). On context error, falls back to per-table `clearSignificanceForRange` for remaining candidates on that sheet — mirrors `runAutoSignificance` batch/fallback pattern.
- **`perfLog`** now emits `contextRuns` and `sheetCount` in addition to existing `clearAggregate` fields.

On the 72-table benchmark workbook this reduces Excel.run context initialisations from 72 to 1 (when all tables are on the same sheet).

---

## Performance impact

| Phase | Before #300 | After commit 1 | After commit 2 |
|---|---|---|---|
| Per-table sync count | 5–6 | 4 | 4 (same, but shared context) |
| Context inits (72 tables, 1 sheet) | 72 | 72 | 1 |
| Re-clear body matrix write | always | skipped | skipped |
| Banner write on clean workbook | 1 sync (no-op) | 1 sync (no-op) | 1 sync (no-op) |

**First Clear baseline (commit 1 measurement):** 17 994 ms → expected substantial reduction from commit 2.
**Repeated Clear baseline (commit 1 measurement):** 8 780 ms → expected substantial reduction from commit 2.

---

## Affected files

- `src/taskpane/taskpane.js` only

## Preserved guarantees

- Data markers removed (cleanup loop logic unchanged)
- Banner markers removed (`clearBannerMarkerUpdatesForRange` mirrors strip logic from legacy function and `applyBannerMarkerUpdatesForRange`)
- Non-RIT parenthesised text preserved (`getTrailingBannerMarker` single-character guard unchanged)
- Row labels untouched (clearTargetRange stays inside data body)
- `clearBannerMarkersAboveRange` (legacy) left in place — unused by new paths, not removed
- All #287/#290/#297 run-path behaviors unchanged
- Manual selected-range Clear uses `clearSignificanceFromSelection` (unchanged)
- Current-table autorun Clear uses `clearSignificanceForRange` (unchanged wrapper)

## Test plan

- [x] `npm test` passes (332/332)
- [x] `npm run build` succeeds (no errors)
- [x] `git diff --check` clean
- [ ] Manual smoke: run workbook autorun with banner letters, then clear — data and banner markers removed
- [ ] Manual smoke: clear again on clean workbook — fast, no-op safe
- [ ] Manual smoke: run significance after clear — output correct
- [ ] Manual smoke: manual selected-range Run + Clear
- [ ] Manual smoke: current-sheet Clear
- [ ] Manual smoke: bare-marker fallback `(a)`, `(b)`, `(c)` removed
- [ ] Manual smoke: `Wave (quarter)`, `сам(а)` preserved
- [ ] Enable `window.__RIT_PERF = true` and confirm `clearAutoSignificance` log shows `contextRuns: 1` (or N-sheets), `clearAggregate`, `totalMs`

## Assumptions / limitations

- `clearAutoCurrentTableSignificance` still uses `clearSignificanceForRange` (own `Excel.run`) — that is the correct single-range path.
- Bold/fill reset (`format.font.bold = false`, `format.fill.clear()`) is always queued unconditionally — reading current state to skip would cost an extra sync.
- The per-table fallback (on context error) counts each fallback invocation as one additional `contextRun` in diagnostics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)