### PR TITLE
Use shared emergency scan limit for current-table resolver (#298)

### DIFF
--- a/src/taskpane/active-cell-resolver.js
+++ b/src/taskpane/active-cell-resolver.js
@@ -33,9 +33,33 @@
 import { scanWorksheetForTables } from "../core/table-inventory-scanner";
 import { findCandidateForActiveCell, extractCandidateSlice } from "../core/active-cell-table-finder";
 import { hasEmptyDataRowGap } from "../core/range-normalizer";
+import { INVENTORY_SCAN_EMERGENCY_CELL_LIMIT } from "./taskpane-inventory-scan";
 
 const RESOLVER_GENERATED_SHEET_NAMES = new Set(["Content", "Run report"]);
-const RESOLVER_SCAN_CELL_LIMIT = 250000;
+
+function shouldBlockResolverScan(
+  rowCount,
+  columnCount,
+  limit = INVENTORY_SCAN_EMERGENCY_CELL_LIMIT
+) {
+  return rowCount * columnCount > limit;
+}
+
+function buildResolverScanBlockedResult(sheetName, rowCount, columnCount) {
+  const cellCount = rowCount * columnCount;
+
+  return {
+    status: "blocked",
+    sheetName,
+    message: `Лист аварийно пропущен — UsedRange слишком большой (${rowCount}×${columnCount} = ${cellCount} ячеек, аварийный лимит: ${INVENTORY_SCAN_EMERGENCY_CELL_LIMIT}).`,
+    details: {
+      rowCount,
+      columnCount,
+      cellCount,
+      limit: INVENTORY_SCAN_EMERGENCY_CELL_LIMIT,
+    },
+  };
+}
 
 /**
  * Resolves which inventory candidate contains the active cell.
@@ -55,7 +79,7 @@ const RESOLVER_SCAN_CELL_LIMIT = 250000;
  *   { status: "no-table" | "generated-sheet" | "ambiguous-boundary" | "blocked" | "error",
  *     sheetName, message, details }
  */
-export async function resolveCurrentTableFromActiveCell(context, settings) {
+async function resolveCurrentTableFromActiveCell(context, settings) {
   let sheetName = null;
 
   try {
@@ -96,18 +120,12 @@ export async function resolveCurrentTableFromActiveCell(context, settings) {
       };
     }
 
-    const cellCount = usedRange.rowCount * usedRange.columnCount;
-    if (cellCount > RESOLVER_SCAN_CELL_LIMIT) {
-      return {
-        status: "blocked",
+    if (shouldBlockResolverScan(usedRange.rowCount, usedRange.columnCount)) {
+      return buildResolverScanBlockedResult(
         sheetName,
-        message: `Лист слишком большой для сканирования (${usedRange.rowCount}×${usedRange.columnCount} = ${cellCount} ячеек).`,
-        details: {
-          rowCount: usedRange.rowCount,
-          columnCount: usedRange.columnCount,
-          cellCount,
-        },
-      };
+        usedRange.rowCount,
+        usedRange.columnCount
+      );
     }
 
     usedRange.load("values");
@@ -208,3 +226,5 @@ export async function resolveCurrentTableFromActiveCell(context, settings) {
     };
   }
 }
+
+export { resolveCurrentTableFromActiveCell, shouldBlockResolverScan };

--- a/tests/core/active-cell-resolver.test.mjs
+++ b/tests/core/active-cell-resolver.test.mjs
@@ -1,0 +1,29 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import { shouldBlockResolverScan } from "../../src/taskpane/active-cell-resolver.js";
+import { INVENTORY_SCAN_EMERGENCY_CELL_LIMIT } from "../../src/taskpane/taskpane-inventory-scan.js";
+
+describe("active-cell-resolver", () => {
+  it("does not block current-table resolution at the old 250k sheet-size guard", () => {
+    const rowCount = 522;
+    const columnCount = 516;
+    const cellCount = rowCount * columnCount;
+
+    assert.equal(cellCount, 269352);
+    assert.equal(cellCount > 250000, true);
+    assert.equal(cellCount < INVENTORY_SCAN_EMERGENCY_CELL_LIMIT, true);
+    assert.equal(shouldBlockResolverScan(rowCount, columnCount), false);
+  });
+
+  it("still blocks truly pathological used ranges using the shared inventory emergency limit", () => {
+    assert.equal(
+      shouldBlockResolverScan(1, INVENTORY_SCAN_EMERGENCY_CELL_LIMIT),
+      false
+    );
+    assert.equal(
+      shouldBlockResolverScan(1, INVENTORY_SCAN_EMERGENCY_CELL_LIMIT + 1),
+      true
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Replaces the current-table resolver's old local `250000` UsedRange guard with the shared inventory emergency scan limit.
- Keeps a true emergency circuit breaker for pathological UsedRanges, but no longer blocks normal wide sheets such as `522×516 = 269352` before table resolution.
- Adds a focused regression test for the old 250k guard case and the shared emergency-limit boundary.

## Why

Current-table autorun should use the same sheet-size safety policy as sheet/workbook inventory paths. The previous resolver-specific guard rejected some valid wide sheets before it could attempt to find the active-cell table.

## Files changed

- `src/taskpane/active-cell-resolver.js`
- `tests/core/active-cell-resolver.test.mjs`

## Validation

Not run in GitHub environment. Please run locally:

- `npm test`
- `npm run build`
- `git diff --check`

## Manual smoke

- On the wide `522×516` sheet, place the active cell inside a valid table and run `Автозапуск → Текущая таблица → Рассчитать`.
- Confirm it no longer reports `Лист слишком большой для сканирования (522×516 = 269352 ячеек.)`.
- Confirm it either processes the table or returns a meaningful current-table/table-resolution message.
- Confirm workbook/current-sheet autorun still works.
- Confirm manual selected-range Run still works.

Closes #298