### PR TITLE
Recognize compact wave value labels (w1, w6, W6, w06, w6 (ноябрь 23))

### DIFF
--- a/src/core/banner-detector.js
+++ b/src/core/banner-detector.js
@@ -1459,6 +1459,24 @@ function detectGroupKeysWithNestedWaveDimension({
       continue;
     }
 
+    // Also check upper scan rows for wave VALUE labels.
+    //
+    // PURPOSE: In real Excel workbooks the wave-value label (e.g. "2025Q4",
+    // "w18 (ноябрь 24)") sometimes sits one or more rows above the immediate
+    // lower banner row — either because the user's selection starts below the
+    // wave-value row, or because Excel's vertical-merge model makes the
+    // non-top cells of a merged area return empty text, so the value only
+    // appears in the upper scan rows.
+    //
+    // The existing lowerBannerRow check handles the common single-level
+    // layout; this companion check handles the merged/multi-level layout.
+    if (
+      hasWaveValueLabelsInIntermediateUpperRow(columnIndexes, upperScanRows, groupLevelRowIndex)
+    ) {
+      waveGroupKeys.add(groupKey);
+      continue;
+    }
+
     if (
       hasWaveDescriptorInIntermediateUpperRow(columnIndexes, upperScanRows, groupLevelRowIndex)
     ) {
@@ -1518,6 +1536,43 @@ function hasWaveDescriptorInIntermediateUpperRow(
     }
 
     if (descriptorCount >= 2) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+/**
+ * Returns true if any non-group-level upper scan row contains at least two
+ * wave VALUE labels (e.g. "2025Q4", "w18 (ноябрь 24)") among the given column
+ * indexes.
+ *
+ * Mirrors hasWaveDescriptorInIntermediateUpperRow but uses isTechnicalWaveValueLabel
+ * instead of isTechnicalWaveDescriptorLabel so that concrete wave/quarter values
+ * that appear in upper scan rows (rather than the lowerBannerRow) are recognised.
+ */
+function hasWaveValueLabelsInIntermediateUpperRow(
+  columnIndexes,
+  upperScanRows,
+  groupLevelRowIndex
+) {
+  if (!Array.isArray(upperScanRows) || upperScanRows.length === 0) {
+    return false;
+  }
+
+  for (let rowIndex = 0; rowIndex < upperScanRows.length; rowIndex++) {
+    if (rowIndex === groupLevelRowIndex) {
+      continue;
+    }
+
+    const row = upperScanRows[rowIndex];
+
+    if (!row) {
+      continue;
+    }
+
+    if (countWaveValueLabelsInColumns(columnIndexes, row) >= 2) {
       return true;
     }
   }

--- a/src/core/banner-detector.js
+++ b/src/core/banner-detector.js
@@ -1470,9 +1470,14 @@ function detectGroupKeysWithNestedWaveDimension({
     //
     // The existing lowerBannerRow check handles the common single-level
     // layout; this companion check handles the merged/multi-level layout.
-    if (
-      hasWaveValueLabelsInIntermediateUpperRow(columnIndexes, upperScanRows, groupLevelRowIndex)
-    ) {
+    //
+    // Unlike hasWaveDescriptorInIntermediateUpperRow, the group-level row is
+    // NOT skipped here. When the wave-value row is the only upper scan row the
+    // detector elects it as the group level (technical candidate, no better
+    // semantic row). Skipping it would prevent wave promotion for that layout.
+    // Semantic group labels ("Gender", "Age", etc.) never match
+    // isTechnicalWaveValueLabel so there is no false-positive risk.
+    if (hasWaveValueLabelsInIntermediateUpperRow(columnIndexes, upperScanRows)) {
       waveGroupKeys.add(groupKey);
       continue;
     }
@@ -1544,28 +1549,25 @@ function hasWaveDescriptorInIntermediateUpperRow(
 }
 
 /**
- * Returns true if any non-group-level upper scan row contains at least two
- * wave VALUE labels (e.g. "2025Q4", "w18 (ноябрь 24)") among the given column
- * indexes.
+ * Returns true if any upper scan row contains at least two wave VALUE labels
+ * (e.g. "2025Q4", "w18 (ноябрь 24)") among the given column indexes.
  *
  * Mirrors hasWaveDescriptorInIntermediateUpperRow but uses isTechnicalWaveValueLabel
  * instead of isTechnicalWaveDescriptorLabel so that concrete wave/quarter values
  * that appear in upper scan rows (rather than the lowerBannerRow) are recognised.
+ *
+ * Unlike the descriptor counterpart, every upper scan row is checked including
+ * the group-level row. When the wave-value row is the only upper scan row the
+ * detector may elect it as the group level; skipping it would suppress wave
+ * promotion for that common single-row layout. Semantic group labels never match
+ * isTechnicalWaveValueLabel so there is no false-positive risk.
  */
-function hasWaveValueLabelsInIntermediateUpperRow(
-  columnIndexes,
-  upperScanRows,
-  groupLevelRowIndex
-) {
+function hasWaveValueLabelsInIntermediateUpperRow(columnIndexes, upperScanRows) {
   if (!Array.isArray(upperScanRows) || upperScanRows.length === 0) {
     return false;
   }
 
   for (let rowIndex = 0; rowIndex < upperScanRows.length; rowIndex++) {
-    if (rowIndex === groupLevelRowIndex) {
-      continue;
-    }
-
     const row = upperScanRows[rowIndex];
 
     if (!row) {
@@ -1667,12 +1669,22 @@ function isTechnicalWaveValueLabel(rawLabel) {
     return false;
   }
 
-  // Compact wave number: first token matches w<digits> (e.g. w1, w6, w06, w12).
-  // Parenthetical suffixes like "w6 (ноябрь 23)" are covered because
-  // normalization collapses parentheses to spaces and we only check the first token.
-  const firstToken = normalizedLabel.split(" ")[0];
-
-  if (/^w\d+$/.test(firstToken)) {
+  // Compact wave number: label starts with  w <optional-separator> <digits>.
+  //
+  // Covers all realistic real-workbook variants:
+  //   w18            — no separator
+  //   w 18           — space (also NBSP, collapsed to space by normalization)
+  //   w-18           — hyphen  (not stripped by normalizeLookupText)
+  //   w_18           — underscore  (not stripped by normalizeLookupText)
+  //   W18            — uppercase  (lowercased by normalization)
+  //   w18 (ноябрь 24) — parenthetical suffix (parens→spaces by normalization)
+  //   w 18 (ноябрь 24) — both space separator and suffix
+  //
+  // (?!\w) prevents "w3c"-style false positives: the wave number must not be
+  // immediately followed by an ASCII letter, digit, or underscore.
+  // Ordinary words like "woman", "work", "wave 18" do not match because they
+  // have a non-digit character immediately after the leading 'w'.
+  if (/^w[\s\-_]?\d+(?!\w)/.test(normalizedLabel)) {
     return true;
   }
 

--- a/src/core/banner-detector.js
+++ b/src/core/banner-detector.js
@@ -1612,6 +1612,15 @@ function isTechnicalWaveValueLabel(rawLabel) {
     return false;
   }
 
+  // Compact wave number: first token matches w<digits> (e.g. w1, w6, w06, w12).
+  // Parenthetical suffixes like "w6 (ноябрь 23)" are covered because
+  // normalization collapses parentheses to spaces and we only check the first token.
+  const firstToken = normalizedLabel.split(" ")[0];
+
+  if (/^w\d+$/.test(firstToken)) {
+    return true;
+  }
+
   const compactLabel = normalizedLabel.replace(/\s+/g, "");
 
   return (

--- a/tests/core/banner-detector.test.mjs
+++ b/tests/core/banner-detector.test.mjs
@@ -698,6 +698,115 @@ describe("detectBannerStructure - compact w-number wave value labels", () => {
     }
   });
 
+  it("w-label variants with space / hyphen / underscore separator all promote wave groups when autoDetectWaveBanners is true", () => {
+    // Root-cause regression for the real-workbook smoke failure:
+    // Excel cells may render the wave number with a space ("w 18 (ноябрь 24)"),
+    // a hyphen ("w-18"), or an underscore ("w_18").
+    // normalizeLookupText does NOT strip hyphens or underscores, so the old
+    // /^w\d+$/ first-token test failed for those variants.
+    // The new regex /^w[\s\-_]?\d+(?!\w)/ on the full normalized label fixes all.
+    const separator_variants = [
+      ["w 18 (ноябрь 24)", "w 19 (май 25)"],   // space — the most common real-world format
+      ["w-18 (ноябрь 24)", "w-19 (май 25)"],    // hyphen
+      ["w_18 (ноябрь 24)", "w_19 (май 25)"],    // underscore
+      ["W 18 (ноябрь 24)", "W 19 (май 25)"],    // uppercase + space
+    ];
+
+    for (const [label1, label2] of separator_variants) {
+      const bannerContext = {
+        selectedColumnCount: 4,
+        lowerBannerRow: [label1, label2, label1, label2],
+        upperScanRows: [["Всего", "", "Мужской", ""]],
+      };
+
+      const result = detectBannerStructure(bannerContext, { autoDetectWaveBanners: true });
+
+      for (const group of result.groups) {
+        assert.strictEqual(
+          group.recommendedComparisonMode,
+          "previousColumn",
+          `variant "${label1}" / "${label2}" should promote previousColumn but got ${group.recommendedComparisonMode}`
+        );
+      }
+
+      // autoDetectWaveBanners: false must never enable previousColumn
+      const resultFalse = detectBannerStructure(bannerContext, { autoDetectWaveBanners: false });
+
+      for (const group of resultFalse.groups) {
+        assert.notStrictEqual(
+          group.recommendedComparisonMode,
+          "previousColumn",
+          `variant "${label1}" must not trigger previousColumn when autoDetectWaveBanners is false`
+        );
+      }
+    }
+  });
+
+  it("ordinary w-words (woman, work) are not recognised as wave value labels", () => {
+    // Ensures the broadened regex does not create false positives for ordinary
+    // words that start with the letter w but are not wave-number labels.
+    // Note: "wave awareness" is intentionally omitted here because it does
+    // trigger the existing WAVE_GROUP_LABEL_KEYWORDS descriptor path ("wave" is
+    // in that list); that is expected and correct behaviour, not a false positive.
+    const nonWaveWords = ["woman", "work"];
+
+    for (const word of nonWaveWords) {
+      const bannerContext = {
+        selectedColumnCount: 4,
+        lowerBannerRow: [word, word, word, word],
+        upperScanRows: [["Group A", "", "Group B", ""]],
+      };
+
+      const result = detectBannerStructure(bannerContext, { autoDetectWaveBanners: true });
+
+      for (const group of result.groups) {
+        assert.notStrictEqual(
+          group.recommendedComparisonMode,
+          "previousColumn",
+          `"${word}" must not trigger wave detection`
+        );
+      }
+    }
+  });
+
+  it("compact w-number labels as the only upper scan row still promote wave groups when autoDetectWaveBanners is true", () => {
+    // Root-cause regression for the groupLevelRowIndex skip bug:
+    // When wave-value labels appear in the only upper scan row, the detector
+    // elects that row as the group level (it is the only candidate, even though
+    // it is technical).  The old hasWaveValueLabelsInIntermediateUpperRow skipped
+    // the group-level row and therefore returned false, preventing wave promotion.
+    // After removing the skip, the function finds the wave values and promotes.
+    const bannerContext = {
+      selectedColumnCount: 4,
+      lowerBannerRow: ["", "", "", ""],
+      upperScanRows: [
+        ["w18 (ноябрь 24)", "w19 (май 25)", "w18 (ноябрь 24)", "w19 (май 25)"],
+        // Only one upper row — after mergeAdjacentWaveValueSpans it becomes a
+        // four-column technical span elected as the group level.
+      ],
+    };
+
+    const resultTrue = detectBannerStructure(bannerContext, { autoDetectWaveBanners: true });
+
+    for (const group of resultTrue.groups) {
+      assert.strictEqual(
+        group.recommendedComparisonMode,
+        "previousColumn",
+        "all groups in a pure wave-value banner should be wave-aware"
+      );
+    }
+
+    const resultFalse = detectBannerStructure(bannerContext, { autoDetectWaveBanners: false });
+
+    for (const group of resultFalse.groups) {
+      assert.notStrictEqual(
+        group.recommendedComparisonMode,
+        "previousColumn",
+        "previousColumn must not be enabled when autoDetectWaveBanners is false"
+      );
+    }
+  });
+
   it("quarter value labels (2025Q4 / 2026Q1) in upper scan row promote wave groups only when autoDetectWaveBanners is true", () => {
     // Same scenario as the compact-w test above, but with existing quarter-style
     // labels so there is a regression test for the vertically-merged layout for

--- a/tests/core/banner-detector.test.mjs
+++ b/tests/core/banner-detector.test.mjs
@@ -596,6 +596,154 @@ describe("detectBannerStructure - compact w-number wave value labels", () => {
       );
     }
   });
+
+  it("compact lower-row w18/w19 labels under semantic parent groups promote wave mode only when autoDetectWaveBanners is true", () => {
+    // Regression test for realistic compact wave labels like "w18 (ноябрь 24)" in
+    // the lowerBannerRow under named semantic groups.  Covers both the true and
+    // false autoDetectWaveBanners paths.
+    const bannerContext = {
+      selectedColumnCount: 6,
+      lowerBannerRow: [
+        "w18 (ноябрь 24)", "w19 (май 25)",
+        "w18 (ноябрь 24)", "w19 (май 25)",
+        "w18 (ноябрь 24)", "w19 (май 25)",
+      ],
+      upperScanRows: [
+        ["Всего", "", "Мужской", "", "Женский", ""],
+      ],
+    };
+
+    const resultTrue = detectBannerStructure(bannerContext, { autoDetectWaveBanners: true });
+
+    assert.deepStrictEqual(
+      resultTrue.groups.map((g) => ({
+        label: g.label,
+        columnIndexes: g.columnIndexes,
+        recommendedComparisonMode: g.recommendedComparisonMode,
+      })),
+      [
+        { label: "Всего",   columnIndexes: [0, 1], recommendedComparisonMode: "previousColumn" },
+        { label: "Мужской", columnIndexes: [2, 3], recommendedComparisonMode: "previousColumn" },
+        { label: "Женский", columnIndexes: [4, 5], recommendedComparisonMode: "previousColumn" },
+      ]
+    );
+
+    const resultFalse = detectBannerStructure(bannerContext, { autoDetectWaveBanners: false });
+
+    // sibling groups must remain separate and marker labels must restart
+    assert.strictEqual(resultFalse.groups.length, 3, "three sibling groups expected");
+
+    const groupKeys = resultFalse.groups.map((g) => g.groupKey);
+    assert.strictEqual(new Set(groupKeys).size, 3, "all three groups must have distinct keys");
+
+    const labelMap = buildBannerLocalSignificanceLabelMap(resultFalse, { autoDetectWaveBanners: false });
+
+    for (let base = 0; base < 6; base += 2) {
+      assert.strictEqual(labelMap.get(base),     "a", `column ${base} must get label a`);
+      assert.strictEqual(labelMap.get(base + 1), "b", `column ${base + 1} must get label b`);
+    }
+
+    for (const group of resultFalse.groups) {
+      assert.notStrictEqual(group.recommendedComparisonMode, "previousColumn");
+    }
+  });
+
+  it("compact w-number labels in upper scan row (vertically merged-like) promote wave groups only when autoDetectWaveBanners is true", () => {
+    // Reproduces the Excel smoke failure: Office.js returns blank text for the
+    // non-top cell of a vertically-merged banner cell, so the wave-value label
+    // (e.g. "w18 (ноябрь 24)") appears in upperScanRows rather than
+    // lowerBannerRow.  detectGroupKeysWithNestedWaveDimension must therefore
+    // also scan upper scan rows for wave value labels.
+    const bannerContext = {
+      selectedColumnCount: 4,
+      lowerBannerRow: ["", "", "", ""],
+      upperScanRows: [
+        ["w18 (ноябрь 24)", "w19 (май 25)", "w18 (ноябрь 24)", "w19 (май 25)"],
+        ["Всего", "", "Мужской", ""],
+      ],
+    };
+
+    const resultTrue = detectBannerStructure(bannerContext, { autoDetectWaveBanners: true });
+
+    assert.deepStrictEqual(
+      resultTrue.groups.map((g) => ({
+        label: g.label,
+        columnIndexes: g.columnIndexes,
+        recommendedComparisonMode: g.recommendedComparisonMode,
+      })),
+      [
+        { label: "Всего",   columnIndexes: [0, 1], recommendedComparisonMode: "previousColumn" },
+        { label: "Мужской", columnIndexes: [2, 3], recommendedComparisonMode: "previousColumn" },
+      ]
+    );
+
+    const resultFalse = detectBannerStructure(bannerContext, { autoDetectWaveBanners: false });
+
+    // sibling groups stay separate with restarting labels even without wave mode
+    assert.strictEqual(resultFalse.groups.length, 2, "two sibling groups expected");
+
+    const g0 = resultFalse.groups.find((g) => g.columnIndexes.includes(0));
+    const g2 = resultFalse.groups.find((g) => g.columnIndexes.includes(2));
+    assert.notStrictEqual(g0.groupKey, g2.groupKey, "groups must be distinct");
+
+    const labelMap = buildBannerLocalSignificanceLabelMap(resultFalse, { autoDetectWaveBanners: false });
+
+    assert.strictEqual(labelMap.get(0), "a");
+    assert.strictEqual(labelMap.get(1), "b");
+    assert.strictEqual(labelMap.get(2), "a");
+    assert.strictEqual(labelMap.get(3), "b");
+
+    for (const group of resultFalse.groups) {
+      assert.notStrictEqual(group.recommendedComparisonMode, "previousColumn");
+    }
+  });
+
+  it("quarter value labels (2025Q4 / 2026Q1) in upper scan row promote wave groups only when autoDetectWaveBanners is true", () => {
+    // Same scenario as the compact-w test above, but with existing quarter-style
+    // labels so there is a regression test for the vertically-merged layout for
+    // both label families in the same fix.
+    const bannerContext = {
+      selectedColumnCount: 4,
+      lowerBannerRow: ["", "", "", ""],
+      upperScanRows: [
+        ["2025Q4", "2026Q1", "2025Q4", "2026Q1"],
+        ["Всего", "", "Мужской", ""],
+      ],
+    };
+
+    const resultTrue = detectBannerStructure(bannerContext, { autoDetectWaveBanners: true });
+
+    assert.deepStrictEqual(
+      resultTrue.groups.map((g) => ({
+        label: g.label,
+        columnIndexes: g.columnIndexes,
+        recommendedComparisonMode: g.recommendedComparisonMode,
+      })),
+      [
+        { label: "Всего",   columnIndexes: [0, 1], recommendedComparisonMode: "previousColumn" },
+        { label: "Мужской", columnIndexes: [2, 3], recommendedComparisonMode: "previousColumn" },
+      ]
+    );
+
+    const resultFalse = detectBannerStructure(bannerContext, { autoDetectWaveBanners: false });
+
+    assert.strictEqual(resultFalse.groups.length, 2, "two sibling groups expected");
+
+    const g0 = resultFalse.groups.find((g) => g.columnIndexes.includes(0));
+    const g2 = resultFalse.groups.find((g) => g.columnIndexes.includes(2));
+    assert.notStrictEqual(g0.groupKey, g2.groupKey, "groups must be distinct");
+
+    const labelMap = buildBannerLocalSignificanceLabelMap(resultFalse, { autoDetectWaveBanners: false });
+
+    assert.strictEqual(labelMap.get(0), "a");
+    assert.strictEqual(labelMap.get(1), "b");
+    assert.strictEqual(labelMap.get(2), "a");
+    assert.strictEqual(labelMap.get(3), "b");
+
+    for (const group of resultFalse.groups) {
+      assert.notStrictEqual(group.recommendedComparisonMode, "previousColumn");
+    }
+  });
 });
 
 describe("detectBannerStructure - sparse lower banner totals", () => {

--- a/tests/core/banner-detector.test.mjs
+++ b/tests/core/banner-detector.test.mjs
@@ -508,6 +508,96 @@ describe("detectBannerStructure - group level selection", () => {
   });
 });
 
+describe("detectBannerStructure - compact w-number wave value labels", () => {
+  it("compact w-number labels in upper row with blank lower cells form one merged group with distinct sibling markers when autoDetectWaveBanners is false", () => {
+    // w6 / w7 in the upper row with blank lower cells must be recognised as
+    // technical wave-value labels so that mergeAdjacentWaveValueSpans merges
+    // them into a single two-column group instead of leaving two orphan
+    // one-column groups that both receive local label "a".
+    const bannerContext = {
+      selectedColumnCount: 6,
+      lowerBannerRow: ["", "", "w1", "w6", "w1", "w6"],
+      upperScanRows: [
+        ["w6", "w7", "Мужской", "", "Женский", ""],
+      ],
+    };
+
+    const result = detectBannerStructure(bannerContext, { autoDetectWaveBanners: false });
+
+    const groupForCol0 = result.groups.find((g) => g.columnIndexes.includes(0));
+    const groupForCol1 = result.groups.find((g) => g.columnIndexes.includes(1));
+
+    assert.ok(groupForCol0, "column 0 must be in a group");
+    assert.ok(groupForCol1, "column 1 must be in a group");
+    assert.strictEqual(
+      groupForCol0.groupKey,
+      groupForCol1.groupKey,
+      "columns 0 and 1 must share the same group key"
+    );
+    assert.deepStrictEqual(groupForCol0.columnIndexes, [0, 1]);
+
+    const groupForCol2 = result.groups.find((g) => g.columnIndexes.includes(2));
+    const groupForCol3 = result.groups.find((g) => g.columnIndexes.includes(3));
+
+    assert.ok(groupForCol2, "column 2 must be in a group");
+    assert.strictEqual(
+      groupForCol2.groupKey,
+      groupForCol3.groupKey,
+      "columns 2 and 3 must share the same group key"
+    );
+    assert.notStrictEqual(
+      groupForCol0.groupKey,
+      groupForCol2.groupKey,
+      "wave group and sibling group must be distinct"
+    );
+
+    const labelMap = buildBannerLocalSignificanceLabelMap(result, { autoDetectWaveBanners: false });
+
+    assert.strictEqual(labelMap.get(0), "a", "first column of wave group must get label a");
+    assert.strictEqual(labelMap.get(1), "b", "second column of wave group must get label b");
+    assert.strictEqual(labelMap.get(2), "a", "first column of sibling group must get label a");
+    assert.strictEqual(labelMap.get(3), "b", "second column of sibling group must get label b");
+
+    for (const group of result.groups) {
+      assert.notStrictEqual(group.recommendedComparisonMode, "previousColumn");
+    }
+  });
+
+  it("compact w-number labels in lower row promote previousColumn mode when autoDetectWaveBanners is true but not when false", () => {
+    const bannerContext = {
+      selectedColumnCount: 4,
+      lowerBannerRow: ["w6", "w7", "w6", "w7"],
+      upperScanRows: [
+        ["Group A", "", "Group B", ""],
+      ],
+    };
+
+    const resultTrue = detectBannerStructure(bannerContext, { autoDetectWaveBanners: true });
+
+    assert.deepStrictEqual(
+      resultTrue.groups.map((group) => ({
+        label: group.label,
+        columnIndexes: group.columnIndexes,
+        recommendedComparisonMode: group.recommendedComparisonMode,
+      })),
+      [
+        { label: "Group A", columnIndexes: [0, 1], recommendedComparisonMode: "previousColumn" },
+        { label: "Group B", columnIndexes: [2, 3], recommendedComparisonMode: "previousColumn" },
+      ]
+    );
+
+    const resultFalse = detectBannerStructure(bannerContext, { autoDetectWaveBanners: false });
+
+    for (const group of resultFalse.groups) {
+      assert.notStrictEqual(
+        group.recommendedComparisonMode,
+        "previousColumn",
+        "previousColumn mode must not be set when autoDetectWaveBanners is false"
+      );
+    }
+  });
+});
+
 describe("detectBannerStructure - sparse lower banner totals", () => {
   it("marks columns with empty lower label as local Total when nearest upper cell is total-like", () => {
     const bannerContext = {


### PR DESCRIPTION
## Summary

- Extends banner wave-value recognition so compact labels like `w18`, `W18`, `w 18`, `w-18`, `w_18`, and `w18 (...)` are treated as technical wave values.
- Adds upper-scan-row wave-value detection for vertically merged-like banner layouts where concrete wave labels such as `2025Q4` / `2026Q1` or `w18 (ноябрь 24)` appear above the immediate lower banner row.
- Preserves the existing `autoDetectWaveBanners` gate: recognition can happen broadly, but `previousColumn` wave behavior is only enabled when the existing setting allows it.

## What changes

The fix affects banner detection only:

1. **`isTechnicalWaveValueLabel`** now recognizes compact `w<number>` variants with optional separators:
   - `w18`
   - `W18`
   - `w 18`
   - `w-18`
   - `w_18`
   - `w18 (ноябрь 24)`
2. **`detectGroupKeysWithNestedWaveDimension`** now also checks upper scan rows for concrete wave value labels, not only `lowerBannerRow` and generic wave descriptors.
3. **Upper-row wave-value scanning does not skip the selected group-level row**, because in real merged-like layouts the wave-value row may itself be the only technical group-level candidate.

## Tests

Regression coverage was added for:

- compact `wN` labels in upper rows with blank lower cells;
- compact `wN` labels in lower rows under semantic groups;
- realistic `w18 (ноябрь 24)` / `w19 (май 25)` labels;
- separator variants: `w 18`, `w-18`, `w_18`, uppercase `W 18`;
- vertically merged-like layouts where wave values live in `upperScanRows`;
- existing quarter labels `2025Q4` / `2026Q1` in the same upper-row layout;
- ordinary `w`-words such as `woman` and `work` not being recognized as wave values;
- `autoDetectWaveBanners: true` vs `false` behavior.

## Affected areas

| Area | Impact |
|---|---|
| `src/core/banner-detector.js` | Wave-value classification and upper-row wave-value detection |
| `tests/core/banner-detector.test.mjs` | Regression coverage for compact `wN` and merged-like wave layouts |

## Validation

- `npm test`: passed locally during PR work.
- `npm run build`: passed locally during PR work, with pre-existing size warnings only.
- `git diff --check`: clean.
- Excel smoke passed after final update:
  - `w18 (ноябрь 24)` wave labels are detected correctly;
  - two-line / vertically merged-like `2025Q4` banner layout remains fixed;
  - `autoDetectWaveBanners` gate is preserved.

## Assumptions / limitations

- Only compact Latin `w` + number forms are treated as wave values.
- Labels like `wave6` or `w6a` are intentionally not recognized as compact wave values.
- Generic `wave` descriptor behavior remains governed by the existing banner dictionary logic.

Closes #301