### PR TITLE
[codex] Move settings incompatibility warnings to action area

### DIFF
--- a/src/taskpane/localization.js
+++ b/src/taskpane/localization.js
@@ -304,7 +304,7 @@ const STRINGS = {
     "settings.roundCellValues": "Round cell values",
     "settings.addTableFootnote": "Add footnote below table",
     "settings.addTableFootnoteUnavailable":
-      "Table footnote is unavailable when labels are not adjoined.",
+      "Table footnote is unavailable when labels are not adjacent to the data.",
     "settings.fillsGroup": "Fills",
     "settings.significantFillColor": "Regular significance",
     "settings.lowerThanTotalFillColor": "Fill < Total",

--- a/src/taskpane/taskpane.css
+++ b/src/taskpane/taskpane.css
@@ -371,6 +371,18 @@ b {
   font-weight: 600;
 }
 
+.action-warning-block {
+  margin: 6px 0 8px 0;
+  color: #c00000;
+  font-size: 12px;
+  line-height: 1.35;
+  font-weight: 600;
+}
+
+.action-warning-line + .action-warning-line {
+  margin-top: 3px;
+}
+
 .status-panel {
   width: 100%;
   box-sizing: border-box;

--- a/src/taskpane/taskpane.html
+++ b/src/taskpane/taskpane.html
@@ -81,15 +81,22 @@
           <button class="scope-btn" data-scope="whole_workbook" data-i18n="scope.wholeWorkbook">Вся книга</button>
         </div>
 
+        <div id="action-settings-warnings" class="action-warning-block" role="status" aria-live="polite" style="display: none">
+          <div class="action-warning-line" data-action-warning="footnote-labels-left" style="display: none">
+            <span data-i18n="settings.addTableFootnoteUnavailable">Подпись под таблицей недоступна, когда лейблы не примыкают к данным.</span>
+          </div>
+          <div class="action-warning-line" data-action-warning="recolor-labels-left" style="display: none">
+            <span data-i18n="settings.recolorBannerAndLabelsUnavailable">Перекраска баннера и лейблов недоступна, когда лейблы не примыкают к данным.</span>
+          </div>
+          <div class="action-warning-line" data-action-warning="manual-run-recolor" style="display: none">
+            <span data-i18n="hint.manualRunRecolorUnavailable">Перекраска баннера и лейблов недоступна в ручном расчёте. Используйте автозапуск по текущей таблице, листу или книге.</span>
+          </div>
+        </div>
+
         <!-- Workspaces: one shown at a time based on action + scope -->
 
         <div class="action-workspace" data-workspace="run-current_table">
           <p class="run-scope-fixed" data-i18n="hint.runCurrentTable">Область: выделенный диапазон</p>
-          <div id="manual-run-recolor-warning" class="settings-warning" style="display: none">
-            <span data-i18n="hint.manualRunRecolorUnavailable"
-              >Перекраска баннера и лейблов недоступна в ручном расчёте. Используйте автозапуск по текущей таблице, листу или книге.</span
-            >
-          </div>
           <div class="action-buttons-row">
             <button id="calculate-significance" class="primary-action-button">
               <svg class="btn-icon" viewBox="0 0 24 24" aria-hidden="true" focusable="false" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round"><rect x="4" y="2" width="16" height="20" rx="2"/><line x1="8" y1="6" x2="16" y2="6"/><line x1="16" y1="14" x2="16" y2="18"/><line x1="8" y1="10" x2="8" y2="10.01"/><line x1="12" y1="10" x2="12" y2="10.01"/><line x1="16" y1="10" x2="16" y2="10.01"/><line x1="8" y1="14" x2="8" y2="14.01"/><line x1="12" y1="14" x2="12" y2="14.01"/><line x1="8" y1="18" x2="8" y2="18.01"/><line x1="12" y1="18" x2="12" y2="18.01"/></svg>

--- a/src/taskpane/taskpane.js
+++ b/src/taskpane/taskpane.js
@@ -368,6 +368,7 @@ function initLanguageSelector() {
       // re-applies the mode-suffix in the new language.
       setLanguage(btn.dataset.lang);
       updateCheckHints();
+      refreshActionWarnings();
     });
   });
 }
@@ -652,6 +653,47 @@ function updateCheckHints() {
   });
 }
 
+function collectActionWarningKeys(action) {
+  if (action !== "run" && action !== "autorun") {
+    return [];
+  }
+
+  const labelsOnLeftSide = getCheckboxValue("labels-on-left-side");
+  const addTableFootnoteRequested = getCheckboxValue("add-table-footnote");
+  const recolorRequested = getCheckboxValue("recolor-banner-and-labels");
+  const warningKeys = [];
+
+  if (labelsOnLeftSide && addTableFootnoteRequested) {
+    warningKeys.push("footnote-labels-left");
+  }
+
+  if (labelsOnLeftSide && recolorRequested) {
+    warningKeys.push("recolor-labels-left");
+  } else if (action === "run" && recolorRequested) {
+    warningKeys.push("manual-run-recolor");
+  }
+
+  return warningKeys;
+}
+
+function refreshActionWarnings() {
+  const warningBlock = document.getElementById("action-settings-warnings");
+  if (!warningBlock) {
+    return;
+  }
+
+  const activeWarnings = new Set(collectActionWarningKeys(_currentAction));
+  let hasWarnings = false;
+
+  warningBlock.querySelectorAll("[data-action-warning]").forEach((line) => {
+    const show = activeWarnings.has(line.dataset.actionWarning);
+    line.style.display = show ? "" : "none";
+    hasWarnings = hasWarnings || show;
+  });
+
+  warningBlock.style.display = hasWarnings ? "" : "none";
+}
+
 function updateActionScopeShell(action, scope) {
   // Update action tab active states
   document.querySelectorAll(".action-tab").forEach((tab) => {
@@ -700,6 +742,7 @@ function updateActionScopeShell(action, scope) {
   }
 
   updateCheckHints();
+  refreshActionWarnings();
 }
 
 function initActionScopeShell() {
@@ -7773,6 +7816,7 @@ function refreshSettingsPanelState() {
   refreshBannerStructureSettingsState();
   refreshTableFootnoteState();
   refreshDesignRecolorState();
+  refreshActionWarnings();
 }
 
 /**
@@ -7789,17 +7833,14 @@ function refreshSettingsPanelState() {
  * is true. The checkbox value itself is preserved (not unchecked) so the user's
  * preference is restored if they turn labels-on-left-side off again.
  *
- * Design recolor is unavailable in Manual Run (a manual selected-range Run may
- * cover only part of a table), so a separate warning is shown in the Manual Run
- * workspace whenever the recolor setting is effectively enabled, pointing the
- * user to the autorun flows that do support it.
+ * Action-area warnings are rendered separately so they can stay contextual to
+ * the current Run/Autorun workspace.
  */
 function refreshDesignRecolorState() {
   const recolorCheckbox = document.getElementById("recolor-banner-and-labels");
   const colorInput = document.getElementById("banner-label-fill-color");
   const labelsOnLeftSideCheckbox = document.getElementById("labels-on-left-side");
   const warningElement = document.getElementById("recolor-banner-and-labels-warning");
-  const manualRunWarningElement = document.getElementById("manual-run-recolor-warning");
 
   if (!recolorCheckbox) {
     return;
@@ -7814,14 +7855,6 @@ function refreshDesignRecolorState() {
 
   if (warningElement) {
     warningElement.style.display = labelsOnLeftSide ? "block" : "none";
-  }
-
-  // Manual Run warning: shown only when recolor is effectively enabled. When
-  // labelsOnLeftSide forces recolor off the feature does nothing, so the Manual
-  // Run warning is hidden to avoid a misleading message.
-  if (manualRunWarningElement) {
-    const recolorEffectivelyEnabled = recolorCheckbox.checked && !labelsOnLeftSide;
-    manualRunWarningElement.style.display = recolorEffectivelyEnabled ? "block" : "none";
   }
 }
 


### PR DESCRIPTION
## Summary
- Add a shared action-area warning block in the sticky action panel near the Run/Clear/action controls.
- Centralize warning visibility in refreshActionWarnings(), refreshed from settings state, action/scope tab changes, saved settings load, and language changes.
- Keep setting-local warnings as secondary help and preserve existing effective settings behavior.

Fixes #309

## Validation
- npm test
- npm run build (passes with existing webpack bundle-size warnings)
- git diff --check