### PR TITLE
Add silent above-block Base fallback for metric detection (#310)

### DIFF
--- a/src/core/generated-rows.js
+++ b/src/core/generated-rows.js
@@ -1,0 +1,27 @@
+/**
+ * Core-safe detection of GENERATED RIT rows.
+ *
+ * PURPOSE:
+ * Some rows in a worksheet are written by RIT itself (not real table content)
+ * and must be treated as hard table boundaries by detection logic — e.g. the
+ * above-Base fallback must never cross them.
+ *
+ * This module is Office.js-free and lives in core so core detection code can
+ * recognise generated rows without depending on the taskpane/UI layer. The
+ * significance-footnote marker has its own module (significance-footnote.js);
+ * this module owns the Content backlink marker. The taskpane re-exports the
+ * backlink helpers from here so there is a single source of truth.
+ */
+
+// Visible Content-backlink marker written into the first cell of a generated
+// "back to table of contents" row.
+export const BACKLINK_MARKER = "← Оглавление";
+
+/**
+ * Returns true when a cell value is a generated RIT backlink row.
+ * Trimmed exact match, so ordinary content is never mistaken for a backlink.
+ */
+export function isGeneratedBacklinkRow(cellValue) {
+  if (cellValue === null || cellValue === undefined) return false;
+  return String(cellValue).trim() === BACKLINK_MARKER;
+}

--- a/src/core/metric-detector.js
+++ b/src/core/metric-detector.js
@@ -1,5 +1,6 @@
 import { METRIC_DICTIONARY } from "./config/dictionary.config"; // Импортируем наш конфиг
 import { normalizeLookupText } from "./string-utils";
+import { isGeneratedSignificanceFootnoteRow } from "./significance-footnote";
 
 export const LABEL_SCAN_COLUMNS_LEFT = 2;
 
@@ -386,6 +387,84 @@ function findBestBaseRowIndex(rowDiagnostics, startRowIndex, options) {
 }
 
 /**
+ * Returns true when a row is a generated RIT row (e.g. a significance-settings
+ * footnote) rather than real table content. Such rows act as hard table
+ * boundaries and must never be crossed by the upward Base fallback.
+ */
+function isGeneratedBoundaryRow(rowDiagnostic) {
+  return isGeneratedSignificanceFootnoteRow(rowDiagnostic?.rawLabel);
+}
+
+/**
+ * Silent upward fallback: finds a usable Base row ABOVE a metric block when no
+ * Base was found below it.
+ *
+ * PURPOSE:
+ * Some valid layouts place the Base row above the metric rows, e.g.
+ *   Base
+ *   Agree / Disagree        (proportions)
+ * or
+ *   Base
+ *   Mean / SD               (mean + spread)
+ * The primary below-block detection misses these, so the block would be skipped.
+ *
+ * BOUNDARIES (the search stops without a result when it would cross any of):
+ * - a blank separator row;
+ * - a generated RIT row (significance footnote / backlink);
+ * - any other value/metric row — these belong to the current or a previous
+ *   block, so we never tunnel past them looking for a distant Base;
+ * - a Base row already consumed by a previous below-block (would steal a Base
+ *   from a previous table).
+ *
+ * Only a Base row sitting directly above the block (optionally as part of a
+ * consecutive run of Base rows) is accepted. When a run is found, the same
+ * priority rules as below-detection pick the best Base in the run.
+ *
+ * @param {Array} rowDiagnostics
+ * @param {number} blockTopRowIndex - index of the block's first (topmost) row
+ * @param {Set<number>} consumedBaseRows - base indexes already used by a below-block
+ * @param {object} options - { preferredBase }
+ * @returns {number|null} best above-Base index, or null when none is usable
+ */
+function findBaseAboveBlockFallback(rowDiagnostics, blockTopRowIndex, consumedBaseRows, options) {
+  let scanIndex = blockTopRowIndex - 1;
+
+  while (scanIndex >= 0) {
+    const rowDiagnostic = rowDiagnostics[scanIndex];
+
+    // Generated rows and blank separators are hard table boundaries.
+    if (isGeneratedBoundaryRow(rowDiagnostic) || rowDiagnostic.rowType === "empty") {
+      return null;
+    }
+
+    if (rowDiagnostic.rowType === "base") {
+      // A Base already used by a previous block belongs to that table.
+      if (consumedBaseRows.has(scanIndex)) {
+        return null;
+      }
+
+      // Walk up to the top of this consecutive run of (unconsumed) Base rows so
+      // the existing priority rules can choose the best one in the run.
+      let runTopIndex = scanIndex;
+      while (
+        runTopIndex - 1 >= 0 &&
+        rowDiagnostics[runTopIndex - 1].rowType === "base" &&
+        !consumedBaseRows.has(runTopIndex - 1)
+      ) {
+        runTopIndex--;
+      }
+
+      return selectBestFromConsecutiveBases(rowDiagnostics, runTopIndex, options);
+    }
+
+    // Any other row type is a value/metric row; do not cross it.
+    return null;
+  }
+
+  return null;
+}
+
+/**
  * Builds calculation blocks from detected row labels.
  *
  * PURPOSE:
@@ -397,6 +476,7 @@ export function buildCalculationBlocks(detectionResult, { preferredBase = "auto"
   const calculationBlocks = []; // Final list of calculation blocks.
   const pendingProportionRows = []; // Proportion rows waiting for the next available base.
   const baseOptions = { preferredBase };
+  const consumedBaseRows = new Set(); // Base rows already claimed by a below-block.
 
   let rowIndex = 0; // Current row scanner position.
 
@@ -414,6 +494,7 @@ export function buildCalculationBlocks(detectionResult, { preferredBase = "auto"
     if (currentRowType === "base") {
       if (pendingProportionRows.length > 0) {
         const bestBaseIndex = selectBestFromConsecutiveBases(rowDiagnostics, rowIndex, baseOptions);
+        consumedBaseRows.add(bestBaseIndex);
         calculationBlocks.push(
           attachBaseSubtype(
             { metricType: "proportion", valueRowIndexes: [...pendingProportionRows], baseRowIndex: bestBaseIndex },
@@ -437,6 +518,7 @@ export function buildCalculationBlocks(detectionResult, { preferredBase = "auto"
       const baseRowIndex = findBestBaseRowIndex(rowDiagnostics, spreadRowIndex, baseOptions);
 
       if (baseRowIndex !== null) {
+        consumedBaseRows.add(baseRowIndex);
         calculationBlocks.push(
           attachBaseSubtype(
             { metricType: "mean", valueRowIndex: rowIndex, spreadRowIndex, spreadType: rowDiagnostics[spreadRowIndex].rowType, baseRowIndex },
@@ -458,6 +540,29 @@ export function buildCalculationBlocks(detectionResult, { preferredBase = "auto"
         rowIndex = spreadRowIndex + 1;
         continue;
       }
+
+      // Silent fallback: no Base below the mean block — try a Base directly above
+      // it within the same table context (issue #310). Statistical handling is
+      // unchanged; only the Base row source differs.
+      const aboveBaseRowIndex = findBaseAboveBlockFallback(
+        rowDiagnostics,
+        rowIndex,
+        consumedBaseRows,
+        baseOptions
+      );
+
+      if (aboveBaseRowIndex !== null) {
+        consumedBaseRows.add(aboveBaseRowIndex);
+        calculationBlocks.push(
+          attachBaseSubtype(
+            { metricType: "mean", valueRowIndex: rowIndex, spreadRowIndex, spreadType: rowDiagnostics[spreadRowIndex].rowType, baseRowIndex: aboveBaseRowIndex },
+            rowDiagnostics, aboveBaseRowIndex
+          )
+        );
+
+        rowIndex = spreadRowIndex + 1;
+        continue;
+      }
     }
 
 
@@ -465,6 +570,7 @@ export function buildCalculationBlocks(detectionResult, { preferredBase = "auto"
     const npsFirstBlock = tryParseNpsFirstBlock(rowDiagnostics, rowIndex);
     if (npsFirstBlock !== null) {
       const baseRowIndex = selectBestFromConsecutiveBases(rowDiagnostics, npsFirstBlock.baseRowIndex, baseOptions);
+      consumedBaseRows.add(baseRowIndex);
 
       if (pendingProportionRows.length > 0) {
         calculationBlocks.push(
@@ -509,6 +615,7 @@ export function buildCalculationBlocks(detectionResult, { preferredBase = "auto"
       const baseRowIndex = findBestBaseRowIndex(rowDiagnostics, spreadRowIndex, baseOptions);
 
       if (baseRowIndex !== null) {
+        consumedBaseRows.add(baseRowIndex);
         calculationBlocks.push(
           attachBaseSubtype(
             { metricType: "npsSpread", valueRowIndex: rowIndex, spreadRowIndex, spreadType: rowDiagnostics[spreadRowIndex].rowType, baseRowIndex },
@@ -546,6 +653,7 @@ export function buildCalculationBlocks(detectionResult, { preferredBase = "auto"
         const baseRowIndex = findBestBaseRowIndex(rowDiagnostics, rowIndex, baseOptions);
 
         if (baseRowIndex !== null) {
+          consumedBaseRows.add(baseRowIndex);
           // All buffered rows, including Detractors and Promoters, receive proportion markers.
           calculationBlocks.push(
             attachBaseSubtype(
@@ -570,6 +678,36 @@ export function buildCalculationBlocks(detectionResult, { preferredBase = "auto"
     }
 
     rowIndex++;
+  }
+
+  // Silent fallback for a proportion block whose Base sits ABOVE its rows
+  // (issue #310). Proportions are normally closed by a Base row below them; if
+  // any remain buffered at the end, no Base was found below. Try a Base directly
+  // above the block within the same table context before skipping it.
+  if (pendingProportionRows.length > 0) {
+    // Blank and generated rows are buffered with proportions, so anchor the
+    // upward search on the first real value row. A blank or generated row
+    // between that row and the Base above is then correctly treated as a table
+    // boundary.
+    const blockTopRowIndex = pendingProportionRows.find(
+      (idx) =>
+        rowDiagnostics[idx].rowType !== "empty" && !isGeneratedBoundaryRow(rowDiagnostics[idx])
+    );
+    const aboveBaseRowIndex =
+      blockTopRowIndex === undefined
+        ? null
+        : findBaseAboveBlockFallback(rowDiagnostics, blockTopRowIndex, consumedBaseRows, baseOptions);
+
+    if (aboveBaseRowIndex !== null) {
+      consumedBaseRows.add(aboveBaseRowIndex);
+      calculationBlocks.push(
+        attachBaseSubtype(
+          { metricType: "proportion", valueRowIndexes: [...pendingProportionRows], baseRowIndex: aboveBaseRowIndex },
+          rowDiagnostics, aboveBaseRowIndex
+        )
+      );
+      pendingProportionRows.length = 0;
+    }
   }
 
   return calculationBlocks;

--- a/src/core/metric-detector.js
+++ b/src/core/metric-detector.js
@@ -1,6 +1,7 @@
 import { METRIC_DICTIONARY } from "./config/dictionary.config"; // Импортируем наш конфиг
 import { normalizeLookupText } from "./string-utils";
 import { isGeneratedSignificanceFootnoteRow } from "./significance-footnote";
+import { isGeneratedBacklinkRow } from "./generated-rows";
 
 export const LABEL_SCAN_COLUMNS_LEFT = 2;
 
@@ -387,12 +388,26 @@ function findBestBaseRowIndex(rowDiagnostics, startRowIndex, options) {
 }
 
 /**
- * Returns true when a row is a generated RIT row (e.g. a significance-settings
- * footnote) rather than real table content. Such rows act as hard table
- * boundaries and must never be crossed by the upward Base fallback.
+ * Returns true when a row is a generated RIT row (a significance-settings
+ * footnote or a Content backlink) rather than real table content. Such rows act
+ * as hard table boundaries and must never be crossed by the upward Base
+ * fallback. Both markers are detected core-side so no taskpane dependency is
+ * introduced.
  */
 function isGeneratedBoundaryRow(rowDiagnostic) {
-  return isGeneratedSignificanceFootnoteRow(rowDiagnostic?.rawLabel);
+  const rawLabel = rowDiagnostic?.rawLabel;
+  return isGeneratedSignificanceFootnoteRow(rawLabel) || isGeneratedBacklinkRow(rawLabel);
+}
+
+/**
+ * Returns true when scanning upward must stop at this row because crossing it
+ * would leave the current continuous table segment: a blank separator row or a
+ * generated RIT row (footnote / backlink). Ordinary value/metric rows are NOT
+ * hard boundaries — within one continuous segment a single above-Base may be
+ * shared by several blocks.
+ */
+function isHardSegmentBoundaryRow(rowDiagnostic) {
+  return rowDiagnostic.rowType === "empty" || isGeneratedBoundaryRow(rowDiagnostic);
 }
 
 /**
@@ -400,56 +415,55 @@ function isGeneratedBoundaryRow(rowDiagnostic) {
  * Base was found below it.
  *
  * PURPOSE:
- * Some valid layouts place the Base row above the metric rows, e.g.
+ * Some valid layouts place the Base row above the metric rows, and a single
+ * above-Base may be shared by several blocks in the same continuous table, e.g.
  *   Base
- *   Agree / Disagree        (proportions)
- * or
- *   Base
- *   Mean / SD               (mean + spread)
- * The primary below-block detection misses these, so the block would be skipped.
+ *   Agree / Disagree        (proportion block)
+ *   Mean / SD               (mean block — same above Base)
  *
- * BOUNDARIES (the search stops without a result when it would cross any of):
- * - a blank separator row;
- * - a generated RIT row (significance footnote / backlink);
- * - any other value/metric row — these belong to the current or a previous
- *   block, so we never tunnel past them looking for a distant Base;
- * - a Base row already consumed by a previous below-block (would steal a Base
- *   from a previous table).
+ * SCAN MODEL:
+ * Scanning upward from the block, ordinary value/metric rows are crossed (they
+ * belong to the same continuous table segment, so the Base above them can be
+ * shared). The scan stops WITHOUT a result when it reaches:
+ * - a blank separator row              → end of the table segment;
+ * - a generated RIT footnote/backlink  → end of the table segment;
+ * - a Base already consumed by a BELOW-block → belongs to a previous table,
+ *   never stolen.
  *
- * Only a Base row sitting directly above the block (optionally as part of a
- * consecutive run of Base rows) is accepted. When a run is found, the same
- * priority rules as below-detection pick the best Base in the run.
+ * When an eligible Base is reached, the scan walks up the consecutive run of
+ * (non-below-consumed) Base rows and reuses the existing priority rules to pick
+ * the best Base in the run. A Base used by an above-fallback block is NOT
+ * marked consumed, so it can legitimately be shared by later blocks in the same
+ * segment.
  *
  * @param {Array} rowDiagnostics
  * @param {number} blockTopRowIndex - index of the block's first (topmost) row
- * @param {Set<number>} consumedBaseRows - base indexes already used by a below-block
+ * @param {Set<number>} basesConsumedByBelowBlock - base indexes claimed by a below-block
  * @param {object} options - { preferredBase }
  * @returns {number|null} best above-Base index, or null when none is usable
  */
-function findBaseAboveBlockFallback(rowDiagnostics, blockTopRowIndex, consumedBaseRows, options) {
-  let scanIndex = blockTopRowIndex - 1;
-
-  while (scanIndex >= 0) {
+function findBaseAboveBlockFallback(rowDiagnostics, blockTopRowIndex, basesConsumedByBelowBlock, options) {
+  for (let scanIndex = blockTopRowIndex - 1; scanIndex >= 0; scanIndex--) {
     const rowDiagnostic = rowDiagnostics[scanIndex];
 
-    // Generated rows and blank separators are hard table boundaries.
-    if (isGeneratedBoundaryRow(rowDiagnostic) || rowDiagnostic.rowType === "empty") {
+    // Blank/generated rows end the current table segment.
+    if (isHardSegmentBoundaryRow(rowDiagnostic)) {
       return null;
     }
 
     if (rowDiagnostic.rowType === "base") {
-      // A Base already used by a previous block belongs to that table.
-      if (consumedBaseRows.has(scanIndex)) {
+      // A Base already closed by a previous below-block belongs to that table.
+      if (basesConsumedByBelowBlock.has(scanIndex)) {
         return null;
       }
 
-      // Walk up to the top of this consecutive run of (unconsumed) Base rows so
-      // the existing priority rules can choose the best one in the run.
+      // Walk up to the top of this consecutive run of eligible Base rows so the
+      // existing priority rules can choose the best one in the run.
       let runTopIndex = scanIndex;
       while (
         runTopIndex - 1 >= 0 &&
         rowDiagnostics[runTopIndex - 1].rowType === "base" &&
-        !consumedBaseRows.has(runTopIndex - 1)
+        !basesConsumedByBelowBlock.has(runTopIndex - 1)
       ) {
         runTopIndex--;
       }
@@ -457,8 +471,7 @@ function findBaseAboveBlockFallback(rowDiagnostics, blockTopRowIndex, consumedBa
       return selectBestFromConsecutiveBases(rowDiagnostics, runTopIndex, options);
     }
 
-    // Any other row type is a value/metric row; do not cross it.
-    return null;
+    // Ordinary value/metric row: stay in the same segment and keep scanning up.
   }
 
   return null;
@@ -476,7 +489,11 @@ export function buildCalculationBlocks(detectionResult, { preferredBase = "auto"
   const calculationBlocks = []; // Final list of calculation blocks.
   const pendingProportionRows = []; // Proportion rows waiting for the next available base.
   const baseOptions = { preferredBase };
-  const consumedBaseRows = new Set(); // Base rows already claimed by a below-block.
+  // Base rows closed by a below-block. Tracked so the above-Base fallback never
+  // steals a Base that already belongs to a previous table. Bases used by the
+  // above-fallback are intentionally NOT recorded here so a single above-Base
+  // can be shared by several blocks within the same continuous table segment.
+  const basesConsumedByBelowBlock = new Set();
 
   let rowIndex = 0; // Current row scanner position.
 
@@ -494,7 +511,7 @@ export function buildCalculationBlocks(detectionResult, { preferredBase = "auto"
     if (currentRowType === "base") {
       if (pendingProportionRows.length > 0) {
         const bestBaseIndex = selectBestFromConsecutiveBases(rowDiagnostics, rowIndex, baseOptions);
-        consumedBaseRows.add(bestBaseIndex);
+        basesConsumedByBelowBlock.add(bestBaseIndex);
         calculationBlocks.push(
           attachBaseSubtype(
             { metricType: "proportion", valueRowIndexes: [...pendingProportionRows], baseRowIndex: bestBaseIndex },
@@ -518,7 +535,7 @@ export function buildCalculationBlocks(detectionResult, { preferredBase = "auto"
       const baseRowIndex = findBestBaseRowIndex(rowDiagnostics, spreadRowIndex, baseOptions);
 
       if (baseRowIndex !== null) {
-        consumedBaseRows.add(baseRowIndex);
+        basesConsumedByBelowBlock.add(baseRowIndex);
         calculationBlocks.push(
           attachBaseSubtype(
             { metricType: "mean", valueRowIndex: rowIndex, spreadRowIndex, spreadType: rowDiagnostics[spreadRowIndex].rowType, baseRowIndex },
@@ -547,12 +564,13 @@ export function buildCalculationBlocks(detectionResult, { preferredBase = "auto"
       const aboveBaseRowIndex = findBaseAboveBlockFallback(
         rowDiagnostics,
         rowIndex,
-        consumedBaseRows,
+        basesConsumedByBelowBlock,
         baseOptions
       );
 
       if (aboveBaseRowIndex !== null) {
-        consumedBaseRows.add(aboveBaseRowIndex);
+        // Not recorded as below-consumed: a shared above-Base may also serve
+        // other blocks in the same continuous table segment.
         calculationBlocks.push(
           attachBaseSubtype(
             { metricType: "mean", valueRowIndex: rowIndex, spreadRowIndex, spreadType: rowDiagnostics[spreadRowIndex].rowType, baseRowIndex: aboveBaseRowIndex },
@@ -570,7 +588,7 @@ export function buildCalculationBlocks(detectionResult, { preferredBase = "auto"
     const npsFirstBlock = tryParseNpsFirstBlock(rowDiagnostics, rowIndex);
     if (npsFirstBlock !== null) {
       const baseRowIndex = selectBestFromConsecutiveBases(rowDiagnostics, npsFirstBlock.baseRowIndex, baseOptions);
-      consumedBaseRows.add(baseRowIndex);
+      basesConsumedByBelowBlock.add(baseRowIndex);
 
       if (pendingProportionRows.length > 0) {
         calculationBlocks.push(
@@ -615,7 +633,7 @@ export function buildCalculationBlocks(detectionResult, { preferredBase = "auto"
       const baseRowIndex = findBestBaseRowIndex(rowDiagnostics, spreadRowIndex, baseOptions);
 
       if (baseRowIndex !== null) {
-        consumedBaseRows.add(baseRowIndex);
+        basesConsumedByBelowBlock.add(baseRowIndex);
         calculationBlocks.push(
           attachBaseSubtype(
             { metricType: "npsSpread", valueRowIndex: rowIndex, spreadRowIndex, spreadType: rowDiagnostics[spreadRowIndex].rowType, baseRowIndex },
@@ -653,7 +671,7 @@ export function buildCalculationBlocks(detectionResult, { preferredBase = "auto"
         const baseRowIndex = findBestBaseRowIndex(rowDiagnostics, rowIndex, baseOptions);
 
         if (baseRowIndex !== null) {
-          consumedBaseRows.add(baseRowIndex);
+          basesConsumedByBelowBlock.add(baseRowIndex);
           // All buffered rows, including Detractors and Promoters, receive proportion markers.
           calculationBlocks.push(
             attachBaseSubtype(
@@ -696,10 +714,9 @@ export function buildCalculationBlocks(detectionResult, { preferredBase = "auto"
     const aboveBaseRowIndex =
       blockTopRowIndex === undefined
         ? null
-        : findBaseAboveBlockFallback(rowDiagnostics, blockTopRowIndex, consumedBaseRows, baseOptions);
+        : findBaseAboveBlockFallback(rowDiagnostics, blockTopRowIndex, basesConsumedByBelowBlock, baseOptions);
 
     if (aboveBaseRowIndex !== null) {
-      consumedBaseRows.add(aboveBaseRowIndex);
       calculationBlocks.push(
         attachBaseSubtype(
           { metricType: "proportion", valueRowIndexes: [...pendingProportionRows], baseRowIndex: aboveBaseRowIndex },

--- a/src/taskpane/taskpane-inventory-formatters.js
+++ b/src/taskpane/taskpane-inventory-formatters.js
@@ -6,15 +6,11 @@
  * plain data structures.
  */
 
-export const BACKLINK_MARKER = "← Оглавление";
-
-/**
- * Returns true if the cell value is a generated backlink marker.
- */
-export function isGeneratedBacklinkRow(cellValue) {
-  if (cellValue === null || cellValue === undefined) return false;
-  return String(cellValue).trim() === BACKLINK_MARKER;
-}
+// The backlink marker and its detector live in core (generated-rows.js) so
+// core detection logic can treat generated backlink rows as table boundaries
+// without depending on the taskpane layer. Re-exported here to keep existing
+// taskpane imports working from a single source of truth.
+export { BACKLINK_MARKER, isGeneratedBacklinkRow } from "../core/generated-rows.js";
 
 export function getInventoryCandidateStatusLabel(candidateStatus) {
   if (candidateStatus === "available") {

--- a/src/taskpane/taskpane-inventory-formatters.js
+++ b/src/taskpane/taskpane-inventory-formatters.js
@@ -8,9 +8,13 @@
 
 // The backlink marker and its detector live in core (generated-rows.js) so
 // core detection logic can treat generated backlink rows as table boundaries
-// without depending on the taskpane layer. Re-exported here to keep existing
-// taskpane imports working from a single source of truth.
-export { BACKLINK_MARKER, isGeneratedBacklinkRow } from "../core/generated-rows.js";
+// without depending on the taskpane layer. Imported (for local use inside this
+// module) and re-exported to keep existing taskpane imports working from a
+// single source of truth. A bare `export { ... } from` would create no local
+// binding, so calls within this file would throw ReferenceError.
+import { BACKLINK_MARKER, isGeneratedBacklinkRow } from "../core/generated-rows.js";
+
+export { BACKLINK_MARKER, isGeneratedBacklinkRow };
 
 export function getInventoryCandidateStatusLabel(candidateStatus) {
   if (candidateStatus === "available") {

--- a/tests/core/metric-detector.test.mjs
+++ b/tests/core/metric-detector.test.mjs
@@ -7,6 +7,7 @@ import {
   extractRowLabelFromLeftCells,
 } from "../../src/core/metric-detector.js";
 import { SIGNIFICANCE_FOOTNOTE_MARKER } from "../../src/core/significance-footnote.js";
+import { BACKLINK_MARKER } from "../../src/core/generated-rows.js";
 
 function detectBlocks(values, labels) {
   const leftLabelValues = labels.map((label) => [label]);
@@ -403,6 +404,56 @@ describe("buildCalculationBlocks — silent above-block Base fallback", () => {
       ["BASE", footnoteLabel, "Agree", "Disagree"]
     );
     assert.deepStrictEqual(blocks, []);
+  });
+
+  it("10. generated backlink row between block and above Base: Base not crossed", () => {
+    const blocks = detectBlocks(
+      [[100, 200], [0, 0], [0.4, 0.6], [0.6, 0.4]],
+      ["BASE", BACKLINK_MARKER, "Agree", "Disagree"]
+    );
+    assert.deepStrictEqual(blocks, []);
+  });
+
+  // ── Shared above-Base reuse within one continuous table segment ────────────
+
+  it("shared Base above several proportion rows: one block uses the above Base", () => {
+    const blocks = detectBlocks(
+      [[100, 200], [0.4, 0.6], [0.6, 0.4], [0.2, 0.3]],
+      ["BASE", "Agree", "Disagree", "Other %"]
+    );
+    assert.deepStrictEqual(blocks, [
+      { metricType: "proportion", valueRowIndexes: [1, 2, 3], baseRowIndex: 0 },
+    ]);
+  });
+
+  it("shared Base above proportions + mean block: both blocks use the same above Base", () => {
+    const blocks = detectBlocks(
+      [[100, 200], [0.4, 0.6], [0.6, 0.4], [29.4, 31.5], [5.1, 6.2]],
+      ["BASE", "Agree", "Disagree", "Mean", "SD"]
+    );
+    const proportionBlock = blocks.find((b) => b.metricType === "proportion");
+    const meanBlock = blocks.find((b) => b.metricType === "mean");
+    assert.ok(proportionBlock, "expected a proportion block");
+    assert.ok(meanBlock, "expected a mean block");
+    assert.deepStrictEqual(proportionBlock.valueRowIndexes, [1, 2]);
+    assert.strictEqual(proportionBlock.baseRowIndex, 0);
+    assert.strictEqual(meanBlock.valueRowIndex, 3);
+    assert.strictEqual(meanBlock.spreadRowIndex, 4);
+    assert.strictEqual(meanBlock.spreadType, "standardDeviation");
+    assert.strictEqual(meanBlock.baseRowIndex, 0);
+  });
+
+  it("shared Base above two mean + SD blocks: both mean blocks use the same above Base", () => {
+    const blocks = detectBlocks(
+      [[100, 200], [29.4, 31.5], [5.1, 6.2], [42.0, 40.1], [7.3, 6.9]],
+      ["BASE", "Mean A", "SD", "Mean B", "SD"]
+    );
+    const meanBlocks = blocks.filter((b) => b.metricType === "mean");
+    assert.strictEqual(meanBlocks.length, 2);
+    assert.strictEqual(meanBlocks[0].valueRowIndex, 1);
+    assert.strictEqual(meanBlocks[0].baseRowIndex, 0);
+    assert.strictEqual(meanBlocks[1].valueRowIndex, 3);
+    assert.strictEqual(meanBlocks[1].baseRowIndex, 0);
   });
 
   it("uses nearest above Base run with priority when several Bases sit above", () => {

--- a/tests/core/metric-detector.test.mjs
+++ b/tests/core/metric-detector.test.mjs
@@ -6,6 +6,7 @@ import {
   detectMetricRowsFromLeftLabels,
   extractRowLabelFromLeftCells,
 } from "../../src/core/metric-detector.js";
+import { SIGNIFICANCE_FOOTNOTE_MARKER } from "../../src/core/significance-footnote.js";
 
 function detectBlocks(values, labels) {
   const leftLabelValues = labels.map((label) => [label]);
@@ -299,5 +300,122 @@ describe("buildCalculationBlocks — preferredBase option", () => {
     const blocks = detectBlocksWithPreference(values, labels, "weighted");
     assert.strictEqual(blocks.length, 1);
     assert.strictEqual(blocks[0].baseSubtype, undefined);
+  });
+});
+
+// ─── Silent above-block Base fallback (issue #310) ───────────────────────────
+
+describe("buildCalculationBlocks — silent above-block Base fallback", () => {
+  it("1. proportion block with Base below: behavior unchanged", () => {
+    const blocks = detectBlocks(
+      [[0.4, 0.6], [0.6, 0.4], [100, 200]],
+      ["Agree", "Disagree", "BASE"]
+    );
+    assert.deepStrictEqual(blocks, [
+      { metricType: "proportion", valueRowIndexes: [0, 1], baseRowIndex: 2 },
+    ]);
+  });
+
+  it("2. proportion block with Base above and none below: uses the above Base", () => {
+    const blocks = detectBlocks(
+      [[100, 200], [0.4, 0.6], [0.6, 0.4]],
+      ["BASE", "Agree", "Disagree"]
+    );
+    assert.deepStrictEqual(blocks, [
+      { metricType: "proportion", valueRowIndexes: [1, 2], baseRowIndex: 0 },
+    ]);
+  });
+
+  it("3. mean + SD block with Base above and none below: uses the above Base", () => {
+    const blocks = detectBlocks(
+      [[100, 200], [29.4, 31.5], [5.1, 6.2]],
+      ["BASE", "Mean", "SD"]
+    );
+    assert.deepStrictEqual(blocks, [
+      {
+        metricType: "mean",
+        valueRowIndex: 1,
+        spreadRowIndex: 2,
+        spreadType: "standardDeviation",
+        baseRowIndex: 0,
+      },
+    ]);
+  });
+
+  it("4. mean + Variance block with Base above and none below: uses the above Base", () => {
+    const blocks = detectBlocks(
+      [[100, 200], [29.4, 31.5], [103.6, 132.6]],
+      ["BASE", "Mean", "Variance"]
+    );
+    assert.deepStrictEqual(blocks, [
+      {
+        metricType: "mean",
+        valueRowIndex: 1,
+        spreadRowIndex: 2,
+        spreadType: "variance",
+        baseRowIndex: 0,
+      },
+    ]);
+  });
+
+  it("5. Base both above and below: the below Base wins", () => {
+    const blocks = detectBlocks(
+      [[100, 200], [0.4, 0.6], [0.6, 0.4], [110, 210]],
+      ["BASE", "Agree", "Disagree", "BASE"]
+    );
+    assert.deepStrictEqual(blocks, [
+      { metricType: "proportion", valueRowIndexes: [1, 2], baseRowIndex: 3 },
+    ]);
+  });
+
+  it("6. no Base below or above: existing skip behavior remains", () => {
+    const blocks = detectBlocks(
+      [[0.4, 0.6], [0.6, 0.4]],
+      ["Agree", "Disagree"]
+    );
+    assert.deepStrictEqual(blocks, []);
+  });
+
+  it("7. above Base separated by a blank row: not used", () => {
+    const blocks = detectBlocks(
+      [[100, 200], [null, null], [0.4, 0.6], [0.6, 0.4]],
+      ["BASE", "", "Agree", "Disagree"]
+    );
+    assert.deepStrictEqual(blocks, []);
+  });
+
+  it("8. two adjacent tables: lower table does not steal the upper table's Base", () => {
+    const blocks = detectBlocks(
+      [[0.4, 0.6], [0.6, 0.4], [100, 200], [0.3, 0.7], [0.7, 0.3]],
+      ["Agree", "Disagree", "BASE", "Agree", "Disagree"]
+    );
+    // Only the upper table forms a block (Base below it, consumed). The lower
+    // table finds no Base below and must not steal the upper table's Base above.
+    assert.deepStrictEqual(blocks, [
+      { metricType: "proportion", valueRowIndexes: [0, 1], baseRowIndex: 2 },
+    ]);
+  });
+
+  it("9. generated footnote row between block and above Base: Base not crossed", () => {
+    const footnoteLabel = `${SIGNIFICANCE_FOOTNOTE_MARKER}Уровень значимости: 95%.`;
+    const blocks = detectBlocks(
+      [[100, 200], [0, 0], [0.4, 0.6], [0.6, 0.4]],
+      ["BASE", footnoteLabel, "Agree", "Disagree"]
+    );
+    assert.deepStrictEqual(blocks, []);
+  });
+
+  it("uses nearest above Base run with priority when several Bases sit above", () => {
+    const blocks = detectBlocks(
+      [[200, 300], [160, 250], [0.4, 0.6], [0.6, 0.4]],
+      ["Base weighted", "Base effective", "Agree", "Disagree"]
+    );
+    // Both Bases form a consecutive run above the block; auto priority prefers
+    // the effective Base over the weighted one.
+    assert.strictEqual(blocks.length, 1);
+    assert.strictEqual(blocks[0].metricType, "proportion");
+    assert.deepStrictEqual(blocks[0].valueRowIndexes, [2, 3]);
+    assert.strictEqual(blocks[0].baseRowIndex, 1);
+    assert.strictEqual(blocks[0].baseSubtype, "effective");
   });
 });

--- a/tests/core/taskpane-inventory-formatters.test.mjs
+++ b/tests/core/taskpane-inventory-formatters.test.mjs
@@ -1,0 +1,56 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import {
+  BACKLINK_MARKER,
+  isGeneratedBacklinkRow,
+  resolveContentDisplayTitle,
+  formatInventoryItemLines,
+} from "../../src/taskpane/taskpane-inventory-formatters.js";
+
+// Regression guard: these helpers call isGeneratedBacklinkRow internally. A bare
+// `export { ... } from` re-export creates no local binding, so the calls would
+// throw ReferenceError at runtime. The local-binding tests below would catch it.
+
+describe("taskpane-inventory-formatters — backlink helper binding", () => {
+  it("re-exports a usable backlink marker and detector", () => {
+    assert.strictEqual(BACKLINK_MARKER, "← Оглавление");
+    assert.strictEqual(isGeneratedBacklinkRow(BACKLINK_MARKER), true);
+    assert.strictEqual(isGeneratedBacklinkRow("Agree"), false);
+  });
+});
+
+describe("resolveContentDisplayTitle — generated backlink title", () => {
+  it("returns the fallback and does not throw when title is the backlink marker", () => {
+    const title = resolveContentDisplayTitle(
+      { title: BACKLINK_MARKER, titleConfidence: "high" },
+      3
+    );
+    assert.strictEqual(title, "Таблица 3");
+  });
+
+  it("still returns a real high-confidence title", () => {
+    const title = resolveContentDisplayTitle(
+      { title: "Удовлетворённость", titleConfidence: "high" },
+      1
+    );
+    assert.strictEqual(title, "Удовлетворённость");
+  });
+});
+
+describe("formatInventoryItemLines — generated backlink title", () => {
+  it("does not throw and does not use the backlink marker as the display title", () => {
+    const lines = formatInventoryItemLines(
+      {
+        title: BACKLINK_MARKER,
+        rangeAddress: "Sheet1!A1:D5",
+        rowCount: 5,
+        columnCount: 4,
+        candidateStatus: "available",
+      },
+      2
+    );
+    // Header must fall back to the range only — the marker must not appear.
+    assert.strictEqual(lines[0], "2. Sheet1!A1:D5");
+    assert.ok(!lines.some((line) => line.includes(BACKLINK_MARKER)));
+  });
+});


### PR DESCRIPTION
Closes #310.

## Summary

Adds a **silent fallback** so metric detection can use a Base row placed **above** a metric block when no suitable Base is found below it. Below-block detection remains the primary path and is unchanged; if a Base exists both below and above, the below Base wins. A single above-Base may be **shared** by several blocks within the same continuous table.

## Root cause / current limitation

`buildCalculationBlocks` in `src/core/metric-detector.js` only ever resolved a Base **below** a block:
- proportion rows are buffered and flushed only when a `base` row is encountered below them (or attached to a mean/NPS block below);
- mean/NPS-spread blocks call `findBestBaseRowIndex`, which scans strictly downward (`findNextBaseRowIndex` starts at `startRowIndex + 1`).

So a layout with the Base above the metric rows produced no block and was silently skipped.

## How the upward fallback works (and how shared above-Base is bounded)

New pure helper `findBaseAboveBlockFallback(rowDiagnostics, blockTopRowIndex, basesConsumedByBelowBlock, options)` scans upward from the row directly above the block. **Ordinary value/metric rows are crossed** — within one continuous table segment a single above-Base can legitimately serve several blocks. The scan returns no result the moment it reaches a **hard segment boundary**:
- a **blank** separator row (`rowType === "empty"`);
- a **generated RIT row** — significance footnote (`isGeneratedSignificanceFootnoteRow`) **or** Content backlink `← Оглавление` (`isGeneratedBacklinkRow`);
- a Base **already consumed by a below-block** (belongs to a previous table — never stolen).

When an eligible Base is reached, the scan walks up the consecutive run of non-below-consumed Base rows and reuses the existing `selectBestFromConsecutiveBases` priority rules (effective > unweighted > plain > weighted, honouring `preferredBase`).

This enables the common shared layouts:
- shared Base above several proportion rows;
- shared Base above proportions **and** a mean+SD/Variance block (both use the same Base);
- shared Base above multiple mean+SD blocks.

## How stealing from a previous table is prevented

A `basesConsumedByBelowBlock` Set records every Base index **closed by a below-block**. The upward scan stops at any Base in that set, so a lower table cannot reuse the previous table's Base. Crucially, a Base used by the **above-fallback is NOT recorded** in that set, so it can still be shared by later blocks in the same segment — separating "below-closure consumption" (a previous-table signal) from "above-fallback sharing" (same-table reuse). Blank and generated rows act as hard boundaries; the proportion fallback anchors its search on the first *real* buffered row (skipping buffered blank/generated rows) so an intervening separator is honoured.

## Generated backlink boundary without bad layering

The backlink marker `← Оглавление` and `isGeneratedBacklinkRow` were moved into a new **core-safe** module `src/core/generated-rows.js` (Office.js-free). The taskpane (`src/taskpane/taskpane-inventory-formatters.js`) now re-exports them, so existing taskpane imports keep working from a single source of truth and core gains **no** dependency on the taskpane layer.

## Metric types supported

- **Proportion** blocks with Base above — supported (including shared Base).
- **Mean + SD / Variance** blocks with Base above — supported (per-block fallback; formulas/`spreadType` unchanged; shared Base supported).
- **NPS** layouts (NPS-first, extended NPS, NPS+spread) — **intentionally left on existing (below-only) behavior.** Their patterns parse the Base at a fixed offset below the structure; an above-Base there would risk the fixed marker-letter order and statistical inputs. Existing NPS/base tests are unchanged and still pass.

## What does NOT change

- No statistical formulas, no marker letter order.
- No Excel writer formatting/performance path.
- No Run report shape.
- No new user setting; the fallback is fully silent on success.
- No block-detection refactor.

## Tests (`tests/core/metric-detector.test.mjs`)

New suite *"silent above-block Base fallback"* covering:
1. proportion Base below — unchanged
2. proportion Base above only — uses above Base
3. mean + SD Base above — uses above Base
4. mean + Variance Base above — uses above Base
5. Base above **and** below — below wins
6. no Base anywhere — skipped
7. above Base separated by blank — not used
8. two adjacent tables — lower table does not steal upper Base
9. generated footnote row between block and above Base — not crossed
10. generated backlink row `← Оглавление` between block and above Base — not crossed
- shared Base above several proportion rows — one block, above Base
- shared Base above proportions + mean+SD — both blocks share the above Base
- shared Base above two mean+SD blocks — both share the above Base
- multiple Bases above — nearest run resolved by existing priority (effective wins)

## Validation

- `npm test` → **420 passing, 0 failing**
- `npm run build` → success (pre-existing bundle-size warnings only)
- `git diff --check` → clean

## Limitations

- A Base closed by a previous below-block is never reused, even within what might be the same continuous segment, to keep the no-stealing guarantee simple and safe.
- NPS layouts deliberately retain existing below-only Base behavior (see above).

## Manual smoke checklist (for human Excel review)

1. Normal table, Base below → output unchanged.
2. Proportion table, Base above rows → Run succeeds silently.
3. Mean + SD/Variance, Base above → Run succeeds silently.
4. Shared Base above proportions + mean → both calculate silently with the same Base.
5. Base both above and below → below wins.
6. No Base → existing skip behavior.
7. Two adjacent tables → previous Base not stolen.
8. Generated RIT footnote / backlink near table → does not confuse fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
