### PR TITLE
Harden significance marker alphabet and overflow handling (#312)

### DIFF
--- a/src/core/significance.js
+++ b/src/core/significance.js
@@ -165,34 +165,253 @@ export function compareAllProportionsInRow(
   return rowComparisons;
 }
 
+// Latin marker letters, excluding t / T (which are reserved for Total markers).
+const LATIN_LOWERCASE_MARKERS = "abcdefghijklmnopqrsuvwxyz"; // a-z without t.
+const LATIN_UPPERCASE_MARKERS = "ABCDEFGHIJKLMNOPQRSUVWXYZ"; // A-Z without T.
+
+// Allowed Cyrillic marker letters.
+//
+// Starting from the full Cyrillic alphabet we remove:
+// - т / Т — reserved for Total markers (pre-existing exclusion);
+// - visually confusable look-alikes of Latin markers (issue #312):
+//     а, А, В, с, С, е, Е, К, М, Н, о, О, р, Р, у, х, Х
+//
+// Note: lowercase Cyrillic `у` is excluded because it reads like Latin `y`,
+// but uppercase Cyrillic `У` is kept because it is visually distinct from
+// Latin `Y`.
+const CYRILLIC_LOWERCASE_MARKERS = "бвгджзийклмнпфцчшщъыьэюя";
+const CYRILLIC_UPPERCASE_MARKERS = "БГДЖЗИЙЛПУФЦЧШЩЪЫЬЭЮЯ";
+
+// Base alphabet used to build multi-character overflow markers (aa, ab, ac...).
+// Always lowercase Latin (without t) regardless of the Cyrillic setting so the
+// extended markers stay predictable and easy to recognise/clean up.
+const MULTI_CHARACTER_MARKER_BASE = LATIN_LOWERCASE_MARKERS.split("");
+
+// Every single-character token RIT may have written as a marker across any
+// historical alphabet (the pre-#312 Latin + full-Cyrillic set, minus t/Т).
+// Used for recognising/removing banner markers so legacy markers — including
+// now-excluded Cyrillic look-alikes — are still cleaned up on re-runs.
+const RECOGNIZED_SINGLE_CHARACTER_MARKERS = new Set(
+  (
+    "abcdefghijklmnopqrsuvwxyz" +
+    "ABCDEFGHIJKLMNOPQRSUVWXYZ" +
+    "абвгдежзийклмнопрсуфхцчшщъыьэюя" +
+    "АБВГДЕЖЗИЙКЛМНОПРСУФХЦЧШЩЪЫЬЭЮЯ"
+  ).split("")
+);
+
+/**
+ * Returns the ordered single-character significance marker alphabet.
+ *
+ * @param {object} [options]
+ * @param {boolean} [options.useCyrillicMarkers] When true, allowed Cyrillic
+ *   markers are appended after the Latin markers. Defaults to false so that,
+ *   for global release safety, generated markers are Latin-only unless the
+ *   user explicitly opts in.
+ */
+export function getSignificanceMarkerAlphabet(options = {}) {
+  const { useCyrillicMarkers = false } =
+    options && typeof options === "object" ? options : {};
+
+  const latinLabels = (LATIN_LOWERCASE_MARKERS + LATIN_UPPERCASE_MARKERS).split("");
+
+  if (!useCyrillicMarkers) {
+    return latinLabels;
+  }
+
+  const cyrillicLabels = (CYRILLIC_LOWERCASE_MARKERS + CYRILLIC_UPPERCASE_MARKERS).split("");
+
+  return [...latinLabels, ...cyrillicLabels];
+}
+
+/**
+ * Builds `count` multi-character overflow marker labels (aa, ab, ac, ...).
+ *
+ * Labels are produced as an odometer over MULTI_CHARACTER_MARKER_BASE, shortest
+ * length first: all 2-letter combinations, then 3-letter, and so on.
+ */
+function buildMultiCharacterMarkerLabels(count) {
+  const labels = [];
+  const base = MULTI_CHARACTER_MARKER_BASE;
+
+  for (let length = 2; labels.length < count; length++) {
+    const combinationCount = Math.pow(base.length, length);
+
+    for (let n = 0; n < combinationCount && labels.length < count; n++) {
+      let remainder = n;
+      let label = "";
+
+      for (let position = 0; position < length; position++) {
+        label = base[remainder % base.length] + label;
+        remainder = Math.floor(remainder / base.length);
+      }
+
+      labels.push(label);
+    }
+  }
+
+  return labels;
+}
+
 /**
  * Generates column significance labels.
  *
  * PURPOSE:
- * Create readable column labels for significance notation:
- * a-z, A-Z, а-я, А-Я.
+ * Create readable column labels for significance notation.
  *
  * IMPORTANT:
- * Excludes:
- * - Latin t / T
- * - Cyrillic т / Т
+ * - Latin t / T and Cyrillic т / Т are excluded (reserved for Total markers).
+ * - Cyrillic markers appear only when `useCyrillicMarkers` is enabled, and then
+ *   exclude the visually confusable Latin look-alikes (issue #312).
+ * - When the single-character alphabet is exhausted and
+ *   `allowMultiCharacterMarkers` is enabled, the sequence is extended with
+ *   multi-character markers (aa, ab, ac, ...).
+ *
+ * @param {object} [options]
+ * @param {boolean} [options.useCyrillicMarkers]
+ * @param {boolean} [options.allowMultiCharacterMarkers]
+ * @param {number} [options.minimumCount] Ensure the returned array has at least
+ *   this many labels (only extends past the single-character alphabet when
+ *   `allowMultiCharacterMarkers` is true).
  *
  * OUTPUT:
  * Array of labels.
  */
-export function generateSignificanceLabels() {
-  const latinLowercaseLabels = "abcdefghijklmnopqrsuvwxyz".split(""); // Latin a-z without t.
-  const latinUppercaseLabels = "ABCDEFGHIJKLMNOPQRSUVWXYZ".split(""); // Latin A-Z without T.
+export function generateSignificanceLabels(options = {}) {
+  const {
+    useCyrillicMarkers = false,
+    allowMultiCharacterMarkers = false,
+    minimumCount = 0,
+  } = options && typeof options === "object" ? options : {};
 
-  const cyrillicLowercaseLabels = "абвгдежзийклмнопрсуфхцчшщъыьэюя".split(""); // Cyrillic а-я without т.
-  const cyrillicUppercaseLabels = "АБВГДЕЖЗИЙКЛМНОПРСУФХЦЧШЩЪЫЬЭЮЯ".split(""); // Cyrillic А-Я without Т.
+  const singleCharacterLabels = getSignificanceMarkerAlphabet({ useCyrillicMarkers });
 
-  return [
-    ...latinLowercaseLabels,
-    ...latinUppercaseLabels,
-    ...cyrillicLowercaseLabels,
-    ...cyrillicUppercaseLabels,
-  ];
+  if (!allowMultiCharacterMarkers || minimumCount <= singleCharacterLabels.length) {
+    return singleCharacterLabels;
+  }
+
+  const extraLabels = buildMultiCharacterMarkerLabels(
+    minimumCount - singleCharacterLabels.length
+  );
+
+  return [...singleCharacterLabels, ...extraLabels];
+}
+
+/**
+ * Builds generation options for {@link generateSignificanceLabels} from the
+ * current calculation settings, ensuring at least `minimumCount` labels.
+ */
+function significanceLabelOptionsFromSettings(calculationSettings = {}, minimumCount = 0) {
+  return {
+    useCyrillicMarkers: Boolean(calculationSettings.useCyrillicMarkers),
+    allowMultiCharacterMarkers: Boolean(calculationSettings.allowMultiCharacterMarkers),
+    minimumCount,
+  };
+}
+
+/**
+ * Returns true when `label` is a token RIT could have written as a significance
+ * marker (one of the recognised single characters, or a multi-character
+ * overflow marker built from the lowercase Latin base).
+ *
+ * Used by banner marker recognition/removal so significance markers are
+ * detected without misreading ordinary parenthesised banner text such as
+ * "Wave (quarter)" or "Region (NE)".
+ */
+export function isSignificanceMarkerLabel(label) {
+  if (typeof label !== "string" || label.length === 0) {
+    return false;
+  }
+
+  if (label.length === 1) {
+    return RECOGNIZED_SINGLE_CHARACTER_MARKERS.has(label);
+  }
+
+  for (const character of label) {
+    if (!MULTI_CHARACTER_MARKER_BASE.includes(character)) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+/**
+ * Number of single-character markers available for the current settings.
+ */
+export function getSignificanceMarkerCapacity(calculationSettings = {}) {
+  return getSignificanceMarkerAlphabet({
+    useCyrillicMarkers: Boolean(calculationSettings.useCyrillicMarkers),
+  }).length;
+}
+
+/**
+ * Computes how many distinct single-character significance labels the given
+ * table would need to assign, so marker overflow can be detected before any
+ * results are written.
+ *
+ * - Banner mode: the largest per-group count of non-Total segment columns.
+ * - firstColumnIsTotal: every column except the Total column.
+ * - Otherwise: every column.
+ */
+export function computeRequiredSignificanceLabelCount(
+  columnCount,
+  calculationSettings = {},
+  bannerStructure = null
+) {
+  if (!Number.isFinite(columnCount) || columnCount < 1) {
+    return 0;
+  }
+
+  if (
+    calculationSettings.respectBannerStructure &&
+    bannerStructure &&
+    bannerStructure.groups &&
+    bannerStructure.groups.length > 0
+  ) {
+    const totalColumnIndexes = new Set(bannerStructure.totalColumnIndexes || []);
+    const globalTotalColumnIndex =
+      bannerStructure.globalTotalColumnIndex === undefined
+        ? null
+        : bannerStructure.globalTotalColumnIndex;
+
+    let maxSegmentCount = 0;
+
+    for (const group of bannerStructure.groups) {
+      let segmentCount = 0;
+
+      for (const columnIndex of group.columnIndexes || []) {
+        if (columnIndex === globalTotalColumnIndex || totalColumnIndexes.has(columnIndex)) {
+          continue;
+        }
+        segmentCount++;
+      }
+
+      maxSegmentCount = Math.max(maxSegmentCount, segmentCount);
+    }
+
+    return maxSegmentCount;
+  }
+
+  return calculationSettings.firstColumnIsTotal ? Math.max(0, columnCount - 1) : columnCount;
+}
+
+/**
+ * Returns true when the table needs more single-character significance markers
+ * than the current alphabet provides.
+ */
+export function detectSignificanceMarkerOverflow(
+  columnCount,
+  calculationSettings = {},
+  bannerStructure = null
+) {
+  const requiredCount = computeRequiredSignificanceLabelCount(
+    columnCount,
+    calculationSettings,
+    bannerStructure
+  );
+
+  return requiredCount > getSignificanceMarkerCapacity(calculationSettings);
 }
 
 /**
@@ -544,15 +763,22 @@ function buildBannerStructureComparisonPairs(
  * - etc.
  */
 export function getSignificanceLabelForColumnIndex(columnIndex, calculationSettings = {}) {
-  const labels = generateSignificanceLabels();
-
   if (calculationSettings.firstColumnIsTotal) {
     if (columnIndex === 0) {
       return "";
     }
 
-    return labels[columnIndex - 1] || "";
+    const labelIndex = columnIndex - 1;
+    const labels = generateSignificanceLabels(
+      significanceLabelOptionsFromSettings(calculationSettings, labelIndex + 1)
+    );
+
+    return labels[labelIndex] || "";
   }
+
+  const labels = generateSignificanceLabels(
+    significanceLabelOptionsFromSettings(calculationSettings, columnIndex + 1)
+  );
 
   return labels[columnIndex] || "";
 }
@@ -605,8 +831,6 @@ function getBannerGroupLocalSignificanceLabel(
   groupKey,
   calculationSettings = {}
 ) {
-  const labels = generateSignificanceLabels();
-
   const group = (bannerStructure.groups || []).find((candidate) => candidate.groupKey === groupKey);
 
   if (!group || !group.columnIndexes) {
@@ -636,6 +860,10 @@ function getBannerGroupLocalSignificanceLabel(
   if (localIndex < 0) {
     return "";
   }
+
+  const labels = generateSignificanceLabels(
+    significanceLabelOptionsFromSettings(calculationSettings, groupSegmentColumnIndexes.length)
+  );
 
   return labels[localIndex] || "";
 }
@@ -726,13 +954,22 @@ function applyFillReasonToCellResult(cellResult, fillReason) {
 
 /**
  * Appends ordinary segment marker and applies normal significance fill.
+ *
+ * When `useSpaceSeparator` is true (multi-character overflow mode), markers are
+ * separated with spaces so adjacent multi-character markers stay distinct, e.g.
+ * "aa ab ac" rather than the ambiguous "aaabac".
  */
-function appendSignificanceMarkerToCellResult(cellResult, marker) {
+function appendSignificanceMarkerToCellResult(cellResult, marker, useSpaceSeparator = false) {
   if (!marker) {
     return;
   }
 
-  cellResult.markers += marker;
+  if (useSpaceSeparator && cellResult.markers) {
+    cellResult.markers += ` ${marker}`;
+  } else {
+    cellResult.markers += marker;
+  }
+
   applyFillReasonToCellResult(cellResult, CELL_FILL_REASONS.SIGNIFICANT);
 }
 
@@ -742,11 +979,14 @@ function appendSignificanceMarkerToCellResult(cellResult, marker) {
  * T = segment is significantly higher than Total.
  * t = segment is significantly lower than Total.
  */
-function prependTotalMarkerToCellResult(cellResult, totalMarker) {
+function prependTotalMarkerToCellResult(cellResult, totalMarker, useSpaceSeparator = false) {
   const markerText = cellResult.markers || "";
-  const markerTextWithoutOldTotalMarker = markerText.replace(/[tT]/g, "");
+  const markerTextWithoutOldTotalMarker = markerText.replace(/[tT]/g, "").trim();
 
-  cellResult.markers = `${totalMarker}${markerTextWithoutOldTotalMarker}`;
+  const separator =
+    useSpaceSeparator && markerTextWithoutOldTotalMarker ? " " : "";
+
+  cellResult.markers = `${totalMarker}${separator}${markerTextWithoutOldTotalMarker}`;
 
   if (totalMarker === "T") {
     cellResult.hasPositiveTotalComparison = true;
@@ -840,7 +1080,12 @@ export function removeSignificanceMarkersFromText(rawText) {
     "абвгдежзийклмнопрсуфхцчшщъыьэюя" +
     "АБВГДЕЖЗИЙКЛМНОПРСУФХЦЧШЩЪЫЬЭЮЯ";
 
-  const markerSuffixPattern = new RegExp(`\\s*[${markerCharacters}↑↓]+$`);
+  // A marker token is a run of marker characters (and previous-column arrows).
+  // Match one trailing token plus any further space-separated tokens so that
+  // multi-character overflow markers ("42% aa ab ac") are removed in full, not
+  // just the last group.
+  const markerToken = `[${markerCharacters}↑↓]+`;
+  const markerSuffixPattern = new RegExp(`\\s*${markerToken}(?:\\s+${markerToken})*$`);
 
   return textValue.replace(markerSuffixPattern, "");
 }
@@ -1390,6 +1635,10 @@ export function applyComparisonResultsToFullCellResultMatrix(
   fullCellResultMatrix,
   calculationSettings = {}
 ) {
+  // In multi-character overflow mode, separate markers with spaces so adjacent
+  // multi-character markers stay distinct ("aa ab ac", not "aaabac").
+  const useSpaceSeparator = Boolean(calculationSettings.allowMultiCharacterMarkers);
+
   for (const comparisonRow of blockResults.comparisonRows) {
     const valueRowIndex = comparisonRow.valueRowIndex;
 
@@ -1419,7 +1668,8 @@ export function applyComparisonResultsToFullCellResultMatrix(
         applyTotalComparisonMarkerToFullCellResultMatrix(
           fullCellResultMatrix,
           valueRowIndex,
-          comparison
+          comparison,
+          useSpaceSeparator
         );
 
         continue;
@@ -1450,14 +1700,16 @@ export function applyComparisonResultsToFullCellResultMatrix(
       if (comparison.result.direction === "first_higher") {
         appendSignificanceMarkerToCellResult(
           fullCellResultMatrix[valueRowIndex][firstColumnIndex],
-          secondLabel
+          secondLabel,
+          useSpaceSeparator
         );
       }
 
       if (comparison.result.direction === "second_higher") {
         appendSignificanceMarkerToCellResult(
           fullCellResultMatrix[valueRowIndex][secondColumnIndex],
-          firstLabel
+          firstLabel,
+          useSpaceSeparator
         );
       }
     }
@@ -1476,7 +1728,8 @@ export function applyComparisonResultsToFullCellResultMatrix(
 function applyTotalComparisonMarkerToFullCellResultMatrix(
   fullCellResultMatrix,
   valueRowIndex,
-  comparison
+  comparison,
+  useSpaceSeparator = false
 ) {
   const totalReferenceColumnIndex = comparison.firstColumnIndex;
   const targetColumnIndex = comparison.secondColumnIndex;
@@ -1497,7 +1750,8 @@ function applyTotalComparisonMarkerToFullCellResultMatrix(
 
   prependTotalMarkerToCellResult(
     fullCellResultMatrix[valueRowIndex][targetColumnIndex],
-    totalMarker
+    totalMarker,
+    useSpaceSeparator
   );
 }
 
@@ -2006,11 +2260,22 @@ function buildBannerGroupKeyByColumnIndex(bannerStructure) {
  */
 export function buildBannerLocalSignificanceLabelMap(bannerStructure, calculationSettings = {}) {
   const labelMap = new Map();
-  const labels = generateSignificanceLabels();
 
   if (!bannerStructure || !bannerStructure.groups) {
     return labelMap;
   }
+
+  // The widest banner group decides how many labels we may need; when overflow
+  // markers are enabled this can extend past the single-character alphabet.
+  const requiredLabelCount = computeRequiredSignificanceLabelCount(
+    1,
+    { ...calculationSettings, respectBannerStructure: true },
+    bannerStructure
+  );
+
+  const labels = generateSignificanceLabels(
+    significanceLabelOptionsFromSettings(calculationSettings, requiredLabelCount)
+  );
 
   const totalColumnIndexes = new Set(bannerStructure.totalColumnIndexes || []);
   const globalTotalColumnIndex =

--- a/src/core/significance.js
+++ b/src/core/significance.js
@@ -350,6 +350,8 @@ export function getSignificanceMarkerCapacity(calculationSettings = {}) {
  * table would need to assign, so marker overflow can be detected before any
  * results are written.
  *
+ * - compareWithPreviousColumn: 0 — previous-column mode marks significance with
+ *   arrows, not letter labels, so the alphabet capacity is irrelevant.
  * - Banner mode: the largest per-group count of non-Total segment columns.
  * - firstColumnIsTotal: every column except the Total column.
  * - Otherwise: every column.
@@ -359,6 +361,12 @@ export function computeRequiredSignificanceLabelCount(
   calculationSettings = {},
   bannerStructure = null
 ) {
+  // Previous-column comparison uses arrow markers, never letter labels, so it
+  // can never overflow the marker alphabet regardless of table width.
+  if (calculationSettings.compareWithPreviousColumn) {
+    return 0;
+  }
+
   if (!Number.isFinite(columnCount) || columnCount < 1) {
     return 0;
   }
@@ -415,25 +423,29 @@ export function detectSignificanceMarkerOverflow(
 }
 
 /**
- * Operation-level overflow preflight for batch runs (current-sheet / workbook).
+ * Cheap operation-level overflow gate for batch runs (current-sheet / workbook),
+ * using each table's raw column count from the inventory.
  *
- * Decides whether ANY candidate table could overflow the marker alphabet,
- * using each table's raw column count from the inventory. This runs before any
- * table is written so the overflow decision can be made once, up front, without
- * partial results.
+ * This is a conservative upper bound: a table's actual required label count is
+ * always <= its raw column count (label/Total columns are dropped during
+ * interpretation, and banner groups are subsets of the columns). So:
+ * - if this returns false, NO eligible table can overflow — skip the dialog and
+ *   any exact preflight entirely;
+ * - if it returns true, a table is at least wide enough that overflow is
+ *   possible; the caller must confirm with the exact, mode-aware check before
+ *   prompting (raw width alone over-counts banner-group and Total columns).
  *
- * The check is deliberately conservative: a table's actual required label count
- * is always <= its raw column count (label/Total columns are dropped during
- * interpretation, and banner groups are subsets of the columns), so this never
- * misses a real overflow. It may over-prompt by a small margin near the
- * alphabet boundary, which is harmless (continuing keeps single-character
- * markers when they still fit).
+ * Previous-column mode never uses letter labels, so it always returns false.
  *
  * @param {Array<number>} columnCounts Raw column counts of the eligible tables.
  * @param {object} [calculationSettings] Used for the Cyrillic capacity.
  */
 export function detectBatchMarkerOverflow(columnCounts, calculationSettings = {}) {
   if (!Array.isArray(columnCounts)) {
+    return false;
+  }
+
+  if (calculationSettings.compareWithPreviousColumn) {
     return false;
   }
 

--- a/src/core/significance.js
+++ b/src/core/significance.js
@@ -415,6 +415,36 @@ export function detectSignificanceMarkerOverflow(
 }
 
 /**
+ * Operation-level overflow preflight for batch runs (current-sheet / workbook).
+ *
+ * Decides whether ANY candidate table could overflow the marker alphabet,
+ * using each table's raw column count from the inventory. This runs before any
+ * table is written so the overflow decision can be made once, up front, without
+ * partial results.
+ *
+ * The check is deliberately conservative: a table's actual required label count
+ * is always <= its raw column count (label/Total columns are dropped during
+ * interpretation, and banner groups are subsets of the columns), so this never
+ * misses a real overflow. It may over-prompt by a small margin near the
+ * alphabet boundary, which is harmless (continuing keeps single-character
+ * markers when they still fit).
+ *
+ * @param {Array<number>} columnCounts Raw column counts of the eligible tables.
+ * @param {object} [calculationSettings] Used for the Cyrillic capacity.
+ */
+export function detectBatchMarkerOverflow(columnCounts, calculationSettings = {}) {
+  if (!Array.isArray(columnCounts)) {
+    return false;
+  }
+
+  const capacity = getSignificanceMarkerCapacity(calculationSettings);
+
+  return columnCounts.some(
+    (columnCount) => Number.isFinite(columnCount) && columnCount > capacity
+  );
+}
+
+/**
  * Builds column comparison pairs based on current comparison settings.
  *
  * MODES:

--- a/src/taskpane/localization.js
+++ b/src/taskpane/localization.js
@@ -148,6 +148,7 @@ const STRINGS = {
     "settings.smallBaseThreshold": "База <",
 
     "settings.roundCellValues": "Округлять значения в ячейках",
+    "settings.useCyrillicMarkers": "Использовать кириллические маркеры",
     "settings.addTableFootnote": "Добавлять подпись под таблицей",
     "settings.addTableFootnoteUnavailable":
       "Подпись под таблицей недоступна, когда лейблы не примыкают к данным.",
@@ -163,6 +164,17 @@ const STRINGS = {
 
     "settings.oneTailedTest": "Односторонний тест",
     "settings.preferredBaseAuto": "Авто",
+
+    "markerOverflow.message":
+      "Колонок для сравнения больше, чем доступных однобуквенных маркеров значимости.\n\n" +
+      "Вы можете продолжить с многосимвольными маркерами (aa, ab, ac и т.д.) " +
+      "или остановить расчёт и изменить настройки.\n\n" +
+      "ОК — продолжить с многосимвольными маркерами.\n" +
+      "Отмена — остановить расчёт.",
+    "markerOverflow.stopped":
+      "Расчёт остановлен: колонок для сравнения больше, чем доступных " +
+      "однобуквенных маркеров значимости. Измените настройки или сократите " +
+      "число сравниваемых колонок.",
 
     "help.link": "Справка об использовании",
   },
@@ -302,6 +314,7 @@ const STRINGS = {
     "settings.smallBaseThreshold": "Base <",
 
     "settings.roundCellValues": "Round cell values",
+    "settings.useCyrillicMarkers": "Use Cyrillic significance markers",
     "settings.addTableFootnote": "Add footnote below table",
     "settings.addTableFootnoteUnavailable":
       "Table footnote is unavailable when labels are not adjacent to the data.",
@@ -317,6 +330,17 @@ const STRINGS = {
 
     "settings.oneTailedTest": "One-tailed test",
     "settings.preferredBaseAuto": "Auto",
+
+    "markerOverflow.message":
+      "There are more comparable columns than available single-letter significance markers.\n\n" +
+      "You can continue with multi-character markers (aa, ab, ac, etc.) " +
+      "or stop the calculation and change the settings.\n\n" +
+      "OK — continue with multi-character markers.\n" +
+      "Cancel — stop the calculation.",
+    "markerOverflow.stopped":
+      "Calculation stopped: there are more comparable columns than available " +
+      "single-letter significance markers. Change the settings or reduce the " +
+      "number of compared columns.",
 
     "help.link": "User guide",
   },

--- a/src/taskpane/localization.js
+++ b/src/taskpane/localization.js
@@ -165,12 +165,13 @@ const STRINGS = {
     "settings.oneTailedTest": "Односторонний тест",
     "settings.preferredBaseAuto": "Авто",
 
+    "markerOverflow.title": "Недостаточно однобуквенных маркеров",
     "markerOverflow.message":
       "Колонок для сравнения больше, чем доступных однобуквенных маркеров значимости.\n\n" +
       "Вы можете продолжить с многосимвольными маркерами (aa, ab, ac и т.д.) " +
-      "или остановить расчёт и изменить настройки.\n\n" +
-      "ОК — продолжить с многосимвольными маркерами.\n" +
-      "Отмена — остановить расчёт.",
+      "или остановить расчёт и изменить настройки.",
+    "markerOverflow.continue": "Продолжить с многосимвольными маркерами",
+    "markerOverflow.stop": "Остановить расчёт",
     "markerOverflow.stopped":
       "Расчёт остановлен: колонок для сравнения больше, чем доступных " +
       "однобуквенных маркеров значимости. Измените настройки или сократите " +
@@ -331,12 +332,13 @@ const STRINGS = {
     "settings.oneTailedTest": "One-tailed test",
     "settings.preferredBaseAuto": "Auto",
 
+    "markerOverflow.title": "Not enough single-letter markers",
     "markerOverflow.message":
       "There are more comparable columns than available single-letter significance markers.\n\n" +
       "You can continue with multi-character markers (aa, ab, ac, etc.) " +
-      "or stop the calculation and change the settings.\n\n" +
-      "OK — continue with multi-character markers.\n" +
-      "Cancel — stop the calculation.",
+      "or stop the calculation and change the settings.",
+    "markerOverflow.continue": "Continue with multi-character markers",
+    "markerOverflow.stop": "Stop calculation",
     "markerOverflow.stopped":
       "Calculation stopped: there are more comparable columns than available " +
       "single-letter significance markers. Change the settings or reduce the " +

--- a/src/taskpane/selected-range-interpreter.js
+++ b/src/taskpane/selected-range-interpreter.js
@@ -13,7 +13,10 @@
  * Office.js context for loading labels and banner rows from the sheet.
  */
 
-import { removeSignificanceMarkersFromMatrix, generateSignificanceLabels } from "../core/significance";
+import {
+  removeSignificanceMarkersFromMatrix,
+  isSignificanceMarkerLabel,
+} from "../core/significance";
 import { LABEL_SCAN_COLUMNS_LEFT } from "../core/metric-detector";
 import { normalizeSelectedRange } from "../core/range-normalizer";
 import { resolveAdjacentLabelColumnCount } from "../core/design-recolor";
@@ -383,12 +386,11 @@ function buildRunBannerContext(bannerContext) {
  */
 function stripAllTrailingBannerMarkersFromCell(rawText) {
   if (rawText === null || rawText === undefined) return "";
-  const labels = generateSignificanceLabels();
   let result = String(rawText);
   for (;;) {
     const match = result.match(/(^|\s)\(([^()]*)\)\s*$/);
     if (!match) break;
-    if (!labels.includes(match[2])) break;
+    if (!isSignificanceMarkerLabel(match[2])) break;
     result = result.slice(0, match.index).trim();
   }
   return result;

--- a/src/taskpane/taskpane-settings.js
+++ b/src/taskpane/taskpane-settings.js
@@ -29,6 +29,7 @@ export const SETTINGS_CONTROL_CONFIG = [
 
   { id: "write-banner-letters", type: "checked", settingName: "writeBannerLetters" },
   { id: "respect-banner-structure", type: "checked", settingName: "respectBannerStructure" },
+  { id: "use-cyrillic-markers", type: "checked", settingName: "useCyrillicMarkers" },
   {
     id: "auto-detect-wave-banners",
     type: "checked",
@@ -94,6 +95,9 @@ export const DEFAULT_CALCULATION_SETTINGS = {
   respectBannerStructure: false,
   autoDetectWaveBanners: false,
   labelsOnLeftSide: false,
+
+  // Default-off for global release safety (issue #312).
+  useCyrillicMarkers: false,
 
   compareOnlyWithTotal: false,
   excludeTotalFromComparisons: false,

--- a/src/taskpane/taskpane.css
+++ b/src/taskpane/taskpane.css
@@ -980,3 +980,88 @@ b {
 .inventory-mode-row {
   margin-top: 8px;
 }
+
+/* ── Marker-overflow modal (issue #312) ─────────────────────────────────── */
+.rs-modal-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 16px;
+  box-sizing: border-box;
+  background: rgba(17, 24, 39, 0.45);
+}
+
+.rs-modal {
+  width: 100%;
+  max-width: 360px;
+  box-sizing: border-box;
+  padding: 18px 18px 16px;
+  border: 1px solid var(--rs-color-border);
+  border-radius: var(--rs-radius-lg);
+  background: var(--rs-color-bg);
+  box-shadow: 0 10px 30px rgba(17, 24, 39, 0.25);
+}
+
+.rs-modal-title {
+  margin: 0 0 10px 0;
+  font-size: 15px;
+  font-weight: 700;
+  color: var(--rs-color-text);
+}
+
+.rs-modal-body {
+  margin: 0 0 16px 0;
+  font-size: 13px;
+  line-height: 1.45;
+  color: var(--rs-color-text);
+  white-space: pre-line;
+}
+
+.rs-modal-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  justify-content: flex-end;
+}
+
+.rs-modal-button {
+  box-sizing: border-box;
+  padding: 8px 14px;
+  border-radius: var(--rs-radius-md);
+  font-size: 13px;
+  font-weight: 700;
+  cursor: pointer;
+  transition:
+    background-color 0.15s ease,
+    border-color 0.15s ease,
+    box-shadow 0.15s ease;
+}
+
+.rs-modal-button-primary {
+  border: 1px solid var(--rs-color-primary);
+  background: var(--rs-color-primary);
+  color: #ffffff;
+}
+
+.rs-modal-button-primary:hover {
+  background: var(--rs-color-primary-dark);
+  border-color: var(--rs-color-primary-dark);
+}
+
+.rs-modal-button-secondary {
+  border: 1px solid var(--rs-color-border);
+  background: transparent;
+  color: var(--rs-color-text);
+}
+
+.rs-modal-button-secondary:hover {
+  background: var(--rs-color-bg-soft);
+}
+
+.rs-modal-button:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px rgba(22, 163, 74, 0.35);
+}

--- a/src/taskpane/taskpane.html
+++ b/src/taskpane/taskpane.html
@@ -407,6 +407,10 @@
               <input type="checkbox" id="round-cell-values" />
               <span data-i18n="settings.roundCellValues">Округлять значения в ячейках</span>
             </label>
+            <label class="inline-checkbox-label" for="use-cyrillic-markers">
+              <input type="checkbox" id="use-cyrillic-markers" />
+              <span data-i18n="settings.useCyrillicMarkers">Использовать кириллические маркеры</span>
+            </label>
           </div>
 
           <div class="settings-group">

--- a/src/taskpane/taskpane.html
+++ b/src/taskpane/taskpane.html
@@ -479,5 +479,44 @@
         >
       </footer>
     </main>
+
+    <!-- Marker-overflow confirmation dialog (issue #312). In-taskpane modal:
+         window.confirm is not supported in the Office add-in webview. -->
+    <div
+      id="marker-overflow-dialog"
+      class="rs-modal-overlay"
+      style="display: none"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="marker-overflow-title"
+      aria-describedby="marker-overflow-body"
+    >
+      <div class="rs-modal" role="document">
+        <h2 id="marker-overflow-title" class="rs-modal-title" data-i18n="markerOverflow.title">
+          Недостаточно однобуквенных маркеров
+        </h2>
+        <p id="marker-overflow-body" class="rs-modal-body" data-i18n="markerOverflow.message">
+          Колонок для сравнения больше, чем доступных однобуквенных маркеров значимости.
+        </p>
+        <div class="rs-modal-actions">
+          <button
+            type="button"
+            id="marker-overflow-stop"
+            class="rs-modal-button rs-modal-button-secondary"
+            data-i18n="markerOverflow.stop"
+          >
+            Остановить расчёт
+          </button>
+          <button
+            type="button"
+            id="marker-overflow-continue"
+            class="rs-modal-button rs-modal-button-primary"
+            data-i18n="markerOverflow.continue"
+          >
+            Продолжить с многосимвольными маркерами
+          </button>
+        </div>
+      </div>
+    </div>
   </body>
 </html>

--- a/src/taskpane/taskpane.js
+++ b/src/taskpane/taskpane.js
@@ -798,15 +798,55 @@ function initActionScopeShell() {
  * - NPS + SD/Variance + Base
  */
 /**
- * Shows the marker-overflow dialog. Returns true to continue with
- * multi-character markers, false to stop the calculation.
+ * Shows the in-taskpane marker-overflow dialog and resolves the user's choice.
  *
- * Uses window.confirm, which is supported in the Office add-in webview and is
- * consistent with keeping the release-time UX minimal: OK continues with
- * multi-character markers, Cancel stops the calculation.
+ * window.confirm is not supported in the Office add-in webview, so this drives a
+ * small custom modal defined in taskpane.html. Returns a Promise:
+ * - true  → continue with multi-character markers;
+ * - false → stop the calculation.
+ *
+ * Esc, clicking the backdrop, or missing markup all resolve to false (stop) so
+ * the safe choice (no writes) is the default.
  */
 function confirmMarkerOverflowDialog() {
-  return window.confirm(t("markerOverflow.message"));
+  return new Promise((resolve) => {
+    const overlay = document.getElementById("marker-overflow-dialog");
+    const continueButton = document.getElementById("marker-overflow-continue");
+    const stopButton = document.getElementById("marker-overflow-stop");
+
+    if (!overlay || !continueButton || !stopButton) {
+      // Fail safe: without the dialog markup, stop rather than write blindly.
+      resolve(false);
+      return;
+    }
+
+    const finish = (shouldContinue) => {
+      overlay.style.display = "none";
+      continueButton.removeEventListener("click", onContinue);
+      stopButton.removeEventListener("click", onStop);
+      overlay.removeEventListener("mousedown", onBackdrop);
+      document.removeEventListener("keydown", onKeydown);
+      resolve(shouldContinue);
+    };
+
+    const onContinue = () => finish(true);
+    const onStop = () => finish(false);
+    const onBackdrop = (event) => {
+      // Clicking outside the dialog body counts as Stop.
+      if (event.target === overlay) finish(false);
+    };
+    const onKeydown = (event) => {
+      if (event.key === "Escape") finish(false);
+    };
+
+    continueButton.addEventListener("click", onContinue);
+    stopButton.addEventListener("click", onStop);
+    overlay.addEventListener("mousedown", onBackdrop);
+    document.addEventListener("keydown", onKeydown);
+
+    overlay.style.display = "flex";
+    continueButton.focus();
+  });
 }
 
 /**
@@ -814,17 +854,28 @@ function confirmMarkerOverflowDialog() {
  *
  * The dialog is shown at most once per Run; the user's choice is then reused for
  * every table processed in the same operation (so batch runs do not re-prompt
- * for each table). `resolve()` returns "continue" or "stop".
+ * for each table). `resolve()` is async and returns "continue" or "stop". A
+ * shared in-flight promise guards against showing two dialogs if `resolve()` is
+ * awaited from more than one place before the first choice is made.
  */
 function createMarkerOverflowDecider() {
   let decision = null; // null | "continue" | "stop"
+  let pending = null;
 
   return {
-    resolve() {
-      if (decision === null) {
-        decision = confirmMarkerOverflowDialog() ? "continue" : "stop";
+    async resolve() {
+      if (decision !== null) {
+        return decision;
       }
-      return decision;
+
+      if (!pending) {
+        pending = confirmMarkerOverflowDialog().then((shouldContinue) => {
+          decision = shouldContinue ? "continue" : "stop";
+          return decision;
+        });
+      }
+
+      return pending;
     },
     get decision() {
       return decision;
@@ -846,7 +897,7 @@ function createMarkerOverflowDecider() {
  * safety net; because the shared decider's choice is cached here, it never
  * re-prompts.
  */
-function preflightBatchMarkerOverflow(eligible, itemMap, calculationSettings, decider) {
+async function preflightBatchMarkerOverflow(eligible, itemMap, calculationSettings, decider) {
   const columnCounts = eligible.map((candidate) => {
     const item = itemMap.get(`${candidate.sheetName}!${candidate.rangeAddress}`);
     return item ? item.columnCount : undefined;
@@ -856,7 +907,7 @@ function preflightBatchMarkerOverflow(eligible, itemMap, calculationSettings, de
     return false;
   }
 
-  if (decider.resolve() === "stop") {
+  if ((await decider.resolve()) === "stop") {
     return true;
   }
 
@@ -1021,7 +1072,7 @@ async function runSignificanceFromSelection() {
         bannerStructure
       )
     ) {
-      if (markerOverflowDecider.resolve() === "stop") {
+      if ((await markerOverflowDecider.resolve()) === "stop") {
         setStatusMessage(t("markerOverflow.stopped"));
         return;
       }
@@ -1356,7 +1407,7 @@ async function runSignificanceForRangeInContext(
     )
   ) {
     const activeDecider = markerOverflowDecider || createMarkerOverflowDecider();
-    if (activeDecider.resolve() === "stop") {
+    if ((await activeDecider.resolve()) === "stop") {
       return { status: "stopped", message: "расчёт остановлен — превышен лимит маркеров", rangeAddress };
     }
     // Mutate the (per-operation) settings so every table in the batch uses
@@ -1953,7 +2004,7 @@ async function runAutoSignificance() {
 
   // Operation-level marker-overflow preflight: decide once, before any table is
   // written. Stop aborts the whole run with no partial results.
-  if (preflightBatchMarkerOverflow(eligible, itemMap, calculationSettings, markerOverflowDecider)) {
+  if (await preflightBatchMarkerOverflow(eligible, itemMap, calculationSettings, markerOverflowDecider)) {
     setStatusMessage(t("markerOverflow.stopped"));
     return;
   }
@@ -3849,7 +3900,7 @@ async function runCurrentSheetSignificance() {
 
   // Operation-level marker-overflow preflight: decide once, before any table is
   // written. Stop aborts the whole run with no partial results.
-  if (preflightBatchMarkerOverflow(eligible, itemMap, calculationSettings, markerOverflowDecider)) {
+  if (await preflightBatchMarkerOverflow(eligible, itemMap, calculationSettings, markerOverflowDecider)) {
     setStatusMessage(t("markerOverflow.stopped"));
     return;
   }

--- a/src/taskpane/taskpane.js
+++ b/src/taskpane/taskpane.js
@@ -3,7 +3,7 @@
  * See LICENSE in the project root for license information.
  */
 
-/* global console, document, Excel, Office */
+/* global console, document, window, Excel, Office */
 
 import {
   createEmptyCellResultMatrix,
@@ -18,6 +18,8 @@ import {
   removeSignificanceMarkersFromText,
   generateSignificanceLabels,
   buildBannerLocalSignificanceLabelMap,
+  isSignificanceMarkerLabel,
+  detectSignificanceMarkerOverflow,
 } from "../core/significance";
 
 import {
@@ -794,9 +796,45 @@ function initActionScopeShell() {
  * - NPS + Promoters + Detractors + Base
  * - NPS + SD/Variance + Base
  */
+/**
+ * Shows the marker-overflow dialog. Returns true to continue with
+ * multi-character markers, false to stop the calculation.
+ *
+ * Uses window.confirm, which is supported in the Office add-in webview and is
+ * consistent with keeping the release-time UX minimal: OK continues with
+ * multi-character markers, Cancel stops the calculation.
+ */
+function confirmMarkerOverflowDialog() {
+  return window.confirm(t("markerOverflow.message"));
+}
+
+/**
+ * Per-operation marker-overflow decision.
+ *
+ * The dialog is shown at most once per Run; the user's choice is then reused for
+ * every table processed in the same operation (so batch runs do not re-prompt
+ * for each table). `resolve()` returns "continue" or "stop".
+ */
+function createMarkerOverflowDecider() {
+  let decision = null; // null | "continue" | "stop"
+
+  return {
+    resolve() {
+      if (decision === null) {
+        decision = confirmMarkerOverflowDialog() ? "continue" : "stop";
+      }
+      return decision;
+    },
+    get decision() {
+      return decision;
+    },
+  };
+}
+
 async function runSignificanceFromSelection() {
   const _t0 = perfNow();
   setStatusMessage(runningStatusMessage("run", "table"));
+  const markerOverflowDecider = createMarkerOverflowDecider();
   await Excel.run(async (context) => {
     const calculationSettings = readCalculationSettingsFromPanel();
     if (calculationSettings.compareWithPreviousColumn && calculationSettings.compareOnlyWithTotal) {
@@ -925,6 +963,38 @@ async function runSignificanceFromSelection() {
       return;
     }
 
+    // Detect banner structure before any write so marker-overflow can be
+    // resolved up front. Detection is pure (interpretedBannerContext is already
+    // sanitized by the interpreter, so it is idempotent across repeated Runs).
+    let bannerStructure = null;
+
+    if (calculationSettings.respectBannerStructure) {
+      const bannerContext = interpretedBannerContext;
+
+      bannerStructure = detectBannerStructure(bannerContext, calculationSettings);
+
+      if (bannerContext.messages && bannerContext.messages.length > 0) {
+        bannerStructure.messages = [...bannerContext.messages, ...(bannerStructure.messages || [])];
+      }
+    }
+
+    // Marker-overflow preflight: when there are more comparable columns than
+    // single-character markers, ask the user before writing anything. Stopping
+    // here leaves the selection untouched (no partial results).
+    if (
+      detectSignificanceMarkerOverflow(
+        valuesForCalculation[0].length,
+        calculationSettings,
+        bannerStructure
+      )
+    ) {
+      if (markerOverflowDecider.resolve() === "stop") {
+        setStatusMessage(t("markerOverflow.stopped"));
+        return;
+      }
+      calculationSettings.allowMultiCharacterMarkers = true;
+    }
+
     writeTargetRange.values = valuesForCalculation;
 
     writeTargetRange.format.font.bold = false;
@@ -949,21 +1019,6 @@ async function runSignificanceFromSelection() {
         )
       );
       return;
-    }
-
-    let bannerStructure = null;
-
-    if (calculationSettings.respectBannerStructure) {
-      // interpretedBannerContext is already sanitized by selected-range-interpreter
-      // (all RIT markers stripped from banner rows) so detection is idempotent
-      // across repeated Runs and Checks.
-      const bannerContext = interpretedBannerContext;
-
-      bannerStructure = detectBannerStructure(bannerContext, calculationSettings);
-
-      if (bannerContext.messages && bannerContext.messages.length > 0) {
-        bannerStructure.messages = [...bannerContext.messages, ...(bannerStructure.messages || [])];
-      }
     }
 
     const fullCellResultMatrix = createEmptyCellResultMatrix(
@@ -1166,7 +1221,13 @@ async function runSignificanceFromSelection() {
  * Returns { status, blocksProcessed, message, rangeAddress }.
  * status: "processed" | "skipped" | "blocked" | "error"
  */
-async function runSignificanceForRangeInContext(context, sheetName, rangeAddress, calculationSettings) {
+async function runSignificanceForRangeInContext(
+  context,
+  sheetName,
+  rangeAddress,
+  calculationSettings,
+  markerOverflowDecider = null
+) {
   const _p0 = perfNow();
   const worksheet = context.workbook.worksheets.getItem(sheetName);
   const sourceRange = worksheet.getRange(rangeAddress);
@@ -1239,6 +1300,37 @@ async function runSignificanceForRangeInContext(context, sheetName, rangeAddress
     };
   }
 
+  // Detect banner structure before any write so marker-overflow can be resolved
+  // up front (the dialog must appear before results are written).
+  let bannerStructure = null;
+
+  if (calculationSettings.respectBannerStructure) {
+    const bannerContext = interpretedBannerContext;
+    bannerStructure = detectBannerStructure(bannerContext, calculationSettings);
+    if (bannerContext && bannerContext.messages && bannerContext.messages.length > 0) {
+      bannerStructure.messages = [...bannerContext.messages, ...(bannerStructure.messages || [])];
+    }
+  }
+
+  // Marker-overflow preflight. When more comparable columns exist than
+  // single-character markers, ask once per operation. Stopping returns before
+  // any write so no partial results are written for this table.
+  if (
+    detectSignificanceMarkerOverflow(
+      valuesForCalculation[0].length,
+      calculationSettings,
+      bannerStructure
+    )
+  ) {
+    const activeDecider = markerOverflowDecider || createMarkerOverflowDecider();
+    if (activeDecider.resolve() === "stop") {
+      return { status: "stopped", message: "расчёт остановлен — превышен лимит маркеров", rangeAddress };
+    }
+    // Mutate the (per-operation) settings so every table in the batch uses
+    // multi-character markers consistently after the user opts to continue.
+    calculationSettings.allowMultiCharacterMarkers = true;
+  }
+
   writeTargetRange.values = valuesForCalculation;
   writeTargetRange.format.font.bold = false;
   writeTargetRange.format.fill.clear();
@@ -1254,16 +1346,6 @@ async function runSignificanceForRangeInContext(context, sheetName, rangeAddress
 
   if (!calculationBlocks || calculationBlocks.length === 0) {
     return { status: "skipped", message: "нет блоков расчёта", rangeAddress };
-  }
-
-  let bannerStructure = null;
-
-  if (calculationSettings.respectBannerStructure) {
-    const bannerContext = interpretedBannerContext;
-    bannerStructure = detectBannerStructure(bannerContext, calculationSettings);
-    if (bannerContext && bannerContext.messages && bannerContext.messages.length > 0) {
-      bannerStructure.messages = [...bannerContext.messages, ...(bannerStructure.messages || [])];
-    }
   }
 
   const fullCellResultMatrix = createEmptyCellResultMatrix(
@@ -1449,9 +1531,20 @@ async function runSignificanceForRangeInContext(context, sheetName, rangeAddress
  * Returns { status, blocksProcessed, message, rangeAddress }.
  * status: "processed" | "skipped" | "blocked" | "error"
  */
-async function runSignificanceForRange(sheetName, rangeAddress, calculationSettings) {
+async function runSignificanceForRange(
+  sheetName,
+  rangeAddress,
+  calculationSettings,
+  markerOverflowDecider = null
+) {
   const result = await Excel.run((context) =>
-    runSignificanceForRangeInContext(context, sheetName, rangeAddress, calculationSettings)
+    runSignificanceForRangeInContext(
+      context,
+      sheetName,
+      rangeAddress,
+      calculationSettings,
+      markerOverflowDecider
+    )
   );
   if (result._phasesMs) {
     perfLog("runSignificanceForRange", { ...result._phasesMs, rangeAddress });
@@ -1711,6 +1804,8 @@ async function writeRunReportSheet(context, reportRows, runLabel) {
 async function runAutoSignificance() {
   const _t0 = perfNow();
   const calculationSettings = readCalculationSettingsFromPanel();
+  // One overflow decision shared across every table processed in this run.
+  const markerOverflowDecider = createMarkerOverflowDecider();
 
   if (calculationSettings.compareWithPreviousColumn && calculationSettings.compareOnlyWithTotal) {
     setStatusMessage(
@@ -1825,6 +1920,9 @@ async function runAutoSignificance() {
 
   let processed = 0;
   let errors = 0;
+  // Set when the user chooses Stop at the marker-overflow dialog: halts further
+  // table processing for the rest of this operation.
+  let markerOverflowStopped = false;
   // Footnote jobs collected during the run and applied bottom-to-top per sheet
   // AFTER all calculations finish (insertions must not shift pending ranges).
   const footnoteJobs = [];
@@ -1864,8 +1962,17 @@ async function runAutoSignificance() {
             context,
             candidate.sheetName,
             candidate.rangeAddress,
-            calculationSettings
+            calculationSettings,
+            markerOverflowDecider
           );
+          if (result.status === "stopped") {
+            // User chose to stop at the marker-overflow dialog. Stop processing
+            // further tables; tables already processed keep their results.
+            skipped++;
+            detailLines.push(`- ${candidate.sheetName} ${candidate.rangeAddress}: ${result.message}`);
+            markerOverflowStopped = true;
+            break;
+          }
           if (result.status === "processed") {
             processed++;
             if (result.footnoteJob) footnoteJobs.push(result.footnoteJob);
@@ -1953,7 +2060,18 @@ async function runAutoSignificance() {
     const candidate = eligible[_fi];
     const item = itemMap.get(`${candidate.sheetName}!${candidate.rangeAddress}`);
     try {
-      const result = await runSignificanceForRange(candidate.sheetName, candidate.rangeAddress, calculationSettings);
+      const result = await runSignificanceForRange(
+        candidate.sheetName,
+        candidate.rangeAddress,
+        calculationSettings,
+        markerOverflowDecider
+      );
+      if (result.status === "stopped") {
+        skipped++;
+        detailLines.push(`- ${candidate.sheetName} ${candidate.rangeAddress}: ${result.message}`);
+        markerOverflowStopped = true;
+        break;
+      }
       if (result.status === "processed") {
         processed++;
         if (result.footnoteJob) footnoteJobs.push(result.footnoteJob);
@@ -2045,6 +2163,10 @@ async function runAutoSignificance() {
     `Пропущено: ${skipped}.`,
     `Ошибок: ${errors}.`,
   ];
+
+  if (markerOverflowStopped) {
+    summaryLines.push("", t("markerOverflow.stopped"));
+  }
 
   if (detailLines.length > 0) {
     summaryLines.push("", ...detailLines);
@@ -2231,7 +2353,9 @@ async function runAutoCurrentTableSignificance() {
   const statusMsg =
     result.status === "processed"
       ? t("status.autorunProcessed", { sheet: sheetName, range: rangeAddress, count: result.blocksProcessed })
-      : t("status.autorunSkipped", { msg: result.message || t("status.resolverFallback") });
+      : result.status === "stopped"
+        ? t("markerOverflow.stopped")
+        : t("status.autorunSkipped", { msg: result.message || t("status.resolverFallback") });
 
   perfLog("runAutoCurrentTableSignificance", {
     resolveMs: _tRun - _t0,
@@ -3574,6 +3698,8 @@ async function clearAutoSignificance() {
 async function runCurrentSheetSignificance() {
   const _t0 = perfNow();
   const calculationSettings = readCalculationSettingsFromPanel();
+  // One overflow decision shared across every table processed in this run.
+  const markerOverflowDecider = createMarkerOverflowDecider();
 
   if (calculationSettings.compareWithPreviousColumn && calculationSettings.compareOnlyWithTotal) {
     setStatusMessage(
@@ -3683,6 +3809,9 @@ async function runCurrentSheetSignificance() {
 
   let processed = 0;
   let errors = 0;
+  // Set when the user chooses Stop at the marker-overflow dialog: halts further
+  // table processing for the rest of this operation.
+  let markerOverflowStopped = false;
   // Footnote jobs collected during the run and applied bottom-to-top per sheet
   // AFTER all calculations finish (insertions must not shift pending ranges).
   const footnoteJobs = [];
@@ -3722,8 +3851,17 @@ async function runCurrentSheetSignificance() {
             context,
             candidate.sheetName,
             candidate.rangeAddress,
-            calculationSettings
+            calculationSettings,
+            markerOverflowDecider
           );
+          if (result.status === "stopped") {
+            // User chose to stop at the marker-overflow dialog. Stop processing
+            // further tables; tables already processed keep their results.
+            skipped++;
+            detailLines.push(`- ${candidate.sheetName} ${candidate.rangeAddress}: ${result.message}`);
+            markerOverflowStopped = true;
+            break;
+          }
           if (result.status === "processed") {
             processed++;
             if (result.footnoteJob) footnoteJobs.push(result.footnoteJob);
@@ -3811,7 +3949,18 @@ async function runCurrentSheetSignificance() {
     const candidate = eligible[_fi];
     const item = itemMap.get(`${candidate.sheetName}!${candidate.rangeAddress}`);
     try {
-      const result = await runSignificanceForRange(candidate.sheetName, candidate.rangeAddress, calculationSettings);
+      const result = await runSignificanceForRange(
+        candidate.sheetName,
+        candidate.rangeAddress,
+        calculationSettings,
+        markerOverflowDecider
+      );
+      if (result.status === "stopped") {
+        skipped++;
+        detailLines.push(`- ${candidate.sheetName} ${candidate.rangeAddress}: ${result.message}`);
+        markerOverflowStopped = true;
+        break;
+      }
       if (result.status === "processed") {
         processed++;
         if (result.footnoteJob) footnoteJobs.push(result.footnoteJob);
@@ -3903,6 +4052,10 @@ async function runCurrentSheetSignificance() {
     `Пропущено: ${skipped}.`,
     `Ошибок: ${errors}.`,
   ];
+
+  if (markerOverflowStopped) {
+    summaryLines.push("", t("markerOverflow.stopped"));
+  }
 
   if (detailLines.length > 0) {
     summaryLines.push("", ...detailLines);
@@ -6950,6 +7103,15 @@ function readCalculationSettingsFromPanel() {
     autoDetectWaveBanners: getCheckboxValue("auto-detect-wave-banners"),
     labelsOnLeftSide,
 
+    // Whether allowed Cyrillic letters may be used as significance markers.
+    // Default-off for global release safety (issue #312). Independent of the
+    // task pane UI language.
+    useCyrillicMarkers: getCheckboxValue("use-cyrillic-markers"),
+
+    // Runtime-only decision (not persisted). Set to true after the user opts to
+    // continue with multi-character overflow markers in the overflow dialog.
+    allowMultiCharacterMarkers: false,
+
     compareOnlyWithTotal: getCheckboxValue("compare-only-with-total"),
     excludeTotalFromComparisons: getCheckboxValue("exclude-total-from-comparisons"),
 
@@ -7249,7 +7411,11 @@ async function applyBannerMarkerUpdatesForRange(
   if (useStructure) {
     labelMap = buildBannerLocalSignificanceLabelMap(bannerStructure, calculationSettings);
   } else {
-    const significanceLabels = generateSignificanceLabels();
+    const significanceLabels = generateSignificanceLabels({
+      useCyrillicMarkers: Boolean(calculationSettings.useCyrillicMarkers),
+      allowMultiCharacterMarkers: Boolean(calculationSettings.allowMultiCharacterMarkers),
+      minimumCount: targetColumnCount,
+    });
     labelMap = new Map();
     for (let dataCol = 0; dataCol < targetColumnCount; dataCol++) {
       if (calculationSettings.firstColumnIsTotal && dataCol === 0) {
@@ -7542,7 +7708,11 @@ async function writeBannerMarkersAboveSelectedRange(context, selectedRange, calc
     return;
   }
 
-  const significanceLabels = generateSignificanceLabels();
+  const significanceLabels = generateSignificanceLabels({
+    useCyrillicMarkers: Boolean(calculationSettings.useCyrillicMarkers),
+    allowMultiCharacterMarkers: Boolean(calculationSettings.allowMultiCharacterMarkers),
+    minimumCount: selectedColumnCount,
+  });
 
   const bannerRange = selectedRange.worksheet.getRangeByIndexes(
     selectedStartRowIndex - 1,
@@ -8280,7 +8450,11 @@ function getTrailingBannerMarker(rawText) {
 
   const markerLabel = markerMatch[2]; // group 2: label inside parens
 
-  if (!generateSignificanceLabels().includes(markerLabel)) {
+  // Recognise any token RIT may have written as a marker — single characters
+  // from any historical alphabet, or multi-character overflow markers — so
+  // banner markers are cleaned up on re-runs regardless of the current
+  // Cyrillic/overflow settings.
+  if (!isSignificanceMarkerLabel(markerLabel)) {
     return null;
   }
 

--- a/src/taskpane/taskpane.js
+++ b/src/taskpane/taskpane.js
@@ -884,10 +884,113 @@ function createMarkerOverflowDecider() {
 }
 
 /**
+ * Read-only marker-overflow check for a single range, mirroring the front half
+ * of runSignificanceForRangeInContext (load → interpret → detect banner) but
+ * WITHOUT writing anything. Returns true when the table would need more
+ * single-character markers than the alphabet provides.
+ *
+ * Used by the banner-aware batch preflight so overflow is judged on the exact
+ * group-local required count rather than raw table width.
+ */
+async function computeRangeMarkerOverflowInContext(
+  context,
+  sheetName,
+  rangeAddress,
+  calculationSettings
+) {
+  const worksheet = context.workbook.worksheets.getItem(sheetName);
+  const sourceRange = worksheet.getRange(rangeAddress);
+
+  sourceRange.load(["values", "text", "rowIndex", "columnIndex", "rowCount", "columnCount"]);
+  await context.sync();
+
+  const selectedValues = sourceRange.values;
+  const selectedText = sourceRange.text;
+
+  if (!selectedValues || selectedValues.length < 2 || selectedValues[0].length < 2) {
+    return false;
+  }
+
+  const interpretation = await interpretSelectedRange(
+    context,
+    sourceRange,
+    selectedValues,
+    selectedText,
+    calculationSettings
+  );
+
+  if (interpretation.state === "blocked") {
+    return false;
+  }
+
+  const { valuesForCalculation, bannerContext } = interpretation;
+
+  if (
+    !valuesForCalculation ||
+    valuesForCalculation.length < 2 ||
+    !valuesForCalculation[0] ||
+    valuesForCalculation[0].length < 2
+  ) {
+    return false;
+  }
+
+  let bannerStructure = null;
+  if (calculationSettings.respectBannerStructure) {
+    bannerStructure = detectBannerStructure(bannerContext, calculationSettings);
+  }
+
+  return detectSignificanceMarkerOverflow(
+    valuesForCalculation[0].length,
+    calculationSettings,
+    bannerStructure
+  );
+}
+
+/**
+ * Exact, read-only batch overflow pass for banner-aware runs.
+ *
+ * Interprets and banner-detects each eligible table (no writes) and returns
+ * true as soon as one would overflow on its group-local required count. Errors
+ * during preflight are ignored here — the per-table run reports them — so a
+ * single bad table never blocks the decision.
+ */
+async function detectBatchMarkerOverflowExact(eligible, calculationSettings) {
+  let overflow = false;
+
+  await Excel.run(async (context) => {
+    for (const candidate of eligible) {
+      try {
+        if (
+          await computeRangeMarkerOverflowInContext(
+            context,
+            candidate.sheetName,
+            candidate.rangeAddress,
+            calculationSettings
+          )
+        ) {
+          overflow = true;
+          return;
+        }
+      } catch (_) {
+        /* preflight read failure is non-fatal; per-table run handles it */
+      }
+    }
+  });
+
+  return overflow;
+}
+
+/**
  * Operation-level marker-overflow preflight for batch runs (current-sheet /
- * workbook). Inspects the eligible candidates' column counts BEFORE any table
- * is written, so the overflow decision is made once, up front, and Stop leaves
- * the whole operation without partial results.
+ * workbook). Decides BEFORE any table is written, so Stop leaves the whole
+ * operation without partial results.
+ *
+ * Comparison-mode aware:
+ * - previous-column mode uses arrow markers, never letter labels → no dialog;
+ * - non-banner modes → conservative raw column-count gate;
+ * - banner-aware mode → raw width is not meaningful (Total/label columns and
+ *   per-group widths), so when the cheap gate says overflow is *possible* an
+ *   exact read-only pass confirms it on the group-local required count.
  *
  * Returns true when the user chose to stop (caller must abort before writing
  * any table). On Continue it sets allowMultiCharacterMarkers on the shared
@@ -898,13 +1001,30 @@ function createMarkerOverflowDecider() {
  * re-prompts.
  */
 async function preflightBatchMarkerOverflow(eligible, itemMap, calculationSettings, decider) {
+  // Previous-column mode never uses letter labels — capacity is irrelevant.
+  if (calculationSettings.compareWithPreviousColumn) {
+    return false;
+  }
+
   const columnCounts = eligible.map((candidate) => {
     const item = itemMap.get(`${candidate.sheetName}!${candidate.rangeAddress}`);
     return item ? item.columnCount : undefined;
   });
 
+  // Cheap gate first: if no table is even wider than the alphabet, nothing can
+  // overflow (the real required count is always <= raw column count).
   if (!detectBatchMarkerOverflow(columnCounts, calculationSettings)) {
     return false;
+  }
+
+  // A table is wide enough that overflow is possible. In banner-aware mode raw
+  // width over-counts (Total columns, per-group widths), so confirm with an
+  // exact read-only pass before prompting. Non-banner modes use the raw gate.
+  if (calculationSettings.respectBannerStructure) {
+    const exactOverflow = await detectBatchMarkerOverflowExact(eligible, calculationSettings);
+    if (!exactOverflow) {
+      return false;
+    }
   }
 
   if ((await decider.resolve()) === "stop") {

--- a/src/taskpane/taskpane.js
+++ b/src/taskpane/taskpane.js
@@ -20,6 +20,7 @@ import {
   buildBannerLocalSignificanceLabelMap,
   isSignificanceMarkerLabel,
   detectSignificanceMarkerOverflow,
+  detectBatchMarkerOverflow,
 } from "../core/significance";
 
 import {
@@ -829,6 +830,38 @@ function createMarkerOverflowDecider() {
       return decision;
     },
   };
+}
+
+/**
+ * Operation-level marker-overflow preflight for batch runs (current-sheet /
+ * workbook). Inspects the eligible candidates' column counts BEFORE any table
+ * is written, so the overflow decision is made once, up front, and Stop leaves
+ * the whole operation without partial results.
+ *
+ * Returns true when the user chose to stop (caller must abort before writing
+ * any table). On Continue it sets allowMultiCharacterMarkers on the shared
+ * calculationSettings so every table uses multi-character markers.
+ *
+ * The per-table preflight inside runSignificanceForRangeInContext stays as a
+ * safety net; because the shared decider's choice is cached here, it never
+ * re-prompts.
+ */
+function preflightBatchMarkerOverflow(eligible, itemMap, calculationSettings, decider) {
+  const columnCounts = eligible.map((candidate) => {
+    const item = itemMap.get(`${candidate.sheetName}!${candidate.rangeAddress}`);
+    return item ? item.columnCount : undefined;
+  });
+
+  if (!detectBatchMarkerOverflow(columnCounts, calculationSettings)) {
+    return false;
+  }
+
+  if (decider.resolve() === "stop") {
+    return true;
+  }
+
+  calculationSettings.allowMultiCharacterMarkers = true;
+  return false;
 }
 
 async function runSignificanceFromSelection() {
@@ -1915,6 +1948,13 @@ async function runAutoSignificance() {
         );
       }
     }
+    return;
+  }
+
+  // Operation-level marker-overflow preflight: decide once, before any table is
+  // written. Stop aborts the whole run with no partial results.
+  if (preflightBatchMarkerOverflow(eligible, itemMap, calculationSettings, markerOverflowDecider)) {
+    setStatusMessage(t("markerOverflow.stopped"));
     return;
   }
 
@@ -3804,6 +3844,13 @@ async function runCurrentSheetSignificance() {
         );
       }
     }
+    return;
+  }
+
+  // Operation-level marker-overflow preflight: decide once, before any table is
+  // written. Stop aborts the whole run with no partial results.
+  if (preflightBatchMarkerOverflow(eligible, itemMap, calculationSettings, markerOverflowDecider)) {
+    setStatusMessage(t("markerOverflow.stopped"));
     return;
   }
 

--- a/tests/core/significance-markers.test.mjs
+++ b/tests/core/significance-markers.test.mjs
@@ -180,6 +180,96 @@ describe("marker capacity and overflow detection", () => {
   });
 });
 
+describe("marker overflow — comparison-mode awareness (issue #312)", () => {
+  const latinCapacity = getSignificanceMarkerCapacity({ useCyrillicMarkers: false });
+
+  it("required count is 0 in previous-column mode even for very wide tables", () => {
+    assert.strictEqual(
+      computeRequiredSignificanceLabelCount(200, { compareWithPreviousColumn: true }),
+      0
+    );
+  });
+
+  it("no overflow in previous-column mode with 100+ columns", () => {
+    assert.ok(!detectSignificanceMarkerOverflow(150, { compareWithPreviousColumn: true }));
+  });
+
+  it("previous-column mode short-circuits the batch gate too", () => {
+    assert.strictEqual(
+      detectBatchMarkerOverflow([200, 300], { compareWithPreviousColumn: true }),
+      false
+    );
+  });
+
+  it("banner-aware: wide table with many small groups does not overflow", () => {
+    // 100 columns split into 25 groups of 4 non-Total columns each. Capacity is
+    // ~50, so the table is far wider than the alphabet but no group needs more
+    // than 4 labels → no overflow.
+    const groups = [];
+    for (let g = 0; g < 25; g++) {
+      const base = g * 4;
+      groups.push({ groupKey: `g${g}`, columnIndexes: [base, base + 1, base + 2, base + 3] });
+    }
+    const bannerStructure = { groups, totalColumnIndexes: [] };
+
+    assert.ok(latinCapacity < 100); // table is genuinely wider than the alphabet
+    assert.strictEqual(
+      computeRequiredSignificanceLabelCount(100, { respectBannerStructure: true }, bannerStructure),
+      4
+    );
+    assert.ok(
+      !detectSignificanceMarkerOverflow(100, { respectBannerStructure: true }, bannerStructure)
+    );
+  });
+
+  it("banner-aware: overflow when one group exceeds capacity", () => {
+    // One group with capacity + 1 non-Total columns overflows.
+    const wideGroupColumns = [];
+    for (let c = 0; c <= latinCapacity; c++) {
+      wideGroupColumns.push(c);
+    }
+    const bannerStructure = {
+      groups: [
+        { groupKey: "wide", columnIndexes: wideGroupColumns },
+        { groupKey: "small", columnIndexes: [latinCapacity + 1, latinCapacity + 2] },
+      ],
+      totalColumnIndexes: [],
+    };
+
+    assert.strictEqual(
+      computeRequiredSignificanceLabelCount(
+        wideGroupColumns.length + 2,
+        { respectBannerStructure: true },
+        bannerStructure
+      ),
+      latinCapacity + 1
+    );
+    assert.ok(
+      detectSignificanceMarkerOverflow(
+        wideGroupColumns.length + 2,
+        { respectBannerStructure: true },
+        bannerStructure
+      )
+    );
+  });
+
+  it("banner-aware: Total columns inside a group do not consume labels", () => {
+    // Group of [Total, a, b, c]: the Total column must not count toward labels.
+    const bannerStructure = {
+      groups: [{ groupKey: "g1", columnIndexes: [0, 1, 2, 3] }],
+      totalColumnIndexes: [0],
+    };
+    assert.strictEqual(
+      computeRequiredSignificanceLabelCount(4, { respectBannerStructure: true }, bannerStructure),
+      3
+    );
+  });
+
+  it("non-banner wide table still overflows", () => {
+    assert.ok(detectSignificanceMarkerOverflow(latinCapacity + 1, {}));
+  });
+});
+
 describe("detectBatchMarkerOverflow — operation-level preflight", () => {
   const latinCapacity = getSignificanceMarkerCapacity({ useCyrillicMarkers: false });
 

--- a/tests/core/significance-markers.test.mjs
+++ b/tests/core/significance-markers.test.mjs
@@ -1,0 +1,297 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  getSignificanceMarkerAlphabet,
+  generateSignificanceLabels,
+  isSignificanceMarkerLabel,
+  getSignificanceMarkerCapacity,
+  computeRequiredSignificanceLabelCount,
+  detectSignificanceMarkerOverflow,
+  getSignificanceLabelForColumnIndex,
+  buildBannerLocalSignificanceLabelMap,
+  applyComparisonResultsToFullCellResultMatrix,
+  createEmptyCellResultMatrix,
+  removeSignificanceMarkersFromText,
+} from "../../src/core/significance.js";
+
+// Cyrillic symbols that must never appear in generated markers (issue #312).
+const EXCLUDED_CYRILLIC = [
+  "а", "А", "В", "с", "С", "е", "Е", "К", "М", "Н",
+  "о", "О", "р", "Р", "у", "х", "Х",
+];
+
+const CYRILLIC_RANGE = /[Ѐ-ӿ]/;
+
+describe("getSignificanceMarkerAlphabet — Latin-only by default", () => {
+  it("contains no Cyrillic characters when Cyrillic markers are disabled", () => {
+    const alphabet = getSignificanceMarkerAlphabet({ useCyrillicMarkers: false });
+    assert.ok(alphabet.every((label) => !CYRILLIC_RANGE.test(label)));
+  });
+
+  it("defaults to Latin-only when no options are passed", () => {
+    const alphabet = getSignificanceMarkerAlphabet();
+    assert.ok(alphabet.every((label) => !CYRILLIC_RANGE.test(label)));
+  });
+
+  it("excludes Latin t and T (reserved for Total markers)", () => {
+    const alphabet = getSignificanceMarkerAlphabet({ useCyrillicMarkers: false });
+    assert.ok(!alphabet.includes("t"));
+    assert.ok(!alphabet.includes("T"));
+  });
+
+  it("starts with the historical Latin sequence a, b, c, ...", () => {
+    const alphabet = getSignificanceMarkerAlphabet();
+    assert.deepStrictEqual(alphabet.slice(0, 5), ["a", "b", "c", "d", "e"]);
+  });
+});
+
+describe("getSignificanceMarkerAlphabet — Cyrillic exclusions", () => {
+  const alphabet = getSignificanceMarkerAlphabet({ useCyrillicMarkers: true });
+
+  it("excludes every visually confusable Cyrillic symbol", () => {
+    for (const symbol of EXCLUDED_CYRILLIC) {
+      assert.ok(!alphabet.includes(symbol), `expected ${symbol} to be excluded`);
+    }
+  });
+
+  it("keeps uppercase Cyrillic У (distinct from Latin Y)", () => {
+    assert.ok(alphabet.includes("У"));
+  });
+
+  it("excludes lowercase Cyrillic у (confusable with Latin y)", () => {
+    assert.ok(!alphabet.includes("у"));
+  });
+
+  it("still excludes Cyrillic т and Т (existing Total exclusion)", () => {
+    assert.ok(!alphabet.includes("т"));
+    assert.ok(!alphabet.includes("Т"));
+  });
+
+  it("appends Cyrillic markers after the full Latin alphabet", () => {
+    const latinCount = getSignificanceMarkerAlphabet({ useCyrillicMarkers: false }).length;
+    assert.deepStrictEqual(
+      alphabet.slice(0, latinCount),
+      getSignificanceMarkerAlphabet({ useCyrillicMarkers: false })
+    );
+    assert.ok(CYRILLIC_RANGE.test(alphabet[latinCount]));
+  });
+});
+
+describe("generateSignificanceLabels — under the single-character limit", () => {
+  it("matches the previous Latin sequence for the first columns", () => {
+    const labels = generateSignificanceLabels({ minimumCount: 6 });
+    assert.deepStrictEqual(labels.slice(0, 6), ["a", "b", "c", "d", "e", "f"]);
+  });
+
+  it("does not extend to multi-character markers when allowance is off", () => {
+    const labels = generateSignificanceLabels({ minimumCount: 1000 });
+    // Latin-only single-character alphabet length.
+    assert.strictEqual(labels.length, getSignificanceMarkerAlphabet().length);
+    assert.ok(labels.every((label) => label.length === 1));
+  });
+});
+
+describe("generateSignificanceLabels — multi-character overflow", () => {
+  it("continues as aa, ab, ac after the single-character alphabet", () => {
+    const singleCount = getSignificanceMarkerAlphabet().length;
+    const labels = generateSignificanceLabels({
+      allowMultiCharacterMarkers: true,
+      minimumCount: singleCount + 3,
+    });
+
+    assert.strictEqual(labels.length, singleCount + 3);
+    assert.deepStrictEqual(labels.slice(singleCount, singleCount + 3), ["aa", "ab", "ac"]);
+  });
+
+  it("only extends past the single-character alphabet when needed", () => {
+    const labels = generateSignificanceLabels({
+      allowMultiCharacterMarkers: true,
+      minimumCount: 3,
+    });
+    assert.ok(labels.every((label) => label.length === 1));
+  });
+});
+
+describe("isSignificanceMarkerLabel", () => {
+  it("recognises single Latin markers", () => {
+    assert.ok(isSignificanceMarkerLabel("a"));
+    assert.ok(isSignificanceMarkerLabel("Z"));
+  });
+
+  it("recognises legacy single Cyrillic markers for cleanup", () => {
+    // Even now-excluded look-alikes must still be removable on re-runs.
+    assert.ok(isSignificanceMarkerLabel("а"));
+    assert.ok(isSignificanceMarkerLabel("В"));
+  });
+
+  it("recognises multi-character overflow markers", () => {
+    assert.ok(isSignificanceMarkerLabel("aa"));
+    assert.ok(isSignificanceMarkerLabel("ac"));
+  });
+
+  it("rejects ordinary banner text", () => {
+    assert.ok(!isSignificanceMarkerLabel("quarter"));
+    assert.ok(!isSignificanceMarkerLabel("NE"));
+    assert.ok(!isSignificanceMarkerLabel(""));
+  });
+});
+
+describe("marker capacity and overflow detection", () => {
+  it("capacity grows when Cyrillic markers are enabled", () => {
+    const latinCapacity = getSignificanceMarkerCapacity({ useCyrillicMarkers: false });
+    const cyrillicCapacity = getSignificanceMarkerCapacity({ useCyrillicMarkers: true });
+    assert.ok(cyrillicCapacity > latinCapacity);
+  });
+
+  it("computes required label count without a Total column", () => {
+    assert.strictEqual(computeRequiredSignificanceLabelCount(5, {}), 5);
+  });
+
+  it("excludes the Total column from the required count", () => {
+    assert.strictEqual(
+      computeRequiredSignificanceLabelCount(5, { firstColumnIsTotal: true }),
+      4
+    );
+  });
+
+  it("does not flag overflow for a normal table under the limit", () => {
+    assert.ok(!detectSignificanceMarkerOverflow(10, {}));
+  });
+
+  it("flags overflow when columns exceed the Latin alphabet", () => {
+    const capacity = getSignificanceMarkerCapacity({ useCyrillicMarkers: false });
+    assert.ok(detectSignificanceMarkerOverflow(capacity + 1, {}));
+  });
+
+  it("uses the widest banner group for the required count", () => {
+    const bannerStructure = {
+      groups: [
+        { groupKey: "g1", columnIndexes: [0, 1, 2] },
+        { groupKey: "g2", columnIndexes: [3, 4, 5, 6] },
+      ],
+      totalColumnIndexes: [],
+    };
+    assert.strictEqual(
+      computeRequiredSignificanceLabelCount(7, { respectBannerStructure: true }, bannerStructure),
+      4
+    );
+  });
+});
+
+describe("getSignificanceLabelForColumnIndex — overflow labels", () => {
+  it("returns multi-character labels past the alphabet when allowed", () => {
+    const capacity = getSignificanceMarkerCapacity({ useCyrillicMarkers: false });
+    const label = getSignificanceLabelForColumnIndex(capacity, {
+      allowMultiCharacterMarkers: true,
+    });
+    assert.strictEqual(label, "aa");
+  });
+
+  it("returns empty string past the alphabet when overflow is not allowed", () => {
+    const capacity = getSignificanceMarkerCapacity({ useCyrillicMarkers: false });
+    assert.strictEqual(getSignificanceLabelForColumnIndex(capacity, {}), "");
+  });
+});
+
+describe("buildBannerLocalSignificanceLabelMap — multi-character labels", () => {
+  it("assigns multi-character labels to a wide banner group when allowed", () => {
+    const capacity = getSignificanceMarkerCapacity({ useCyrillicMarkers: false });
+    const columnIndexes = [];
+    for (let i = 0; i <= capacity; i++) {
+      columnIndexes.push(i);
+    }
+
+    const bannerStructure = {
+      groups: [{ groupKey: "g1", columnIndexes }],
+      totalColumnIndexes: [],
+    };
+
+    const labelMap = buildBannerLocalSignificanceLabelMap(bannerStructure, {
+      allowMultiCharacterMarkers: true,
+    });
+
+    assert.strictEqual(labelMap.get(0), "a");
+    assert.strictEqual(labelMap.get(capacity), "aa");
+  });
+});
+
+// ─── Data-cell marker append / removal ────────────────────────────────────────
+
+function buildSignificantComparison(firstColumnIndex, secondColumnIndex, direction) {
+  return {
+    firstColumnIndex,
+    secondColumnIndex,
+    comparisonType: "segment",
+    result: { isSignificant: true, direction },
+  };
+}
+
+describe("data-cell marker append — multi-character separation", () => {
+  it("separates multiple multi-character markers with spaces", () => {
+    // A wide table where column index `capacity+2` is higher than three lower
+    // overflow columns, so its cell collects three multi-character markers.
+    const capacity = getSignificanceMarkerCapacity({ useCyrillicMarkers: false });
+    const target = capacity + 2; // label for this column is irrelevant; it is the higher one
+    const lowerColumns = [capacity, capacity + 1, capacity + 3];
+
+    const matrix = createEmptyCellResultMatrix(1, capacity + 5);
+    const rowComparisons = lowerColumns.map((lower) =>
+      buildSignificantComparison(target, lower, "first_higher")
+    );
+
+    applyComparisonResultsToFullCellResultMatrix(
+      { comparisonRows: [{ valueRowIndex: 0, rowComparisons }] },
+      matrix,
+      { allowMultiCharacterMarkers: true }
+    );
+
+    const markers = matrix[0][target].markers;
+    // Three multi-character markers, each separated by a single space.
+    assert.ok(/^[a-z]{2}( [a-z]{2}){2}$/.test(markers), `got "${markers}"`);
+  });
+
+  it("keeps single-character markers concatenated under the limit", () => {
+    const matrix = createEmptyCellResultMatrix(1, 4);
+    const rowComparisons = [
+      buildSignificantComparison(3, 1, "first_higher"), // appends label for col 1 = "b"
+      buildSignificantComparison(3, 2, "first_higher"), // appends label for col 2 = "c"
+    ];
+
+    applyComparisonResultsToFullCellResultMatrix(
+      { comparisonRows: [{ valueRowIndex: 0, rowComparisons }] },
+      matrix,
+      {}
+    );
+
+    assert.strictEqual(matrix[0][3].markers, "bc");
+  });
+});
+
+describe("removeSignificanceMarkersFromText — multi-character markers", () => {
+  it("removes a single trailing marker", () => {
+    assert.strictEqual(removeSignificanceMarkersFromText("42% b"), "42%");
+  });
+
+  it("removes concatenated single-character markers", () => {
+    assert.strictEqual(removeSignificanceMarkersFromText("42% bcd"), "42%");
+  });
+
+  it("removes space-separated multi-character markers", () => {
+    assert.strictEqual(removeSignificanceMarkersFromText("42% aa ab ac"), "42%");
+  });
+
+  it("removes a Total marker followed by multi-character markers", () => {
+    assert.strictEqual(removeSignificanceMarkersFromText("42% T aa ab"), "42%");
+  });
+
+  it("leaves a clean numeric value untouched", () => {
+    assert.strictEqual(removeSignificanceMarkersFromText("42%"), "42%");
+  });
+
+  it("is idempotent across repeated removals", () => {
+    const once = removeSignificanceMarkersFromText("21% aa ab");
+    const twice = removeSignificanceMarkersFromText(once);
+    assert.strictEqual(once, twice);
+  });
+});

--- a/tests/core/significance-markers.test.mjs
+++ b/tests/core/significance-markers.test.mjs
@@ -8,6 +8,7 @@ import {
   getSignificanceMarkerCapacity,
   computeRequiredSignificanceLabelCount,
   detectSignificanceMarkerOverflow,
+  detectBatchMarkerOverflow,
   getSignificanceLabelForColumnIndex,
   buildBannerLocalSignificanceLabelMap,
   applyComparisonResultsToFullCellResultMatrix,
@@ -176,6 +177,38 @@ describe("marker capacity and overflow detection", () => {
       computeRequiredSignificanceLabelCount(7, { respectBannerStructure: true }, bannerStructure),
       4
     );
+  });
+});
+
+describe("detectBatchMarkerOverflow — operation-level preflight", () => {
+  const latinCapacity = getSignificanceMarkerCapacity({ useCyrillicMarkers: false });
+
+  it("returns false when no eligible table overflows", () => {
+    assert.strictEqual(detectBatchMarkerOverflow([3, 10, latinCapacity], {}), false);
+  });
+
+  it("returns true when a single eligible table overflows", () => {
+    assert.strictEqual(detectBatchMarkerOverflow([latinCapacity + 1], {}), true);
+  });
+
+  it("returns true when the first table is normal but a later one overflows", () => {
+    assert.strictEqual(detectBatchMarkerOverflow([5, 8, latinCapacity + 5], {}), true);
+  });
+
+  it("respects the larger Cyrillic capacity", () => {
+    const cyrillicCapacity = getSignificanceMarkerCapacity({ useCyrillicMarkers: true });
+    const between = latinCapacity + 1; // overflows Latin, still fits Cyrillic
+    assert.ok(between <= cyrillicCapacity);
+    assert.strictEqual(detectBatchMarkerOverflow([between], { useCyrillicMarkers: false }), true);
+    assert.strictEqual(detectBatchMarkerOverflow([between], { useCyrillicMarkers: true }), false);
+  });
+
+  it("ignores missing / non-finite column counts", () => {
+    assert.strictEqual(detectBatchMarkerOverflow([undefined, null, NaN, 4], {}), false);
+  });
+
+  it("returns false for a non-array input", () => {
+    assert.strictEqual(detectBatchMarkerOverflow(undefined, {}), false);
   });
 });
 


### PR DESCRIPTION
Closes #312.

## Summary

Hardens significance marker generation/removal before release: trims visually confusable Cyrillic letters, adds an explicit Cyrillic-markers setting (default off), and adds explicit marker-overflow handling with a user dialog and multi-character markers. No statistical formulas, comparison logic (beyond a marker-capacity preflight), or the Excel writer performance path were changed.

## Part 1 — Cyrillic marker alphabet

Marker generation is centralized in pure helpers in `src/core/significance.js`. When Cyrillic markers are enabled, the alphabet excludes the confusable Latin look-alikes:

`а, А, В, с, С, е, Е, К, М, Н, о, О, р, Р, у, х, Х`

- lowercase Cyrillic `у` is excluded (reads like Latin `y`);
- uppercase Cyrillic `У` is kept (visually distinct from Latin `Y`);
- existing Latin/Cyrillic `t`/`Т` exclusions are preserved.

## Part 2 — Cyrillic marker setting

New persisted checkbox **"Использовать кириллические маркеры" / "Use Cyrillic significance markers"**.

- **Default: `false`** — a deliberate product decision for global-market release safety. With the setting off, generated markers contain no Cyrillic characters.
- When enabled, allowed Cyrillic markers are appended **after** the full Latin alphabet.
- The setting is independent of panel language (a Russian user can enable Cyrillic markers while the panel is in English).

## Part 3 — Marker overflow handling

When there are more comparable columns than available single-character markers:

- overflow is detected **before any write**;
- a dialog asks the user to **continue with multi-character markers (`aa`, `ab`, `ac`, …)** or **stop and change settings** (RU/EN copy from the issue);
- **Stop → no partial results are written** (see batch semantics below);
- **Continue → multi-character markers are used and written safely.**

Multi-character data-cell markers are **space-separated** (`42% aa ab ac`, never `42% aaabac`). Marker parsing/removal supports one- and multi-character, space-separated markers idempotently, including the prepended Total marker (`42% T aa ab`). Banner marker recognition/clearing is multi-character-aware and still recognizes legacy single-character (incl. Cyrillic) markers so re-runs and Clear Significance never leave stale markers.

The overflow decision is asked **once per operation** via a shared decider, not once per table.

### Batch overflow semantics (no partial results)

Marker overflow is resolved **before any table is written** in every Run path:

- **Manual Run / current-table Run** — single-table preflight runs before the table's value write; Stop leaves the selection untouched.
- **Current-sheet / workbook Run** — a **comparison-mode-aware operation-level preflight** (`preflightBatchMarkerOverflow`) decides up front, before the processing loop:
  - if any table could overflow, the dialog is shown **once**;
  - **Stop → the whole run aborts with no tables written;**
  - **Continue → `allowMultiCharacterMarkers` is set and all tables are processed** with multi-character markers.

The batch preflight is mode-aware so it does not false-prompt:
- **Previous-column mode** uses arrow markers, never letter labels → no dialog at all (`compareWithPreviousColumn` short-circuits both `computeRequiredSignificanceLabelCount` and `detectBatchMarkerOverflow`).
- A **cheap raw-count gate** runs first (`detectBatchMarkerOverflow`): a table's true required count is always ≤ its raw column count, so if no table is even wider than the alphabet, nothing can overflow — no dialog and no extra reads.
- When the gate fires in **banner-aware mode**, raw width over-counts (Total/label columns, per-group widths), so an **exact read-only pass** (`detectBatchMarkerOverflowExact`) interprets and banner-detects each eligible table and judges overflow on the **group-local required count** (`computeRequiredSignificanceLabelCount` with `bannerStructure`). The dialog appears only if at least one banner group needs more labels than capacity.
- **Non-banner** modes keep the existing conservative raw-count behavior.

The exact pass is **read-only** and runs before any write, so Stop still writes nothing. The exact per-table preflight (`detectSignificanceMarkerOverflow` with the table's own `bannerStructure`) remains as a safety net and never re-prompts (the shared decision is cached).

## Affected Run paths

- Manual Run (`runSignificanceFromSelection`)
- Current-table Run (`runAutoCurrentTableSignificance` → `runSignificanceForRange`)
- Current-sheet Run (`runCurrentSheetSignificance`) — operation-level preflight added
- Workbook Run (`runAutoSignificance`) — operation-level preflight added

Banner-letter writing (structure and non-structure paths) and the legacy above-range banner writer thread the same settings.

## Files changed

- `src/core/significance.js` — marker alphabet helpers (`getSignificanceMarkerAlphabet`, `generateSignificanceLabels` with options), overflow helpers (`computeRequiredSignificanceLabelCount`, `detectSignificanceMarkerOverflow`, `detectBatchMarkerOverflow`, `getSignificanceMarkerCapacity`), multi-character extension, space-separated append, multi-token removal, `isSignificanceMarkerLabel`.
- `src/taskpane/taskpane.js` — `useCyrillicMarkers` setting read, async overflow dialog/decider (in-taskpane modal), comparison-mode-aware operation-level batch preflight (`preflightBatchMarkerOverflow` + read-only exact pass `detectBatchMarkerOverflowExact` / `computeRangeMarkerOverflowInContext`) before sheet/workbook writes, per-table preflight (safety net) in all Run paths, multi-character-aware banner marker validation.
- `src/taskpane/selected-range-interpreter.js` — banner marker stripping uses the multi-character-aware predicate.
- `src/taskpane/taskpane-settings.js` — persisted setting config + default `false`.
- `src/taskpane/taskpane.html` — new checkbox (Design tab) + marker-overflow modal markup.
- `src/taskpane/taskpane.css` — minimal modal/overlay/button styling.
- `src/taskpane/localization.js` — RU/EN labels + overflow dialog title/body/button copy.
- `tests/core/significance-markers.test.mjs` — new pure unit tests.

## Tests added/updated

New suite `tests/core/significance-markers.test.mjs` covers: Latin-only default (no Cyrillic), Cyrillic exclusions + retained `У`, retained `t`-like exclusions, under-limit Latin sequence, overflow extension (`aa, ab, ac`), space-separated multi-character data-cell append, one-/multi-character removal + idempotency, banner overflow label assignment, overflow detection/required-count, the **operation-level batch gate** (`detectBatchMarkerOverflow`): no overflowing tables → no prompt; a single overflowing table → prompt; first table normal but a later one overflowing → prompt; Cyrillic capacity respected; missing/non-finite counts ignored — and **comparison-mode awareness**: previous-column mode returns required count 0 / no overflow even for 100+ columns (per-table and batch gate); banner-aware required count uses the max group-local non-Total column count (wide table of many small groups → no overflow; one oversized group → overflow; Total columns inside a group don't consume labels); non-banner wide table still overflows.

The read-only batch helpers (`detectBatchMarkerOverflowExact` / `computeRangeMarkerOverflowInContext`) depend on Office.js and are covered by Excel smoke rather than unit tests; their pure decision input (`detectSignificanceMarkerOverflow` with `bannerStructure`) is unit-tested above.

## Validation

- `npm test` — **471 passed** (424 existing + 47 new), 0 failed.
- `npm run build` — succeeds (only pre-existing bundle-size warnings).
- `git diff --check` — clean.

## Manual smoke checklist (for human Excel testing)

1. Default off → generated markers Latin-only.
2. Cyrillic on → eventually uses allowed Cyrillic letters; excluded symbols never appear; uppercase `У` may appear.
3. Normal under-limit table → behavior unchanged; no dialog.
4. Wide table over the single-marker limit → custom in-taskpane dialog appears before writing.
5. Single current-table overflow, Stop → table left untouched (no writes).
6. Continue → multi-character markers, space-separated in data cells.
7. Re-run after multi-character markers → old markers cleared/replaced, no stale markers.
8. Clear Significance → removes multi-character markers.
9. Banner marker mode → works with the new policy and multi-character labels.
10. **Workbook/sheet run, first table normal + second table overflowing, choose Stop → no tables are written.**
11. **Same scenario, choose Continue → all tables process, the overflowing table uses multi-character markers.**
12. Normal under-limit batch → no dialog; overflow asked at most once.
13. Switch UI language RU/EN → dialog title, body and buttons localize.
14. Dialog Esc / backdrop click → treated as Stop (no writes).
15. **Previous-column mode ON, wide table over capacity → no dialog; run works with arrows as before.**
16. **Banner mode ON, wide table with many groups each shorter than capacity → no dialog.**
17. **Banner mode ON, one group longer than capacity → dialog appears before writing; Stop writes nothing, Continue uses multi-character markers only where needed.**

## Limitations / risks

- **Batch preflight precision:** banner-aware runs use an exact read-only pass, so wide multi-group banner tables no longer false-prompt. Non-banner runs keep the cheap raw-count gate, so a non-banner table whose label columns push its raw width just past the ~50-column alphabet boundary could still trigger the dialog slightly early. This is intentional (guarantees no partial writes) and harmless (Continue keeps single-character markers when they still fit). Overflow only matters above ~50 columns, which is rare for crosstabs.
- **Banner-aware preflight cost:** the exact read-only pass re-reads the eligible tables, but only when the cheap gate already found a table wider than the alphabet (rare, >~50 columns) and `respectBannerStructure` is on. Normal banner runs hit the cheap gate and do no extra reads.
- The overflow prompt is a small **custom in-taskpane modal** (`window.confirm`/`alert`/`prompt` are not supported in the Office add-in webview). `confirmMarkerOverflowDialog()` is async (`Promise<boolean>`); Esc, backdrop click, or missing markup resolve to **Stop** (no writes). The decision is asked once per operation via an async decider guarded by a shared in-flight promise; all callers await it. DOM modal behavior is verified by Excel smoke (not unit-tested).

## Technical debt

No known technical debt introduced. Marker alphabet/generation is now centralized (no duplicated alphabet across writer/banner code). Lint is not run as a gate (the repo ships with pre-existing prettier/CRLF lint noise); the lint issues introduced during development were resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


