### PR TITLE
[codex] Add Clear target regression tests

### DIFF
--- a/tests/core/clear-target-resolution.test.mjs
+++ b/tests/core/clear-target-resolution.test.mjs
@@ -1,0 +1,366 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { normalizeSelectedRange } from "../../src/core/range-normalizer.js";
+import { removeSignificanceMarkersFromMatrix } from "../../src/core/significance.js";
+import { SIGNIFICANCE_FOOTNOTE_MARKER } from "../../src/core/significance-footnote.js";
+import {
+  detectEmbeddedLabelColumns,
+  detectLeadingEmptyColumns,
+} from "../../src/taskpane/selected-range-interpreter.js";
+
+function toDisplayText(values) {
+  return values.map((row) =>
+    row.map((cell) => (cell === null || cell === undefined ? "" : String(cell)))
+  );
+}
+
+function sliceMatrix(matrix, rowOffset, colOffset, rowCount, colCount) {
+  return matrix
+    .slice(rowOffset, rowOffset + rowCount)
+    .map((row) => row.slice(colOffset, colOffset + colCount));
+}
+
+function resolveCurrentClearTargetBody(selectedValues, selectedText = toDisplayText(selectedValues)) {
+  const cleanedValues = removeSignificanceMarkersFromMatrix(selectedValues);
+  const normalized = normalizeSelectedRange(cleanedValues, selectedText);
+
+  if (normalized.normalizationNeeded && !normalized.normalizationApplied) {
+    return {
+      state: "blocked",
+      blockingReasons: normalized.blockingReasons,
+    };
+  }
+
+  if (normalized.normalizationNeeded && normalized.normalizationApplied) {
+    const bodyRowCount = normalized.valuesForCalculation.length;
+    let bodyColCount = normalized.valuesForCalculation[0].length;
+    let effectiveClearColOffset = normalized.dataColOffset;
+    let textForLeadingEmptyCheck = normalized.textForCalculation;
+
+    if (normalized.dataColOffset === 0) {
+      const additionalLabelCols = detectEmbeddedLabelColumns(normalized.valuesForCalculation);
+      if (additionalLabelCols > 0) {
+        effectiveClearColOffset += additionalLabelCols;
+        bodyColCount -= additionalLabelCols;
+        textForLeadingEmptyCheck = normalized.textForCalculation.map((row) =>
+          row.slice(additionalLabelCols)
+        );
+      }
+    }
+
+    const clearLeadingEmptyCols = detectLeadingEmptyColumns(textForLeadingEmptyCheck);
+    if (clearLeadingEmptyCols > 0) {
+      bodyColCount -= clearLeadingEmptyCols;
+      effectiveClearColOffset += clearLeadingEmptyCols;
+    }
+
+    return {
+      state: "normalized",
+      rowOffset: normalized.dataRowOffset,
+      colOffset: effectiveClearColOffset,
+      rowCount: bodyRowCount,
+      colCount: bodyColCount,
+      targetValues: sliceMatrix(
+        cleanedValues,
+        normalized.dataRowOffset,
+        effectiveClearColOffset,
+        bodyRowCount,
+        bodyColCount
+      ),
+      normalized,
+    };
+  }
+
+  const embeddedLabelColsForClear = detectEmbeddedLabelColumns(cleanedValues);
+  const leadingBlankColsForClear =
+    embeddedLabelColsForClear === 0 ? detectLeadingEmptyColumns(selectedText) : 0;
+  const skipLeftCols =
+    embeddedLabelColsForClear > 0 ? embeddedLabelColsForClear : leadingBlankColsForClear;
+
+  return {
+    state: "passThrough",
+    rowOffset: 0,
+    colOffset: skipLeftCols,
+    rowCount: selectedValues.length,
+    colCount: selectedValues[0].length - skipLeftCols,
+    targetValues: sliceMatrix(
+      cleanedValues,
+      0,
+      skipLeftCols,
+      selectedValues.length,
+      selectedValues[0].length - skipLeftCols
+    ),
+    normalized,
+  };
+}
+
+describe("current Clear target body resolution", () => {
+  it("keeps a strict numeric selected range as the clear target", () => {
+    const values = [
+      [0.44, 0.41],
+      [0.56, 0.59],
+      [5605, 1320],
+    ];
+
+    const target = resolveCurrentClearTargetBody(values);
+
+    assert.strictEqual(target.state, "passThrough");
+    assert.deepStrictEqual(
+      {
+        rowOffset: target.rowOffset,
+        colOffset: target.colOffset,
+        rowCount: target.rowCount,
+        colCount: target.colCount,
+      },
+      { rowOffset: 0, colOffset: 0, rowCount: 3, colCount: 2 }
+    );
+    assert.deepStrictEqual(target.targetValues, [
+      ["0.44", "0.41"],
+      ["0.56", "0.59"],
+      ["5605", "1320"],
+    ]);
+  });
+
+  it("normalizes a sloppy full-table selection to the data body below banner/header rows", () => {
+    const values = [
+      ["Ваш пол:", "", ""],
+      ["", "Всего", ""],
+      ["", "2025Q4", "2026Q1"],
+      ["Мужской", 0.44, 0.41],
+      ["Женский", 0.56, 0.59],
+      ["BASE", 5605, 1320],
+    ];
+
+    const target = resolveCurrentClearTargetBody(values);
+
+    assert.strictEqual(target.state, "normalized");
+    assert.deepStrictEqual(
+      {
+        rowOffset: target.rowOffset,
+        colOffset: target.colOffset,
+        rowCount: target.rowCount,
+        colCount: target.colCount,
+      },
+      { rowOffset: 3, colOffset: 1, rowCount: 3, colCount: 2 }
+    );
+    assert.deepStrictEqual(target.targetValues, [
+      ["0.44", "0.41"],
+      ["0.56", "0.59"],
+      ["5605", "1320"],
+    ]);
+  });
+
+  it("excludes adjacent row-label columns from the clear target", () => {
+    const values = [
+      ["Agree", 0.44, 0.41],
+      ["Disagree", 0.56, 0.59],
+      ["BASE", 5605, 1320],
+    ];
+
+    const target = resolveCurrentClearTargetBody(values);
+
+    assert.strictEqual(target.state, "normalized");
+    assert.deepStrictEqual(
+      {
+        rowOffset: target.rowOffset,
+        colOffset: target.colOffset,
+        rowCount: target.rowCount,
+        colCount: target.colCount,
+      },
+      { rowOffset: 0, colOffset: 1, rowCount: 3, colCount: 2 }
+    );
+    assert.deepStrictEqual(target.targetValues, [
+      ["0.44", "0.41"],
+      ["0.56", "0.59"],
+      ["5605", "1320"],
+    ]);
+  });
+
+  it("excludes a leading empty structural column where the current pass-through clear path does", () => {
+    const values = [
+      ["", 4.2, 4.4],
+      ["", 1.1, 1.2],
+      ["", 500, 600],
+    ];
+
+    const target = resolveCurrentClearTargetBody(values);
+
+    assert.strictEqual(target.state, "passThrough");
+    assert.deepStrictEqual(
+      {
+        rowOffset: target.rowOffset,
+        colOffset: target.colOffset,
+        rowCount: target.rowCount,
+        colCount: target.colCount,
+      },
+      { rowOffset: 0, colOffset: 1, rowCount: 3, colCount: 2 }
+    );
+    assert.deepStrictEqual(target.targetValues, [
+      ["4.2", "4.4"],
+      ["1.1", "1.2"],
+      ["500", "600"],
+    ]);
+  });
+
+  it("preserves far-left labels mode limitation: clear resolution has no settings branch", () => {
+    // In labels-on-left-side mode, labels live outside the selected data range.
+    // Current Clear target resolution does not accept calculation settings, so a
+    // strict numeric selection remains the target and far-left labels are not
+    // part of the body-resolution decision.
+    const values = [
+      [4.2, 4.4],
+      [1.1, 1.2],
+      [500, 600],
+    ];
+
+    const target = resolveCurrentClearTargetBody(values);
+
+    assert.strictEqual(target.state, "passThrough");
+    assert.deepStrictEqual(
+      {
+        rowOffset: target.rowOffset,
+        colOffset: target.colOffset,
+        rowCount: target.rowCount,
+        colCount: target.colCount,
+      },
+      { rowOffset: 0, colOffset: 0, rowCount: 3, colCount: 2 }
+    );
+  });
+
+  it("does not include a generated RIT significance footnote row as data body", () => {
+    const values = [
+      ["Ваш пол:", "", ""],
+      ["", "2025Q4", "2026Q1"],
+      ["Мужской", 0.44, 0.41],
+      ["Женский", 0.56, 0.59],
+      ["BASE", 5605, 1320],
+      [`${SIGNIFICANCE_FOOTNOTE_MARKER}Уровень значимости: 95%.`, "", ""],
+    ];
+
+    const target = resolveCurrentClearTargetBody(values);
+
+    assert.strictEqual(target.state, "normalized");
+    assert.deepStrictEqual(
+      {
+        rowOffset: target.rowOffset,
+        colOffset: target.colOffset,
+        rowCount: target.rowCount,
+        colCount: target.colCount,
+      },
+      { rowOffset: 2, colOffset: 1, rowCount: 3, colCount: 2 }
+    );
+    assert.deepStrictEqual(target.targetValues, [
+      ["0.44", "0.41"],
+      ["0.56", "0.59"],
+      ["5605", "1320"],
+    ]);
+  });
+
+  it("does not include an ordinary user note below the table as data body", () => {
+    const values = [
+      ["Ваш пол:", "", ""],
+      ["", "2025Q4", "2026Q1"],
+      ["Мужской", 0.44, 0.41],
+      ["Женский", 0.56, 0.59],
+      ["BASE", 5605, 1320],
+      ["Все респонденты", "", ""],
+    ];
+
+    const target = resolveCurrentClearTargetBody(values);
+
+    assert.strictEqual(target.state, "normalized");
+    assert.deepStrictEqual(
+      {
+        rowOffset: target.rowOffset,
+        colOffset: target.colOffset,
+        rowCount: target.rowCount,
+        colCount: target.colCount,
+      },
+      { rowOffset: 2, colOffset: 1, rowCount: 3, colCount: 2 }
+    );
+    assert.deepStrictEqual(target.targetValues, [
+      ["0.44", "0.41"],
+      ["0.56", "0.59"],
+      ["5605", "1320"],
+    ]);
+  });
+
+  it("recognizes marker-stripped numeric cells as the current clear target body", () => {
+    const values = [
+      ["Agree", "44% a", "41% b"],
+      ["Disagree", "56% b", "59% a"],
+      ["BASE", 5605, 1320],
+    ];
+
+    const target = resolveCurrentClearTargetBody(values);
+
+    assert.strictEqual(target.state, "normalized");
+    assert.deepStrictEqual(
+      {
+        rowOffset: target.rowOffset,
+        colOffset: target.colOffset,
+        rowCount: target.rowCount,
+        colCount: target.colCount,
+      },
+      { rowOffset: 0, colOffset: 1, rowCount: 3, colCount: 2 }
+    );
+    assert.deepStrictEqual(target.targetValues, [
+      ["44%", "41%"],
+      ["56%", "59%"],
+      ["5605", "1320"],
+    ]);
+  });
+
+  it("blocks a selected range spanning two close tables instead of bleeding into the neighbor", () => {
+    const values = [
+      ["Таблица 1", "", ""],
+      ["", "Всего", "Кат A"],
+      ["Вариант A", 0.4, 0.3],
+      ["Вариант B", 0.6, 0.7],
+      ["BASE", 1000, 500],
+      ["Таблица 2", "", ""],
+      ["", "Всего", "Кат B"],
+      ["Вариант X", 0.5, 0.4],
+      ["Вариант Y", 0.5, 0.6],
+      ["BASE", 800, 400],
+    ];
+
+    const target = resolveCurrentClearTargetBody(values);
+
+    assert.strictEqual(target.state, "blocked");
+    assert.ok(
+      target.blockingReasons.includes("BODY_APPEARS_MULTI_TABLE") ||
+        target.blockingReasons.includes("HEADER_AREA_TOO_LARGE"),
+      `expected multi-table blocking reason, got ${JSON.stringify(target.blockingReasons)}`
+    );
+  });
+
+  it("preserves minimal labeled-table limitation: two-row labels are not stripped in pass-through", () => {
+    // Current behavior: this tiny labeled shape is too small to normalize, then
+    // marker stripping removes pure-text labels before detectEmbeddedLabelColumns
+    // can see them. Clear therefore targets the whole selection. This documents
+    // the limitation for the extraction PR rather than changing behavior here.
+    const values = [
+      ["Agree", 0.5],
+      ["BASE", 100],
+    ];
+
+    const target = resolveCurrentClearTargetBody(values);
+
+    assert.strictEqual(target.state, "passThrough");
+    assert.deepStrictEqual(
+      {
+        rowOffset: target.rowOffset,
+        colOffset: target.colOffset,
+        rowCount: target.rowCount,
+        colCount: target.colCount,
+      },
+      { rowOffset: 0, colOffset: 0, rowCount: 2, colCount: 2 }
+    );
+    assert.deepStrictEqual(target.targetValues, [
+      ["", "0.5"],
+      ["", "100"],
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

Adds tests-first regression coverage for the current Clear target-body resolution behavior before PR2 extracts the duplicated Clear target logic from `taskpane.js`.

No production code was changed. The new test file uses a small test-only resolver that mirrors the existing Clear geometry: marker stripping, selected-range normalization, embedded label-column stripping, leading-empty-column stripping, and blocked multi-table handling.

## Files changed

- `tests/core/clear-target-resolution.test.mjs`

## Tests added

Added `current Clear target body resolution` coverage for:

- strict numeric selected range remains the selected body
- sloppy full-table selection with banner/header rows resolves to the data body
- adjacent row-label columns are excluded from the clear target
- leading empty structural columns are excluded where the current pass-through path does so
- far-left labels mode limitation is preserved and documented: Clear target resolution has no settings branch
- generated RIT significance footnote rows below the table are excluded from the data body
- ordinary user notes below the table are excluded from the data body
- previously written significance markers are stripped for body recognition
- selected ranges spanning two close tables block instead of bleeding into the neighbor
- minimal two-row labeled table behavior is preserved and documented: it remains pass-through and targets the whole selection because pure-text labels are stripped before the pass-through label heuristic can see them

## Current Clear-target behavior covered

The tests cover the behavior currently duplicated in `clearSignificanceFromSelection` and `clearSignificanceForRangeInContext`: normalize first when needed, apply the secondary embedded-label-column check when the normalizer leaves labels in column 0, apply the leading-empty-column check, and otherwise preserve pass-through numeric selections.

## Scenarios not tested

All requested target-body resolution scenarios are represented in pure unit tests. These tests intentionally do not exercise Office.js mutation, formatting cleanup, Clear footnote-removal writes, or Excel writer behavior because this PR is behavior-preserving and scoped to pre-extraction target resolution coverage.

## Technical debt / limitations

No production technical debt was introduced. The test-only resolver intentionally duplicates the current Clear geometry so the next refactor PR can replace it with an extracted production helper and prove behavior is unchanged.

Discovered ambiguity: a minimal two-row labeled table currently stays in pass-through and does not exclude the label column, because marker stripping removes pure-text labels before the pass-through embedded-label heuristic can see them. This PR documents that behavior rather than changing it.

## Validation

- `npm test` passed: 481 tests
- `npm run build` passed; webpack reported the existing taskpane bundle size warnings
- `git diff --check` passed

## Production behavior

No production behavior changes were intended or made.
