### PR TITLE
[codex] Extract Clear target body resolver

### DIFF
--- a/src/taskpane/selected-range-interpreter.js
+++ b/src/taskpane/selected-range-interpreter.js
@@ -343,6 +343,132 @@ export function detectLeadingEmptyColumns(selectedText) {
   return emptyCols;
 }
 
+/**
+ * Resolves the selected-range sub-rectangle Clear should mutate.
+ *
+ * Pure geometry helper shared by manual Clear and auto Clear. It mirrors the
+ * current Clear behavior:
+ * - marker-strip values before selected-range normalization;
+ * - block unsafe broad selections before any writes;
+ * - for normalized full-table selections, target only the resolved data body;
+ * - apply the secondary embedded-label-column strip when the normalizer leaves
+ *   mixed label/data column 0 inside the body;
+ * - apply the leading-empty structural column strip where Clear already does;
+ * - keep strict numeric selections as pass-through.
+ *
+ * @param {Object} input
+ * @param {Array<Array<*>>} input.values Excel range values.
+ * @param {Array<Array<string>>} input.text Excel range display text.
+ * @returns {Object} Pure target result.
+ *   state: "passThrough" | "normalized" | "blocked" | "empty"
+ *   rowOffset/colOffset: relative start within the original selected range
+ *   rowCount/colCount: target body dimensions
+ *   usesFullSelection: true when callers can reuse the original range object
+ *   cleanedValues: marker-stripped values used for normalization
+ *   normalized: raw normalizeSelectedRange result
+ *   blockingMessage/blockingReasons: populated when state is "blocked"
+ */
+export function resolveClearTargetBodyRange({ values, text }) {
+  const cleanedValues = removeSignificanceMarkersFromMatrix(values);
+  const normalized = normalizeSelectedRange(cleanedValues, text);
+
+  if (normalized.normalizationNeeded && !normalized.normalizationApplied) {
+    return {
+      state: "blocked",
+      rowOffset: 0,
+      colOffset: 0,
+      rowCount: 0,
+      colCount: 0,
+      usesFullSelection: false,
+      cleanedValues,
+      normalized,
+      blockingMessage: normalized.blockingMessage,
+      blockingReasons: normalized.blockingReasons,
+    };
+  }
+
+  if (normalized.normalizationNeeded && normalized.normalizationApplied) {
+    const bodyRowCount = normalized.valuesForCalculation.length;
+    let bodyColCount = normalized.valuesForCalculation[0].length;
+    let effectiveClearColOffset = normalized.dataColOffset;
+    let textForLeadingEmptyCheck = normalized.textForCalculation;
+    let embeddedLabelColumnCount = 0;
+    let leadingEmptyColumnCount = 0;
+
+    if (normalized.dataColOffset === 0) {
+      embeddedLabelColumnCount = detectEmbeddedLabelColumns(normalized.valuesForCalculation);
+      if (embeddedLabelColumnCount > 0) {
+        effectiveClearColOffset += embeddedLabelColumnCount;
+        bodyColCount -= embeddedLabelColumnCount;
+        textForLeadingEmptyCheck = normalized.textForCalculation.map((row) =>
+          row.slice(embeddedLabelColumnCount)
+        );
+      }
+    }
+
+    leadingEmptyColumnCount = detectLeadingEmptyColumns(textForLeadingEmptyCheck);
+    if (leadingEmptyColumnCount > 0) {
+      bodyColCount -= leadingEmptyColumnCount;
+      effectiveClearColOffset += leadingEmptyColumnCount;
+    }
+
+    if (bodyRowCount < 1 || bodyColCount < 1) {
+      return {
+        state: "empty",
+        rowOffset: normalized.dataRowOffset,
+        colOffset: effectiveClearColOffset,
+        rowCount: bodyRowCount,
+        colCount: bodyColCount,
+        usesFullSelection: false,
+        cleanedValues,
+        normalized,
+        blockingMessage: "",
+        blockingReasons: [],
+        embeddedLabelColumnCount,
+        leadingEmptyColumnCount,
+      };
+    }
+
+    return {
+      state: "normalized",
+      rowOffset: normalized.dataRowOffset,
+      colOffset: effectiveClearColOffset,
+      rowCount: bodyRowCount,
+      colCount: bodyColCount,
+      usesFullSelection: false,
+      cleanedValues,
+      normalized,
+      blockingMessage: "",
+      blockingReasons: [],
+      embeddedLabelColumnCount,
+      leadingEmptyColumnCount,
+    };
+  }
+
+  const rowCount = Array.isArray(values) ? values.length : 0;
+  const colCount = rowCount > 0 && Array.isArray(values[0]) ? values[0].length : 0;
+  const embeddedLabelColumnCount = detectEmbeddedLabelColumns(cleanedValues);
+  const leadingEmptyColumnCount =
+    embeddedLabelColumnCount === 0 ? detectLeadingEmptyColumns(text) : 0;
+  const skipLeftCols =
+    embeddedLabelColumnCount > 0 ? embeddedLabelColumnCount : leadingEmptyColumnCount;
+
+  return {
+    state: "passThrough",
+    rowOffset: 0,
+    colOffset: skipLeftCols,
+    rowCount,
+    colCount: colCount - skipLeftCols,
+    usesFullSelection: skipLeftCols === 0,
+    cleanedValues,
+    normalized,
+    blockingMessage: "",
+    blockingReasons: [],
+    embeddedLabelColumnCount,
+    leadingEmptyColumnCount,
+  };
+}
+
 // ─── Banner context adapter ────────────────────────────────────────────────────
 
 /**

--- a/src/taskpane/taskpane.js
+++ b/src/taskpane/taskpane.js
@@ -14,7 +14,6 @@ import {
   compareMeanBlockByRowIndexes,
   compareNpsStructureBlockByRowIndexes,
   compareNpsSpreadBlockByRowIndexes,
-  removeSignificanceMarkersFromMatrix,
   removeSignificanceMarkersFromText,
   generateSignificanceLabels,
   buildBannerLocalSignificanceLabelMap,
@@ -49,14 +48,13 @@ import { detectBannerStructure } from "../core/banner-detector";
 
 import { buildDesignRecolorJob } from "../core/design-recolor";
 
-import { normalizeSelectedRange, hasEmptyDataRowGap, selectionHasMultiTableGap } from "../core/range-normalizer";
+import { hasEmptyDataRowGap, selectionHasMultiTableGap } from "../core/range-normalizer";
 
 import { filterWorkbookCandidates } from "../core/batch-candidate-filter";
 
 import {
   interpretSelectedRange,
-  detectEmbeddedLabelColumns,
-  detectLeadingEmptyColumns,
+  resolveClearTargetBodyRange,
 } from "./selected-range-interpreter";
 
 import { resolveCurrentTableFromActiveCell } from "./active-cell-resolver";
@@ -2374,79 +2372,31 @@ async function clearSignificanceForRangeInContext(context, sheetName, rangeAddre
     return { status: "skipped", message: "нет данных в диапазоне", _clearDetails: null };
   }
 
-  const cleanedValues = removeSignificanceMarkersFromMatrix(selectedValues);
-  const normalized = normalizeSelectedRange(cleanedValues, selectedText);
+  const clearTarget = resolveClearTargetBodyRange({
+    values: selectedValues,
+    text: selectedText,
+  });
 
-  if (normalized.normalizationNeeded && !normalized.normalizationApplied) {
+  if (clearTarget.state === "blocked") {
     const codes =
-      normalized.blockingReasons && normalized.blockingReasons.length > 0
-        ? ` [${normalized.blockingReasons.join(", ")}]`
+      clearTarget.blockingReasons && clearTarget.blockingReasons.length > 0
+        ? ` [${clearTarget.blockingReasons.join(", ")}]`
         : "";
-    return { status: "skipped", message: `${normalized.blockingMessage}${codes}`, _clearDetails: null };
+    return { status: "skipped", message: `${clearTarget.blockingMessage}${codes}`, _clearDetails: null };
+  }
+
+  if (clearTarget.state === "empty") {
+    return { status: "skipped", message: "нет данных после нормализации", _clearDetails: null };
   }
 
   let clearTargetRange;
 
-  if (normalized.normalizationNeeded && normalized.normalizationApplied) {
-    const bodyRowCount = normalized.valuesForCalculation.length;
-    let bodyColCount = normalized.valuesForCalculation[0].length;
-    let effectiveClearColOffset = normalized.dataColOffset;
-    let textForLeadingEmptyCheck = normalized.textForCalculation;
-
-    // Secondary embedded-label-column check (mirrors interpretSelectedRange
-    // State 2 / clearSignificanceFromSelection).  Protects auto-clear ranges
-    // whose label column has mixed text + numeric-looking values from being
-    // overwritten when normalizeSelectedRange leaves col[0] inside the body.
-    if (normalized.dataColOffset === 0) {
-      const additionalLabelCols = detectEmbeddedLabelColumns(
-        normalized.valuesForCalculation
-      );
-      if (additionalLabelCols > 0) {
-        effectiveClearColOffset += additionalLabelCols;
-        bodyColCount -= additionalLabelCols;
-        textForLeadingEmptyCheck = normalized.textForCalculation.map(
-          (row) => row.slice(additionalLabelCols)
-        );
-      }
-    }
-
-    const clearLeadingEmptyCols = detectLeadingEmptyColumns(textForLeadingEmptyCheck);
-    if (clearLeadingEmptyCols > 0) {
-      bodyColCount -= clearLeadingEmptyCols;
-      effectiveClearColOffset += clearLeadingEmptyCols;
-    }
-
-    if (bodyRowCount < 1 || bodyColCount < 1) {
-      return { status: "skipped", message: "нет данных после нормализации", _clearDetails: null };
-    }
-
-    clearTargetRange = sourceRange
-      .getCell(normalized.dataRowOffset, effectiveClearColOffset)
-      .getResizedRange(bodyRowCount - 1, bodyColCount - 1);
+  if (clearTarget.usesFullSelection) {
+    clearTargetRange = sourceRange;
   } else {
-    // Pass-through mirrors interpretSelectedRange / clearSignificanceFromSelection:
-    // prefer detectEmbeddedLabelColumns to keep row labels out of the clear
-    // target on wide tables; fall back to detectLeadingEmptyColumns otherwise.
-    const embeddedLabelColsForClear = detectEmbeddedLabelColumns(cleanedValues);
-    const leadingBlankColsForClear =
-      embeddedLabelColsForClear === 0
-        ? detectLeadingEmptyColumns(selectedText)
-        : 0;
-    const skipLeftCols =
-      embeddedLabelColsForClear > 0
-        ? embeddedLabelColsForClear
-        : leadingBlankColsForClear;
-
-    if (skipLeftCols > 0) {
-      clearTargetRange = sourceRange
-        .getCell(0, skipLeftCols)
-        .getResizedRange(
-          selectedValues.length - 1,
-          selectedValues[0].length - skipLeftCols - 1
-        );
-    } else {
-      clearTargetRange = sourceRange;
-    }
+    clearTargetRange = sourceRange
+      .getCell(clearTarget.rowOffset, clearTarget.colOffset)
+      .getResizedRange(clearTarget.rowCount - 1, clearTarget.colCount - 1);
   }
 
   clearTargetRange.load(["values", "numberFormat", "rowIndex", "columnIndex", "columnCount"]);
@@ -2686,69 +2636,35 @@ async function clearSignificanceForSheetBatched(context, worksheetRef, candidate
       continue;
     }
 
-    const cleanedValues = removeSignificanceMarkersFromMatrix(selectedValues);
-    const normalized = normalizeSelectedRange(cleanedValues, selectedText);
+    const clearTarget = resolveClearTargetBodyRange({
+      values: selectedValues,
+      text: selectedText,
+    });
 
-    if (normalized.normalizationNeeded && !normalized.normalizationApplied) {
+    if (clearTarget.state === "blocked") {
       const codes =
-        normalized.blockingReasons && normalized.blockingReasons.length > 0
-          ? ` [${normalized.blockingReasons.join(", ")}]`
+        clearTarget.blockingReasons && clearTarget.blockingReasons.length > 0
+          ? ` [${clearTarget.blockingReasons.join(", ")}]`
           : "";
       rec.status = "skipped";
-      rec.message = `${normalized.blockingMessage}${codes}`;
+      rec.message = `${clearTarget.blockingMessage}${codes}`;
+      continue;
+    }
+
+    if (clearTarget.state === "empty") {
+      rec.status = "skipped";
+      rec.message = "нет данных после нормализации";
       continue;
     }
 
     let clearTargetRange;
 
-    if (normalized.normalizationNeeded && normalized.normalizationApplied) {
-      const bodyRowCount = normalized.valuesForCalculation.length;
-      let bodyColCount = normalized.valuesForCalculation[0].length;
-      let effectiveClearColOffset = normalized.dataColOffset;
-      let textForLeadingEmptyCheck = normalized.textForCalculation;
-
-      if (normalized.dataColOffset === 0) {
-        const additionalLabelCols = detectEmbeddedLabelColumns(normalized.valuesForCalculation);
-        if (additionalLabelCols > 0) {
-          effectiveClearColOffset += additionalLabelCols;
-          bodyColCount -= additionalLabelCols;
-          textForLeadingEmptyCheck = normalized.textForCalculation.map((row) =>
-            row.slice(additionalLabelCols)
-          );
-        }
-      }
-
-      const clearLeadingEmptyCols = detectLeadingEmptyColumns(textForLeadingEmptyCheck);
-      if (clearLeadingEmptyCols > 0) {
-        bodyColCount -= clearLeadingEmptyCols;
-        effectiveClearColOffset += clearLeadingEmptyCols;
-      }
-
-      if (bodyRowCount < 1 || bodyColCount < 1) {
-        rec.status = "skipped";
-        rec.message = "нет данных после нормализации";
-        continue;
-      }
-
-      clearTargetRange = rec.sourceRange
-        .getCell(normalized.dataRowOffset, effectiveClearColOffset)
-        .getResizedRange(bodyRowCount - 1, bodyColCount - 1);
+    if (clearTarget.usesFullSelection) {
+      clearTargetRange = rec.sourceRange;
     } else {
-      // Pass-through: use JS dimensions — avoids loading sourceRange.rowCount/columnCount.
-      const rowCount = selectedValues.length;
-      const colCount = selectedValues[0].length;
-      const embeddedLabelCols = detectEmbeddedLabelColumns(cleanedValues);
-      const leadingBlankCols =
-        embeddedLabelCols === 0 ? detectLeadingEmptyColumns(selectedText) : 0;
-      const skipLeftCols = embeddedLabelCols > 0 ? embeddedLabelCols : leadingBlankCols;
-
-      if (skipLeftCols > 0) {
-        clearTargetRange = rec.sourceRange
-          .getCell(0, skipLeftCols)
-          .getResizedRange(rowCount - 1, colCount - skipLeftCols - 1);
-      } else {
-        clearTargetRange = rec.sourceRange;
-      }
+      clearTargetRange = rec.sourceRange
+        .getCell(clearTarget.rowOffset, clearTarget.colOffset)
+        .getResizedRange(clearTarget.rowCount - 1, clearTarget.colCount - 1);
     }
 
     rec.clearTargetRange = clearTargetRange;
@@ -3057,69 +2973,35 @@ async function clearSignificanceForWorkbookBatched(context, eligible) {
       continue;
     }
 
-    const cleanedValues = removeSignificanceMarkersFromMatrix(selectedValues);
-    const normalized = normalizeSelectedRange(cleanedValues, selectedText);
+    const clearTarget = resolveClearTargetBodyRange({
+      values: selectedValues,
+      text: selectedText,
+    });
 
-    if (normalized.normalizationNeeded && !normalized.normalizationApplied) {
+    if (clearTarget.state === "blocked") {
       const codes =
-        normalized.blockingReasons && normalized.blockingReasons.length > 0
-          ? ` [${normalized.blockingReasons.join(", ")}]`
+        clearTarget.blockingReasons && clearTarget.blockingReasons.length > 0
+          ? ` [${clearTarget.blockingReasons.join(", ")}]`
           : "";
       rec.status = "skipped";
-      rec.message = `${normalized.blockingMessage}${codes}`;
+      rec.message = `${clearTarget.blockingMessage}${codes}`;
+      continue;
+    }
+
+    if (clearTarget.state === "empty") {
+      rec.status = "skipped";
+      rec.message = "нет данных после нормализации";
       continue;
     }
 
     let clearTargetRange;
 
-    if (normalized.normalizationNeeded && normalized.normalizationApplied) {
-      const bodyRowCount = normalized.valuesForCalculation.length;
-      let bodyColCount = normalized.valuesForCalculation[0].length;
-      let effectiveClearColOffset = normalized.dataColOffset;
-      let textForLeadingEmptyCheck = normalized.textForCalculation;
-
-      if (normalized.dataColOffset === 0) {
-        const additionalLabelCols = detectEmbeddedLabelColumns(normalized.valuesForCalculation);
-        if (additionalLabelCols > 0) {
-          effectiveClearColOffset += additionalLabelCols;
-          bodyColCount -= additionalLabelCols;
-          textForLeadingEmptyCheck = normalized.textForCalculation.map((row) =>
-            row.slice(additionalLabelCols)
-          );
-        }
-      }
-
-      const clearLeadingEmptyCols = detectLeadingEmptyColumns(textForLeadingEmptyCheck);
-      if (clearLeadingEmptyCols > 0) {
-        bodyColCount -= clearLeadingEmptyCols;
-        effectiveClearColOffset += clearLeadingEmptyCols;
-      }
-
-      if (bodyRowCount < 1 || bodyColCount < 1) {
-        rec.status = "skipped";
-        rec.message = "нет данных после нормализации";
-        continue;
-      }
-
-      clearTargetRange = rec.sourceRange
-        .getCell(normalized.dataRowOffset, effectiveClearColOffset)
-        .getResizedRange(bodyRowCount - 1, bodyColCount - 1);
+    if (clearTarget.usesFullSelection) {
+      clearTargetRange = rec.sourceRange;
     } else {
-      // Pass-through: use JS dimensions — avoids loading unneeded sourceRange properties.
-      const rowCount = selectedValues.length;
-      const colCount = selectedValues[0].length;
-      const embeddedLabelCols = detectEmbeddedLabelColumns(cleanedValues);
-      const leadingBlankCols =
-        embeddedLabelCols === 0 ? detectLeadingEmptyColumns(selectedText) : 0;
-      const skipLeftCols = embeddedLabelCols > 0 ? embeddedLabelCols : leadingBlankCols;
-
-      if (skipLeftCols > 0) {
-        clearTargetRange = rec.sourceRange
-          .getCell(0, skipLeftCols)
-          .getResizedRange(rowCount - 1, colCount - skipLeftCols - 1);
-      } else {
-        clearTargetRange = rec.sourceRange;
-      }
+      clearTargetRange = rec.sourceRange
+        .getCell(clearTarget.rowOffset, clearTarget.colOffset)
+        .getResizedRange(clearTarget.rowCount - 1, clearTarget.colCount - 1);
     }
 
     rec.clearTargetRange = clearTargetRange;
@@ -4588,102 +4470,35 @@ async function clearSignificanceFromSelection() {
       return;
     }
 
-    const cleanedValues = removeSignificanceMarkersFromMatrix(selectedValues);
-    const normalized = normalizeSelectedRange(cleanedValues, selectedText);
+    const clearTarget = resolveClearTargetBodyRange({
+      values: selectedValues,
+      text: selectedText,
+    });
 
     // State 3: broad/full-table-like selection but decomposition failed.
     // Block and return without mutating anything.
-    if (normalized.normalizationNeeded && !normalized.normalizationApplied) {
+    if (clearTarget.state === "blocked") {
       const codes =
-        normalized.blockingReasons && normalized.blockingReasons.length > 0
-          ? ` [${normalized.blockingReasons.join(", ")}]`
+        clearTarget.blockingReasons && clearTarget.blockingReasons.length > 0
+          ? ` [${clearTarget.blockingReasons.join(", ")}]`
           : "";
-      setStatusMessage(`${normalized.blockingMessage}${codes}`);
+      setStatusMessage(`${clearTarget.blockingMessage}${codes}`);
       return;
     }
 
-    // Resolve the clear target:
-    //   - State 1 (pass-through): the original selection is numeric-only.
-    //   - State 2 (normalized):   only the detected data body subrange.
+    if (clearTarget.state === "empty") {
+      setStatusMessage("Нет данных в выделенном диапазоне.");
+      return;
+    }
+
     let clearTargetRange;
 
-    if (normalized.normalizationNeeded && normalized.normalizationApplied) {
-      const bodyRowCount = normalized.valuesForCalculation.length;
-      let bodyColCount = normalized.valuesForCalculation[0].length;
-      let effectiveClearColOffset = normalized.dataColOffset;
-      let textForLeadingEmptyCheck = normalized.textForCalculation;
-
-      // Secondary embedded-label-column check (mirrors interpretSelectedRange
-      // State 2).  The normalizer leaves the label column inside
-      // valuesForCalculation when col[0] text fraction is uncertain (mix of
-      // text and numeric-looking labels, e.g. "Нет", "1", "2", "BASE").
-      // detectEmbeddedLabelColumns recognises that shape by looking for at
-      // least one genuine text cell in col[0]; without it, Clear's target
-      // would still include the row-label column and overwrite label text.
-      if (normalized.dataColOffset === 0) {
-        const additionalLabelCols = detectEmbeddedLabelColumns(
-          normalized.valuesForCalculation
-        );
-        if (additionalLabelCols > 0) {
-          effectiveClearColOffset += additionalLabelCols;
-          bodyColCount -= additionalLabelCols;
-          textForLeadingEmptyCheck = normalized.textForCalculation.map(
-            (row) => row.slice(additionalLabelCols)
-          );
-        }
-      }
-
-      // Tertiary strip mirrors interpretSelectedRange State 2: the normalizer
-      // may leave leading all-blank helper columns (e.g. column B in a
-      // mean-only table) inside the normalized body.  Clear must exclude
-      // those same columns so it does not widen the clear target beyond the
-      // real data body.
-      const clearLeadingEmptyCols = detectLeadingEmptyColumns(
-        textForLeadingEmptyCheck
-      );
-      if (clearLeadingEmptyCols > 0) {
-        bodyColCount -= clearLeadingEmptyCols;
-        effectiveClearColOffset += clearLeadingEmptyCols;
-      }
-
-      if (bodyRowCount < 1 || bodyColCount < 1) {
-        setStatusMessage("Нет данных в выделенном диапазоне.");
-        return;
-      }
-
-      clearTargetRange = selectedRange
-        .getCell(normalized.dataRowOffset, effectiveClearColOffset)
-        .getResizedRange(bodyRowCount - 1, bodyColCount - 1);
+    if (clearTarget.usesFullSelection) {
+      clearTargetRange = selectedRange;
     } else {
-      // Pass-through.  Mirror interpretSelectedRange pass-through path
-      // (selected-range-interpreter.js): first try detectEmbeddedLabelColumns
-      // (recognises a leftmost column with at least one genuine text cell,
-      // optionally followed by uniform unit columns), and only fall back to
-      // detectLeadingEmptyColumns when no embedded label column was found.
-      // This excludes row labels from the clear target on wide tables whose
-      // col[0] text fraction sits just below the normalizer pass-through gate
-      // (e.g. labels "Нет"/"1"/"2"/"BASE") so the original strict workflow
-      // for pure numeric selections is preserved.
-      const embeddedLabelColsForClear = detectEmbeddedLabelColumns(cleanedValues);
-      const leadingBlankColsForClear =
-        embeddedLabelColsForClear === 0
-          ? detectLeadingEmptyColumns(selectedText)
-          : 0;
-      const skipLeftCols =
-        embeddedLabelColsForClear > 0
-          ? embeddedLabelColsForClear
-          : leadingBlankColsForClear;
-
-      if (skipLeftCols > 0) {
-        clearTargetRange = selectedRange
-          .getCell(0, skipLeftCols)
-          .getResizedRange(
-            selectedRange.rowCount - 1,
-            selectedRange.columnCount - skipLeftCols - 1
-          );
-      } else {
-        clearTargetRange = selectedRange;
-      }
+      clearTargetRange = selectedRange
+        .getCell(clearTarget.rowOffset, clearTarget.colOffset)
+        .getResizedRange(clearTarget.rowCount - 1, clearTarget.colCount - 1);
     }
 
     clearTargetRange.load(["values", "numberFormat", "rowIndex", "columnIndex", "columnCount"]);

--- a/tests/core/clear-target-resolution.test.mjs
+++ b/tests/core/clear-target-resolution.test.mjs
@@ -1,13 +1,8 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 
-import { normalizeSelectedRange } from "../../src/core/range-normalizer.js";
-import { removeSignificanceMarkersFromMatrix } from "../../src/core/significance.js";
 import { SIGNIFICANCE_FOOTNOTE_MARKER } from "../../src/core/significance-footnote.js";
-import {
-  detectEmbeddedLabelColumns,
-  detectLeadingEmptyColumns,
-} from "../../src/taskpane/selected-range-interpreter.js";
+import { resolveClearTargetBodyRange } from "../../src/taskpane/selected-range-interpreter.js";
 
 function toDisplayText(values) {
   return values.map((row) =>
@@ -22,76 +17,24 @@ function sliceMatrix(matrix, rowOffset, colOffset, rowCount, colCount) {
 }
 
 function resolveCurrentClearTargetBody(selectedValues, selectedText = toDisplayText(selectedValues)) {
-  const cleanedValues = removeSignificanceMarkersFromMatrix(selectedValues);
-  const normalized = normalizeSelectedRange(cleanedValues, selectedText);
+  const target = resolveClearTargetBodyRange({
+    values: selectedValues,
+    text: selectedText,
+  });
 
-  if (normalized.normalizationNeeded && !normalized.normalizationApplied) {
-    return {
-      state: "blocked",
-      blockingReasons: normalized.blockingReasons,
-    };
+  if (target.state === "blocked") {
+    return target;
   }
-
-  if (normalized.normalizationNeeded && normalized.normalizationApplied) {
-    const bodyRowCount = normalized.valuesForCalculation.length;
-    let bodyColCount = normalized.valuesForCalculation[0].length;
-    let effectiveClearColOffset = normalized.dataColOffset;
-    let textForLeadingEmptyCheck = normalized.textForCalculation;
-
-    if (normalized.dataColOffset === 0) {
-      const additionalLabelCols = detectEmbeddedLabelColumns(normalized.valuesForCalculation);
-      if (additionalLabelCols > 0) {
-        effectiveClearColOffset += additionalLabelCols;
-        bodyColCount -= additionalLabelCols;
-        textForLeadingEmptyCheck = normalized.textForCalculation.map((row) =>
-          row.slice(additionalLabelCols)
-        );
-      }
-    }
-
-    const clearLeadingEmptyCols = detectLeadingEmptyColumns(textForLeadingEmptyCheck);
-    if (clearLeadingEmptyCols > 0) {
-      bodyColCount -= clearLeadingEmptyCols;
-      effectiveClearColOffset += clearLeadingEmptyCols;
-    }
-
-    return {
-      state: "normalized",
-      rowOffset: normalized.dataRowOffset,
-      colOffset: effectiveClearColOffset,
-      rowCount: bodyRowCount,
-      colCount: bodyColCount,
-      targetValues: sliceMatrix(
-        cleanedValues,
-        normalized.dataRowOffset,
-        effectiveClearColOffset,
-        bodyRowCount,
-        bodyColCount
-      ),
-      normalized,
-    };
-  }
-
-  const embeddedLabelColsForClear = detectEmbeddedLabelColumns(cleanedValues);
-  const leadingBlankColsForClear =
-    embeddedLabelColsForClear === 0 ? detectLeadingEmptyColumns(selectedText) : 0;
-  const skipLeftCols =
-    embeddedLabelColsForClear > 0 ? embeddedLabelColsForClear : leadingBlankColsForClear;
 
   return {
-    state: "passThrough",
-    rowOffset: 0,
-    colOffset: skipLeftCols,
-    rowCount: selectedValues.length,
-    colCount: selectedValues[0].length - skipLeftCols,
+    ...target,
     targetValues: sliceMatrix(
-      cleanedValues,
-      0,
-      skipLeftCols,
-      selectedValues.length,
-      selectedValues[0].length - skipLeftCols
+      target.cleanedValues,
+      target.rowOffset,
+      target.colOffset,
+      target.rowCount,
+      target.colCount
     ),
-    normalized,
   };
 }
 


### PR DESCRIPTION
## Summary

Extracts a pure Clear target-body resolver from the duplicated Clear geometry in `taskpane.js`.

This PR is stacked on PR #319 / `codex/clear-target-regression-tests` so the regression tests added there can be updated to call the production helper directly.

## Files changed

- `src/taskpane/selected-range-interpreter.js`
- `src/taskpane/taskpane.js`
- `tests/core/clear-target-resolution.test.mjs`

## Helper added

Added `resolveClearTargetBodyRange({ values, text })` in `src/taskpane/selected-range-interpreter.js`.

The helper is pure: it has no DOM, Excel, or Office.js dependencies. It returns relative target geometry:

- `state`: `passThrough`, `normalized`, `blocked`, or `empty`
- `rowOffset`, `colOffset`
- `rowCount`, `colCount`
- `usesFullSelection`
- `cleanedValues`
- `normalized`
- `blockingMessage`, `blockingReasons`
- debug counts for embedded label and leading empty columns

## Duplicated logic consolidated

The helper consolidates the current Clear-only target resolution behavior:

- marker-strip values before normalization
- call selected-range normalization
- block unsafe broad selections before any write
- target normalized data body rather than banner/header rows
- apply the secondary `detectEmbeddedLabelColumns` strip when needed
- apply the `detectLeadingEmptyColumns` strip where current Clear does
- preserve strict numeric pass-through selections
- preserve marker-stripped numeric recognition

## Clear flows touched

Now using the helper:

- `clearSignificanceFromSelection`
- `clearSignificanceForRangeInContext`
- `clearSignificanceForSheetBatched`
- `clearSignificanceForWorkbookBatched`

Not moved:

- Clear write loop
- full Clear pipeline
- footnote cleanup
- banner cleanup
- Run/Check/Content handlers
- Excel writer/statistical/core logic
- UI/status/report logic

## Behavior-preservation notes

No Clear behavior changes were intended. The PR replaces duplicated target geometry with a single pure helper and keeps the Office range construction and cleanup/write loops in place.

Known current ambiguity remains documented in tests: minimal two-row labeled tables still pass through and target the whole selection because pure-text labels are marker-stripped before the pass-through label heuristic can see them.

## Tests added/updated

Updated `tests/core/clear-target-resolution.test.mjs` so the PR #319 regression tests call `resolveClearTargetBodyRange` directly instead of a test-only duplicate resolver.

No new scenarios were needed; the existing PR #319 coverage now protects the extracted helper.

## Validation

- `npm test` passed: 481 tests
- `npm run build` passed; webpack reported the existing taskpane bundle-size warnings
- `git diff --check` passed

## Manual smoke checklist

Not run in this environment; requires Excel smoke testing.

- Manual Clear on strict numeric body selection
- Manual Clear on sloppy full-table selection with banner/header included
- Manual Clear with adjacent row-label columns included
- Manual Clear with leading empty structural column
- Auto/current-table Clear
- Current-sheet/workbook Clear
- Clear removes generated RIT footnotes as before
- Clear preserves ordinary user note rows as before
- Clear removes one-character and multi-character significance markers
- Clear does not touch neighboring tables
