### PR TITLE
Extract marker overflow dialog helpers

### DIFF
--- a/src/taskpane/taskpane-dialogs.js
+++ b/src/taskpane/taskpane-dialogs.js
@@ -1,0 +1,91 @@
+/* global document */
+
+const MARKER_OVERFLOW_DIALOG_ID = "marker-overflow-dialog";
+const MARKER_OVERFLOW_CONTINUE_ID = "marker-overflow-continue";
+const MARKER_OVERFLOW_STOP_ID = "marker-overflow-stop";
+
+/**
+ * Shows the in-taskpane marker-overflow dialog and resolves the user's choice.
+ *
+ * window.confirm is not supported in the Office add-in webview, so this drives a
+ * small custom modal defined in taskpane.html. Returns a Promise:
+ * - true  -> continue with multi-character markers;
+ * - false -> stop the calculation.
+ *
+ * Esc, clicking the backdrop, or missing markup all resolve to false (stop) so
+ * the safe choice (no writes) is the default.
+ */
+export function confirmMarkerOverflowDialog() {
+  return new Promise((resolve) => {
+    const overlay = document.getElementById(MARKER_OVERFLOW_DIALOG_ID);
+    const continueButton = document.getElementById(MARKER_OVERFLOW_CONTINUE_ID);
+    const stopButton = document.getElementById(MARKER_OVERFLOW_STOP_ID);
+
+    if (!overlay || !continueButton || !stopButton) {
+      // Fail safe: without the dialog markup, stop rather than write blindly.
+      resolve(false);
+      return;
+    }
+
+    const finish = (shouldContinue) => {
+      overlay.style.display = "none";
+      continueButton.removeEventListener("click", onContinue);
+      stopButton.removeEventListener("click", onStop);
+      overlay.removeEventListener("mousedown", onBackdrop);
+      document.removeEventListener("keydown", onKeydown);
+      resolve(shouldContinue);
+    };
+
+    const onContinue = () => finish(true);
+    const onStop = () => finish(false);
+    const onBackdrop = (event) => {
+      // Clicking outside the dialog body counts as Stop.
+      if (event.target === overlay) finish(false);
+    };
+    const onKeydown = (event) => {
+      if (event.key === "Escape") finish(false);
+    };
+
+    continueButton.addEventListener("click", onContinue);
+    stopButton.addEventListener("click", onStop);
+    overlay.addEventListener("mousedown", onBackdrop);
+    document.addEventListener("keydown", onKeydown);
+
+    overlay.style.display = "flex";
+    continueButton.focus();
+  });
+}
+
+/**
+ * Per-operation marker-overflow decision.
+ *
+ * The dialog is shown at most once per Run; the user's choice is then reused for
+ * every table processed in the same operation (so batch runs do not re-prompt
+ * for each table). `resolve()` is async and returns "continue" or "stop". A
+ * shared in-flight promise guards against showing two dialogs if `resolve()` is
+ * awaited from more than one place before the first choice is made.
+ */
+export function createMarkerOverflowDecider(confirmDialog = confirmMarkerOverflowDialog) {
+  let decision = null; // null | "continue" | "stop"
+  let pending = null;
+
+  return {
+    async resolve() {
+      if (decision !== null) {
+        return decision;
+      }
+
+      if (!pending) {
+        pending = confirmDialog().then((shouldContinue) => {
+          decision = shouldContinue ? "continue" : "stop";
+          return decision;
+        });
+      }
+
+      return pending;
+    },
+    get decision() {
+      return decision;
+    },
+  };
+}

--- a/src/taskpane/taskpane.js
+++ b/src/taskpane/taskpane.js
@@ -56,6 +56,8 @@ import { resolveCurrentTableFromActiveCell } from "./active-cell-resolver";
 
 import { t, setLanguage, loadSavedLanguage, applyI18n } from "./localization";
 
+import { createMarkerOverflowDecider } from "./taskpane-dialogs";
+
 import {
   setStatusMessage,
   setCheckMessage,
@@ -471,106 +473,6 @@ function initActionScopeShell() {
 // ─────────────────────────────────────────────────────────────────────────────
 
 /**
- * Reads selected Excel range, detects metric blocks, calculates pairwise significance,
- * and writes significance letters only into actual value rows.
- *
- * PURPOSE:
- * Unified auto mode for complex tables.
- * One selected range may contain proportions, means, and NPS blocks.
- *
- * SUPPORTED BLOCKS:
- * - Proportions + Base
- * - Mean + SD/Variance + Base
- * - NPS + Promoters + Detractors + Base
- * - NPS + SD/Variance + Base
- */
-/**
- * Shows the in-taskpane marker-overflow dialog and resolves the user's choice.
- *
- * window.confirm is not supported in the Office add-in webview, so this drives a
- * small custom modal defined in taskpane.html. Returns a Promise:
- * - true  → continue with multi-character markers;
- * - false → stop the calculation.
- *
- * Esc, clicking the backdrop, or missing markup all resolve to false (stop) so
- * the safe choice (no writes) is the default.
- */
-function confirmMarkerOverflowDialog() {
-  return new Promise((resolve) => {
-    const overlay = document.getElementById("marker-overflow-dialog");
-    const continueButton = document.getElementById("marker-overflow-continue");
-    const stopButton = document.getElementById("marker-overflow-stop");
-
-    if (!overlay || !continueButton || !stopButton) {
-      // Fail safe: without the dialog markup, stop rather than write blindly.
-      resolve(false);
-      return;
-    }
-
-    const finish = (shouldContinue) => {
-      overlay.style.display = "none";
-      continueButton.removeEventListener("click", onContinue);
-      stopButton.removeEventListener("click", onStop);
-      overlay.removeEventListener("mousedown", onBackdrop);
-      document.removeEventListener("keydown", onKeydown);
-      resolve(shouldContinue);
-    };
-
-    const onContinue = () => finish(true);
-    const onStop = () => finish(false);
-    const onBackdrop = (event) => {
-      // Clicking outside the dialog body counts as Stop.
-      if (event.target === overlay) finish(false);
-    };
-    const onKeydown = (event) => {
-      if (event.key === "Escape") finish(false);
-    };
-
-    continueButton.addEventListener("click", onContinue);
-    stopButton.addEventListener("click", onStop);
-    overlay.addEventListener("mousedown", onBackdrop);
-    document.addEventListener("keydown", onKeydown);
-
-    overlay.style.display = "flex";
-    continueButton.focus();
-  });
-}
-
-/**
- * Per-operation marker-overflow decision.
- *
- * The dialog is shown at most once per Run; the user's choice is then reused for
- * every table processed in the same operation (so batch runs do not re-prompt
- * for each table). `resolve()` is async and returns "continue" or "stop". A
- * shared in-flight promise guards against showing two dialogs if `resolve()` is
- * awaited from more than one place before the first choice is made.
- */
-function createMarkerOverflowDecider() {
-  let decision = null; // null | "continue" | "stop"
-  let pending = null;
-
-  return {
-    async resolve() {
-      if (decision !== null) {
-        return decision;
-      }
-
-      if (!pending) {
-        pending = confirmMarkerOverflowDialog().then((shouldContinue) => {
-          decision = shouldContinue ? "continue" : "stop";
-          return decision;
-        });
-      }
-
-      return pending;
-    },
-    get decision() {
-      return decision;
-    },
-  };
-}
-
-/**
  * Read-only marker-overflow check for a single range, mirroring the front half
  * of runSignificanceForRangeInContext (load → interpret → detect banner) but
  * WITHOUT writing anything. Returns true when the table would need more
@@ -722,6 +624,20 @@ async function preflightBatchMarkerOverflow(eligible, itemMap, calculationSettin
   return false;
 }
 
+/**
+ * Reads selected Excel range, detects metric blocks, calculates pairwise significance,
+ * and writes significance letters only into actual value rows.
+ *
+ * PURPOSE:
+ * Unified auto mode for complex tables.
+ * One selected range may contain proportions, means, and NPS blocks.
+ *
+ * SUPPORTED BLOCKS:
+ * - Proportions + Base
+ * - Mean + SD/Variance + Base
+ * - NPS + Promoters + Detractors + Base
+ * - NPS + SD/Variance + Base
+ */
 async function runSignificanceFromSelection() {
   const _t0 = perfNow();
   setStatusMessage(runningStatusMessage("run", "table"));

--- a/tests/core/marker-overflow-dialog.test.mjs
+++ b/tests/core/marker-overflow-dialog.test.mjs
@@ -1,0 +1,45 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import { createMarkerOverflowDecider } from "../../src/taskpane/taskpane-dialogs.js";
+
+describe("createMarkerOverflowDecider", () => {
+  it("caches a continue decision and reuses the in-flight prompt", async () => {
+    let calls = 0;
+    let resolvePrompt;
+    const decider = createMarkerOverflowDecider(() => {
+      calls += 1;
+      return new Promise((resolve) => {
+        resolvePrompt = resolve;
+      });
+    });
+
+    assert.equal(decider.decision, null);
+
+    const first = decider.resolve();
+    const second = decider.resolve();
+
+    assert.equal(calls, 1);
+
+    resolvePrompt(true);
+
+    assert.equal(await first, "continue");
+    assert.equal(await second, "continue");
+    assert.equal(decider.decision, "continue");
+    assert.equal(await decider.resolve(), "continue");
+    assert.equal(calls, 1);
+  });
+
+  it("caches a stop decision", async () => {
+    let calls = 0;
+    const decider = createMarkerOverflowDecider(async () => {
+      calls += 1;
+      return false;
+    });
+
+    assert.equal(await decider.resolve(), "stop");
+    assert.equal(decider.decision, "stop");
+    assert.equal(await decider.resolve(), "stop");
+    assert.equal(calls, 1);
+  });
+});


### PR DESCRIPTION
## Summary
- Extracts the marker-overflow confirmation dialog and per-operation decision cache from `src/taskpane/taskpane.js` into `src/taskpane/taskpane-dialogs.js`.
- Keeps Run, batch preflight, Clear, Check/Content/inventory, status rendering, settings persistence, report writing, marker generation, Excel writer, and footnote logic unchanged.
- Adds minimal pure tests for the decision cache/in-flight behavior.

## Files changed
- `src/taskpane/taskpane-dialogs.js`
- `src/taskpane/taskpane.js`
- `tests/core/marker-overflow-dialog.test.mjs`

## Functions moved
- `confirmMarkerOverflowDialog`
- `createMarkerOverflowDecider`

## Functions intentionally left in taskpane.js
- `computeRangeMarkerOverflowInContext`: remains in `taskpane.js` because it depends on Excel context, selected-range interpretation, banner context, and calculation settings.
- `detectBatchMarkerOverflowExact`: remains in `taskpane.js` because it orchestrates Excel read-only batch preflight over eligible candidates.
- `preflightBatchMarkerOverflow`: remains in `taskpane.js` because it is Run/batch preflight orchestration that sets operation-level calculation settings before writes.
- Run entry points and `runSignificanceForRangeInContext`: intentionally left in place; PR4A does not start Run pipeline extraction.

## Exported API
- `confirmMarkerOverflowDialog()`: returns `Promise<boolean>` for the modal choice.
- `createMarkerOverflowDecider(confirmDialog = confirmMarkerOverflowDialog)`: returns an operation-scoped decider with `resolve()` and `decision`.

## Dependency / circular dependency notes
- `taskpane-dialogs.js` does not import `taskpane.js`.
- `taskpane.js` imports `createMarkerOverflowDecider` from `taskpane-dialogs.js`.
- The new module only depends on the taskpane DOM markup via element IDs; no Office.js or core-module dependency was introduced.
- No circular dependency was found or introduced.

## Async modal behavior
- Continue still resolves `true` through `confirmMarkerOverflowDialog`, which the decider maps to `"continue"`.
- Stop still resolves `false`, which the decider maps to `"stop"`.
- Esc, backdrop click, and missing markup still resolve `false` as the safe default.
- Event listeners are still removed during dialog completion.
- A shared pending promise and cached decision still ensure only one prompt appears per operation.
- Batch behavior is preserved: prompt happens before writes, Stop aborts before writes, Continue enables multi-character markers for the operation, and repeated prompts are avoided.

## Validation
- `npm test` passed: 483 tests.
- `npm run build` passed with existing webpack bundle-size warnings for `taskpane.js`.
- `git diff --check` passed.

## Manual smoke checklist
- [ ] Taskpane loads.
- [ ] Marker-overflow dialog opens when column count exceeds marker capacity.
- [ ] Stop aborts before writing anything.
- [ ] Continue processes with multi-character markers.
- [ ] Previous-column comparison mode does not show dialog.
- [ ] Banner-aware mode only shows dialog when a group exceeds marker capacity.
- [ ] Dialog is not shown repeatedly within one batch operation.
- [ ] Basic Manual Run still works.
- [ ] Current-table/current-sheet/workbook Run smoke.
- [ ] Clear still works after extraction.

## Architecture / validation notes
- Affected table-structure matrix areas: none expected; this is a taskpane dialog extraction only.
- Affected gold-standard cases: marker-overflow and Run smoke areas only; no statistical calculation behavior changed.
- Technical debt: no known new technical debt. The modal remains DOM-smoked manually rather than covered by a complex DOM test, matching the requested test scope.
