### PR TITLE
Extract taskpane action warning helpers

### DIFF
--- a/src/taskpane/taskpane-action-warnings.js
+++ b/src/taskpane/taskpane-action-warnings.js
@@ -1,0 +1,66 @@
+/* global document */
+
+export function collectActionWarningKeys({
+  action,
+  labelsOnLeftSide = false,
+  addTableFootnoteRequested = false,
+  recolorRequested = false,
+} = {}) {
+  if (action !== "run" && action !== "autorun") {
+    return [];
+  }
+
+  const warningKeys = [];
+
+  if (labelsOnLeftSide && addTableFootnoteRequested) {
+    warningKeys.push("footnote-labels-left");
+  }
+
+  if (labelsOnLeftSide && recolorRequested) {
+    warningKeys.push("recolor-labels-left");
+  } else if (action === "run" && recolorRequested) {
+    warningKeys.push("manual-run-recolor");
+  }
+
+  return warningKeys;
+}
+
+export function renderActionWarnings(warningBlock, warningKeys) {
+  if (!warningBlock) {
+    return;
+  }
+
+  const activeWarnings = new Set(warningKeys);
+  let hasWarnings = false;
+
+  warningBlock.querySelectorAll("[data-action-warning]").forEach((line) => {
+    const show = activeWarnings.has(line.dataset.actionWarning);
+    line.style.display = show ? "" : "none";
+    hasWarnings = hasWarnings || show;
+  });
+
+  warningBlock.style.display = hasWarnings ? "" : "none";
+}
+
+export function refreshActionWarnings({
+  documentRef = typeof document === "undefined" ? null : document,
+  action,
+  labelsOnLeftSide = false,
+  addTableFootnoteRequested = false,
+  recolorRequested = false,
+} = {}) {
+  if (!documentRef) {
+    return;
+  }
+
+  const warningBlock = documentRef.getElementById("action-settings-warnings");
+  renderActionWarnings(
+    warningBlock,
+    collectActionWarningKeys({
+      action,
+      labelsOnLeftSide,
+      addTableFootnoteRequested,
+      recolorRequested,
+    })
+  );
+}

--- a/src/taskpane/taskpane.js
+++ b/src/taskpane/taskpane.js
@@ -58,6 +58,8 @@ import { t, setLanguage, loadSavedLanguage, applyI18n } from "./localization";
 
 import { createMarkerOverflowDecider } from "./taskpane-dialogs";
 
+import { refreshActionWarnings } from "./taskpane-action-warnings";
+
 import {
   setStatusMessage,
   setCheckMessage,
@@ -328,7 +330,7 @@ function initLanguageSelector() {
       // re-applies the mode-suffix in the new language.
       setLanguage(btn.dataset.lang);
       updateCheckHints();
-      refreshActionWarnings();
+      refreshActionWarningDisplay();
     });
   });
 }
@@ -349,45 +351,20 @@ function updateCheckHints() {
   });
 }
 
-function collectActionWarningKeys(action) {
-  if (action !== "run" && action !== "autorun") {
-    return [];
-  }
-
-  const labelsOnLeftSide = getCheckboxValue("labels-on-left-side");
-  const addTableFootnoteRequested = getCheckboxValue("add-table-footnote");
-  const recolorRequested = getCheckboxValue("recolor-banner-and-labels");
-  const warningKeys = [];
-
-  if (labelsOnLeftSide && addTableFootnoteRequested) {
-    warningKeys.push("footnote-labels-left");
-  }
-
-  if (labelsOnLeftSide && recolorRequested) {
-    warningKeys.push("recolor-labels-left");
-  } else if (action === "run" && recolorRequested) {
-    warningKeys.push("manual-run-recolor");
-  }
-
-  return warningKeys;
+function getActionWarningSettings() {
+  return {
+    labelsOnLeftSide: getCheckboxValue("labels-on-left-side"),
+    addTableFootnoteRequested: getCheckboxValue("add-table-footnote"),
+    recolorRequested: getCheckboxValue("recolor-banner-and-labels"),
+  };
 }
 
-function refreshActionWarnings() {
-  const warningBlock = document.getElementById("action-settings-warnings");
-  if (!warningBlock) {
-    return;
-  }
-
-  const activeWarnings = new Set(collectActionWarningKeys(_currentAction));
-  let hasWarnings = false;
-
-  warningBlock.querySelectorAll("[data-action-warning]").forEach((line) => {
-    const show = activeWarnings.has(line.dataset.actionWarning);
-    line.style.display = show ? "" : "none";
-    hasWarnings = hasWarnings || show;
+function refreshActionWarningDisplay() {
+  refreshActionWarnings({
+    documentRef: document,
+    action: _currentAction,
+    ...getActionWarningSettings(),
   });
-
-  warningBlock.style.display = hasWarnings ? "" : "none";
 }
 
 function updateActionScopeShell(action, scope) {
@@ -438,7 +415,7 @@ function updateActionScopeShell(action, scope) {
   }
 
   updateCheckHints();
-  refreshActionWarnings();
+  refreshActionWarningDisplay();
 }
 
 function initActionScopeShell() {
@@ -5842,7 +5819,7 @@ function refreshSettingsPanelState() {
   refreshBannerStructureSettingsState();
   refreshTableFootnoteState();
   refreshDesignRecolorState();
-  refreshActionWarnings();
+  refreshActionWarningDisplay();
 }
 
 /**

--- a/tests/core/taskpane-action-warnings.test.mjs
+++ b/tests/core/taskpane-action-warnings.test.mjs
@@ -1,0 +1,59 @@
+import assert from "node:assert/strict";
+import test, { describe } from "node:test";
+
+import { collectActionWarningKeys } from "../../src/taskpane/taskpane-action-warnings.js";
+
+describe("taskpane action warnings", () => {
+  test("returns no warnings outside Run and Autorun actions", () => {
+    assert.deepStrictEqual(
+      collectActionWarningKeys({
+        action: "check",
+        labelsOnLeftSide: true,
+        addTableFootnoteRequested: true,
+        recolorRequested: true,
+      }),
+      []
+    );
+  });
+
+  test("shows manual Run recolor warning only for manual Run", () => {
+    assert.deepStrictEqual(
+      collectActionWarningKeys({
+        action: "run",
+        recolorRequested: true,
+      }),
+      ["manual-run-recolor"]
+    );
+
+    assert.deepStrictEqual(
+      collectActionWarningKeys({
+        action: "autorun",
+        recolorRequested: true,
+      }),
+      []
+    );
+  });
+
+  test("prioritizes far-left label incompatibility over manual Run recolor warning", () => {
+    assert.deepStrictEqual(
+      collectActionWarningKeys({
+        action: "run",
+        labelsOnLeftSide: true,
+        recolorRequested: true,
+      }),
+      ["recolor-labels-left"]
+    );
+  });
+
+  test("includes far-left footnote and recolor incompatibility warnings together", () => {
+    assert.deepStrictEqual(
+      collectActionWarningKeys({
+        action: "autorun",
+        labelsOnLeftSide: true,
+        addTableFootnoteRequested: true,
+        recolorRequested: true,
+      }),
+      ["footnote-labels-left", "recolor-labels-left"]
+    );
+  });
+});


### PR DESCRIPTION

## Summary
- Extracted action-area settings incompatibility warning computation/rendering from `src/taskpane/taskpane.js` into `src/taskpane/taskpane-action-warnings.js`.
- Left `taskpane.js` responsible only for reading existing checkbox values and passing explicit values to the warning module.
- Added focused pure tests for action warning key computation.

## Files changed
- `src/taskpane/taskpane-action-warnings.js`
- `src/taskpane/taskpane.js`
- `tests/core/taskpane-action-warnings.test.mjs`

## Functions moved
- `collectActionWarningKeys` moved from `taskpane.js` to `taskpane-action-warnings.js` and now accepts explicit action/settings values.
- `refreshActionWarnings` moved from `taskpane.js` to `taskpane-action-warnings.js` and now accepts explicit document/action/settings values.
- DOM show/hide rendering from the old `refreshActionWarnings` moved into exported `renderActionWarnings`.

## Functions intentionally left in taskpane.js
- `getActionWarningSettings`: retained as the narrow adapter that reads the existing taskpane checkbox DOM values.
- `refreshActionWarningDisplay`: retained as the narrow adapter that passes `_currentAction`, `document`, and explicit checkbox values into the new module.
- Previous-column / Total settings-panel warning logic remains in `refreshPreviousColumnComparisonState` because it is settings-panel state management, not action-area warning rendering.

## Exported API
- `collectActionWarningKeys({ action, labelsOnLeftSide, addTableFootnoteRequested, recolorRequested })`
- `renderActionWarnings(warningBlock, warningKeys)`
- `refreshActionWarnings({ documentRef, action, labelsOnLeftSide, addTableFootnoteRequested, recolorRequested })`

## Dependency and circular dependency notes
- `taskpane-action-warnings.js` does not import `taskpane.js` or any taskpane state.
- `taskpane.js` imports the new warning helper module.
- No circular dependency introduced.

## Localization
- Existing DOM IDs, `data-action-warning` keys, `data-i18n` spans, classes, and warning text are unchanged.
- RU/EN behavior remains driven by `applyI18n`; language switch still refreshes warning visibility after changing language.

## Validation
- `npm test` passed: 487 tests passing.
- `npm run build` passed. Webpack reported existing taskpane bundle-size warnings.
- `git diff --check` passed.

## Manual smoke checklist
- [ ] Taskpane loads. Not run in this environment.
- [ ] Settings changes still update action-area incompatibility warnings. Not run in this environment.
- [ ] Manual Run + recolor warning still appears in the expected place. Not run in this environment.
- [ ] Far-left labels + recolor warning still appears / blocks as before. Not run in this environment.
- [ ] RU/EN switch still updates warning text. Not run in this environment.
- [ ] Basic Run smoke. Not run in this environment.
- [ ] Basic Clear smoke. Not run in this environment.
- [ ] Check/Content buttons still work. Not run in this environment.

## Assumptions / limitations
- No production behavior changes intended.
- No Run pipeline, Clear pipeline, settings persistence, localization text, or statistical/core logic changed.
