### PR TITLE
PR4C: tighten taskpane status helpers

### DIFF
--- a/src/taskpane/taskpane-status.js
+++ b/src/taskpane/taskpane-status.js
@@ -1,7 +1,5 @@
 /* global document */
 
-import { t } from "./localization";
-
 // Banner message codes that should be surfaced to the user.
 // Moved here with the formatBannerUserMessages* helpers that consume it.
 const USER_VISIBLE_BANNER_MESSAGE_CODES = new Set([
@@ -47,11 +45,15 @@ export function setInventoryMessage(message) {
   if (result) result.textContent = message || "";
 }
 
+function resolveTranslator(translate) {
+  return typeof translate === "function" ? translate : (key) => key;
+}
+
 // Shown when the user has a non-contiguous (multi-area) selection active.
 // context.workbook.getSelectedRange() throws a RichApi.Error for such selections.
-// Resolved via t() at call sites so the message respects the active UI language.
-export function nonContiguousSelectionMessage() {
-  return t("status.nonContiguousSelection");
+// Resolved via the caller-provided translator so the active UI language is used.
+export function nonContiguousSelectionMessage(translate) {
+  return resolveTranslator(translate)("status.nonContiguousSelection");
 }
 
 export function formatBannerUserMessages(bannerStructure) {
@@ -199,7 +201,8 @@ export function buildBatchProgressStatus({ action, scope, currentIndex, total, s
   ].join("\n");
 }
 
-export function buildCheckResolverMessage(resolverResult) {
+export function buildCheckResolverMessage(resolverResult = {}, translate) {
+  const t = resolveTranslator(translate);
   if (resolverResult.message) return resolverResult.message;
   switch (resolverResult.status) {
     case "no-table":

--- a/src/taskpane/taskpane.js
+++ b/src/taskpane/taskpane.js
@@ -84,7 +84,7 @@ function getClearPipelineOptions() {
   return {
     setStatusMessage,
     runningStatusMessage,
-    nonContiguousSelectionMessage,
+    nonContiguousSelectionMessage: () => nonContiguousSelectionMessage(t),
     t,
     perfLog,
   };
@@ -663,7 +663,7 @@ async function runSignificanceFromSelection() {
       selectedRange.load(["address", "rowIndex", "columnIndex", "rowCount", "columnCount"]);
       await context.sync();
     } catch (_selectionErr) {
-      setStatusMessage(nonContiguousSelectionMessage());
+      setStatusMessage(nonContiguousSelectionMessage(t));
       return;
     }
 
@@ -3629,7 +3629,7 @@ async function runCheckTable() {
       await context.sync();
       guardValues = selectionForGuard.values;
     } catch (_selectionErr) {
-      setCheckMessage(nonContiguousSelectionMessage());
+      setCheckMessage(nonContiguousSelectionMessage(t));
       return;
     }
 
@@ -3658,7 +3658,7 @@ async function runCheckTable() {
     const resolverResult = await resolveCurrentTableFromActiveCell(context, calculationSettings);
 
     if (resolverResult.status !== "ok") {
-      const msg = buildCheckResolverMessage(resolverResult);
+      const msg = buildCheckResolverMessage(resolverResult, t);
       setCheckMessage(msg);
       if (isCheckReportEnabled()) {
         await writeRunReportSheet(context, [{
@@ -3820,7 +3820,7 @@ async function runCheckSelectedRange() {
       rangeAddress =
         exclamationIndex >= 0 ? fullAddress.substring(exclamationIndex + 1) : fullAddress;
     } catch (_selectionErr) {
-      setCheckMessage(nonContiguousSelectionMessage());
+      setCheckMessage(nonContiguousSelectionMessage(t));
       return;
     }
 

--- a/tests/core/taskpane-status.test.mjs
+++ b/tests/core/taskpane-status.test.mjs
@@ -1,0 +1,154 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  BATCH_PROGRESS_BAR_WIDTH,
+  appendSelectedRangeGuardrailMessages,
+  buildBatchProgressBar,
+  buildBatchProgressStatus,
+  buildCheckResolverMessage,
+  formatBannerUserMessages,
+  formatBannerUserMessagesExcludingCodes,
+  formatSelectedRangeGuardrailMessages,
+  formatStatusWithSelectedRangeGuardrails,
+  nonContiguousSelectionMessage,
+  runningStatusMessage,
+} from "../../src/taskpane/taskpane-status.js";
+
+const translate = (key) =>
+  ({
+    "status.nonContiguousSelection": "localized non-contiguous selection",
+    "status.resolverNoTable": "localized no table",
+    "status.resolverGeneratedSheet": "localized generated sheet",
+    "status.resolverAmbiguousBoundary": "localized ambiguous boundary",
+    "status.resolverBlocked": "localized blocked",
+    "status.resolverFallback": "localized fallback",
+  })[key] || `missing:${key}`;
+
+describe("runningStatusMessage", () => {
+  it("keeps current Russian run/check/content wording", () => {
+    assert.strictEqual(
+      runningStatusMessage("run", "table"),
+      "Расчёт начат… Идёт обработка текущей таблицы."
+    );
+    assert.strictEqual(
+      runningStatusMessage("check", "workbook"),
+      "Проверка начата… Идёт обработка таблиц в книге."
+    );
+    assert.strictEqual(runningStatusMessage("content"), "Оглавление создаётся…");
+  });
+});
+
+describe("buildBatchProgressBar", () => {
+  it("builds a fixed-width progress bar and clamps percent", () => {
+    assert.strictEqual(BATCH_PROGRESS_BAR_WIDTH, 20);
+    assert.strictEqual(buildBatchProgressBar(50, 10), "[█████░░░░░]");
+    assert.strictEqual(buildBatchProgressBar(150, 4), "[████]");
+    assert.strictEqual(buildBatchProgressBar(-20, 4), "[░░░░]");
+  });
+});
+
+describe("buildBatchProgressStatus", () => {
+  it("formats live batch progress text", () => {
+    assert.strictEqual(
+      buildBatchProgressStatus({
+        action: "run",
+        scope: "workbook",
+        currentIndex: 2,
+        total: 5,
+        sheetName: "Wave 1",
+      }),
+      [
+        "Расчёт — вся книга",
+        "[████████░░░░░░░░░░░░] 40%",
+        "Таблица 2 из 5 · Лист: Wave 1",
+        "Осталось: 3",
+      ].join("\n")
+    );
+  });
+
+  it("bounds the current index to the total", () => {
+    assert.strictEqual(
+      buildBatchProgressStatus({
+        action: "clear",
+        scope: "sheet",
+        currentIndex: 9,
+        total: 4,
+      }),
+      [
+        "Очистка — текущий лист",
+        "[████████████████████] 100%",
+        "Таблица 4 из 4 · Лист: —",
+        "Осталось: 0",
+      ].join("\n")
+    );
+  });
+});
+
+describe("banner status message helpers", () => {
+  const bannerStructure = {
+    messages: [
+      { code: "GLOBAL_TOTAL_USED", text: "Global total used." },
+      { code: "INTERNAL_ONLY", text: "Internal message." },
+      { code: "BANNER_MALFORMED_STRUCTURE", text: "Banner malformed." },
+    ],
+  };
+
+  it("formats only user-visible banner messages", () => {
+    assert.strictEqual(
+      formatBannerUserMessages(bannerStructure),
+      ["Сообщения:", "- Global total used.", "- Banner malformed."].join("\n")
+    );
+  });
+
+  it("can exclude specific visible banner codes", () => {
+    assert.strictEqual(
+      formatBannerUserMessagesExcludingCodes(bannerStructure, ["GLOBAL_TOTAL_USED"]),
+      "Banner malformed."
+    );
+  });
+});
+
+describe("selected range guardrail message helpers", () => {
+  const warnings = [{ text: "Keep selected data only." }, { text: "Keep selected data only." }, { text: "" }];
+
+  it("deduplicates warning text", () => {
+    assert.strictEqual(formatSelectedRangeGuardrailMessages(warnings), "Keep selected data only.");
+  });
+
+  it("appends guardrail text after a blank separator", () => {
+    assert.deepStrictEqual(appendSelectedRangeGuardrailMessages(["Done."], warnings), [
+      "Done.",
+      "",
+      "Keep selected data only.",
+    ]);
+    assert.strictEqual(
+      formatStatusWithSelectedRangeGuardrails("Done.", warnings),
+      "Done.\n\nKeep selected data only."
+    );
+  });
+});
+
+describe("localized status helpers", () => {
+  it("uses the caller-provided translator for non-contiguous selection messages", () => {
+    assert.strictEqual(
+      nonContiguousSelectionMessage(translate),
+      "localized non-contiguous selection"
+    );
+  });
+
+  it("uses resolver messages before translating fallback statuses", () => {
+    assert.strictEqual(
+      buildCheckResolverMessage({ status: "blocked", message: "Specific resolver message." }, translate),
+      "Specific resolver message."
+    );
+  });
+
+  it("uses the caller-provided translator for resolver status fallbacks", () => {
+    assert.strictEqual(
+      buildCheckResolverMessage({ status: "ambiguous-boundary" }, translate),
+      "localized ambiguous boundary"
+    );
+    assert.strictEqual(buildCheckResolverMessage({ status: "future" }, translate), "localized fallback");
+  });
+});


### PR DESCRIPTION
## Files changed
- `src/taskpane/taskpane-status.js`
- `src/taskpane/taskpane.js`
- `tests/core/taskpane-status.test.mjs`

## Functions moved
No additional function bodies were moved in this branch because `src/taskpane/taskpane-status.js` already exists on current `main`. This PR keeps that PR4C status-helper surface focused and adds coverage around it.

Status helpers currently exported by the dedicated module:
- `setStatusMessage`
- `setCheckMessage`
- `setInventoryMessage`
- `nonContiguousSelectionMessage`
- `formatBannerUserMessages`
- `formatBannerUserMessagesExcludingCodes`
- `formatSelectedRangeGuardrailMessages`
- `appendSelectedRangeGuardrailMessages`
- `formatStatusWithSelectedRangeGuardrails`
- `runningStatusMessage`
- `BATCH_PROGRESS_BAR_WIDTH`
- `buildBatchProgressBar`
- `buildBatchProgressStatus`
- `buildCheckResolverMessage`

## Functions intentionally left in `taskpane.js` and why
- Run handlers and orchestration, including `runSignificanceFromSelection`, current-table/current-sheet/workbook Run paths, and batch loops: entangled with Excel state, marker overflow decisions, report rows, and write behavior.
- Clear/check button handlers and scope orchestration: kept in place to avoid broadening this PR beyond UI status helper boundaries.
- Check/content/inventory report assembly, including `formatWorkbookInventoryMessage`: tied to inventory/check reporting rather than status DOM helpers.
- Batch loop progress calculations and result aggregation: only the pure status string builder remains in the status module; loop state stays with the pipelines.

## Exported API
The status module exports small DOM setters plus pure/near-pure text builders only. Localized helpers now accept the translator explicitly where needed:
- `nonContiguousSelectionMessage(t)`
- `buildCheckResolverMessage(resolverResult, t)`

## Dependency / circular dependency notes
- `taskpane-status.js` does not import `taskpane.js`.
- This PR also removes the direct `localization` import from `taskpane-status.js`.
- `taskpane.js` imports status helpers and passes `t` explicitly.
- No circular dependency was found.

## Localization behavior notes
- RU/EN behavior for non-contiguous selection and check resolver fallback messages is preserved by passing the active `t` function from `taskpane.js`.
- Existing hard-coded Russian running/progress/banner/guardrail strings are left unchanged.
- DOM IDs/classes and `textContent` rendering behavior are unchanged.

## Validation results
- `npm test` passed: 498 tests.
- `npm run build` passed with existing webpack size warnings for `taskpane.js`.
- `git diff --cached --check` passed.

## Manual smoke checklist
Not run in this coding session; requires Excel add-in smoke testing.
- [ ] Taskpane loads.
- [ ] Default status/check messages render as before.
- [ ] Run status/progress messages render as before.
- [ ] Clear status/progress messages render as before.
- [ ] Check status/messages render as before.
- [ ] RU/EN switch keeps status/check labels correct.
- [ ] Basic Manual Run smoke.
- [ ] Current-table/current-sheet/workbook Run smoke.
- [ ] Basic Clear smoke.
- [ ] Check/Content buttons still work.