### PR TITLE
[codex] Extract Run marker-overflow preflight

### DIFF
--- a/src/taskpane/run-preflight.js
+++ b/src/taskpane/run-preflight.js
@@ -1,0 +1,172 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+ * See LICENSE in the project root for license information.
+ */
+
+/* global Excel */
+
+import {
+  detectSignificanceMarkerOverflow,
+  detectBatchMarkerOverflow,
+} from "../core/significance";
+
+import { detectBannerStructure } from "../core/banner-detector";
+
+import { interpretSelectedRange } from "./selected-range-interpreter";
+
+/**
+ * Read-only marker-overflow check for a single range, mirroring the front half
+ * of runSignificanceForRangeInContext (load -> interpret -> detect banner) but
+ * WITHOUT writing anything. Returns true when the table would need more
+ * single-character markers than the alphabet provides.
+ *
+ * Used by the banner-aware batch preflight so overflow is judged on the exact
+ * group-local required count rather than raw table width.
+ */
+export async function computeRangeMarkerOverflowInContext(
+  context,
+  sheetName,
+  rangeAddress,
+  calculationSettings
+) {
+  const worksheet = context.workbook.worksheets.getItem(sheetName);
+  const sourceRange = worksheet.getRange(rangeAddress);
+
+  sourceRange.load(["values", "text", "rowIndex", "columnIndex", "rowCount", "columnCount"]);
+  await context.sync();
+
+  const selectedValues = sourceRange.values;
+  const selectedText = sourceRange.text;
+
+  if (!selectedValues || selectedValues.length < 2 || selectedValues[0].length < 2) {
+    return false;
+  }
+
+  const interpretation = await interpretSelectedRange(
+    context,
+    sourceRange,
+    selectedValues,
+    selectedText,
+    calculationSettings
+  );
+
+  if (interpretation.state === "blocked") {
+    return false;
+  }
+
+  const { valuesForCalculation, bannerContext } = interpretation;
+
+  if (
+    !valuesForCalculation ||
+    valuesForCalculation.length < 2 ||
+    !valuesForCalculation[0] ||
+    valuesForCalculation[0].length < 2
+  ) {
+    return false;
+  }
+
+  let bannerStructure = null;
+  if (calculationSettings.respectBannerStructure) {
+    bannerStructure = detectBannerStructure(bannerContext, calculationSettings);
+  }
+
+  return detectSignificanceMarkerOverflow(
+    valuesForCalculation[0].length,
+    calculationSettings,
+    bannerStructure
+  );
+}
+
+/**
+ * Exact, read-only batch overflow pass for banner-aware runs.
+ *
+ * Interprets and banner-detects each eligible table (no writes) and returns
+ * true as soon as one would overflow on its group-local required count. Errors
+ * during preflight are ignored here -- the per-table run reports them -- so a
+ * single bad table never blocks the decision.
+ */
+export async function detectBatchMarkerOverflowExact(eligible, calculationSettings) {
+  let overflow = false;
+
+  await Excel.run(async (context) => {
+    for (const candidate of eligible) {
+      try {
+        if (
+          await computeRangeMarkerOverflowInContext(
+            context,
+            candidate.sheetName,
+            candidate.rangeAddress,
+            calculationSettings
+          )
+        ) {
+          overflow = true;
+          return;
+        }
+      } catch (_) {
+        /* preflight read failure is non-fatal; per-table run handles it */
+      }
+    }
+  });
+
+  return overflow;
+}
+
+/**
+ * Operation-level marker-overflow preflight for batch runs (current-sheet /
+ * workbook). Decides BEFORE any table is written, so Stop leaves the whole
+ * operation without partial results.
+ *
+ * Comparison-mode aware:
+ * - previous-column mode uses arrow markers, never letter labels -> no dialog;
+ * - non-banner modes -> conservative raw column-count gate;
+ * - banner-aware mode -> raw width is not meaningful (Total/label columns and
+ *   per-group widths), so when the cheap gate says overflow is *possible* an
+ *   exact read-only pass confirms it on the group-local required count.
+ *
+ * Returns true when the user chose to stop (caller must abort before writing
+ * any table). On Continue it sets allowMultiCharacterMarkers on the shared
+ * calculationSettings so every table uses multi-character markers.
+ *
+ * The per-table preflight inside runSignificanceForRangeInContext stays as a
+ * safety net; because the shared decider's choice is cached here, it never
+ * re-prompts.
+ */
+export async function preflightBatchMarkerOverflow(
+  eligible,
+  itemMap,
+  calculationSettings,
+  decider
+) {
+  // Previous-column mode never uses letter labels -- capacity is irrelevant.
+  if (calculationSettings.compareWithPreviousColumn) {
+    return false;
+  }
+
+  const columnCounts = eligible.map((candidate) => {
+    const item = itemMap.get(`${candidate.sheetName}!${candidate.rangeAddress}`);
+    return item ? item.columnCount : undefined;
+  });
+
+  // Cheap gate first: if no table is even wider than the alphabet, nothing can
+  // overflow (the real required count is always <= raw column count).
+  if (!detectBatchMarkerOverflow(columnCounts, calculationSettings)) {
+    return false;
+  }
+
+  // A table is wide enough that overflow is possible. In banner-aware mode raw
+  // width over-counts (Total columns, per-group widths), so confirm with an
+  // exact read-only pass before prompting. Non-banner modes use the raw gate.
+  if (calculationSettings.respectBannerStructure) {
+    const exactOverflow = await detectBatchMarkerOverflowExact(eligible, calculationSettings);
+    if (!exactOverflow) {
+      return false;
+    }
+  }
+
+  if ((await decider.resolve()) === "stop") {
+    return true;
+  }
+
+  calculationSettings.allowMultiCharacterMarkers = true;
+  return false;
+}

--- a/src/taskpane/taskpane.js
+++ b/src/taskpane/taskpane.js
@@ -18,7 +18,6 @@ import {
   buildBannerLocalSignificanceLabelMap,
   isSignificanceMarkerLabel,
   detectSignificanceMarkerOverflow,
-  detectBatchMarkerOverflow,
 } from "../core/significance";
 
 import {
@@ -57,6 +56,8 @@ import { resolveCurrentTableFromActiveCell } from "./active-cell-resolver";
 import { t, setLanguage, loadSavedLanguage, applyI18n } from "./localization";
 
 import { createMarkerOverflowDecider } from "./taskpane-dialogs";
+
+import { preflightBatchMarkerOverflow } from "./run-preflight";
 
 import { refreshActionWarnings } from "./taskpane-action-warnings";
 
@@ -448,158 +449,6 @@ function initActionScopeShell() {
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
-
-/**
- * Read-only marker-overflow check for a single range, mirroring the front half
- * of runSignificanceForRangeInContext (load → interpret → detect banner) but
- * WITHOUT writing anything. Returns true when the table would need more
- * single-character markers than the alphabet provides.
- *
- * Used by the banner-aware batch preflight so overflow is judged on the exact
- * group-local required count rather than raw table width.
- */
-async function computeRangeMarkerOverflowInContext(
-  context,
-  sheetName,
-  rangeAddress,
-  calculationSettings
-) {
-  const worksheet = context.workbook.worksheets.getItem(sheetName);
-  const sourceRange = worksheet.getRange(rangeAddress);
-
-  sourceRange.load(["values", "text", "rowIndex", "columnIndex", "rowCount", "columnCount"]);
-  await context.sync();
-
-  const selectedValues = sourceRange.values;
-  const selectedText = sourceRange.text;
-
-  if (!selectedValues || selectedValues.length < 2 || selectedValues[0].length < 2) {
-    return false;
-  }
-
-  const interpretation = await interpretSelectedRange(
-    context,
-    sourceRange,
-    selectedValues,
-    selectedText,
-    calculationSettings
-  );
-
-  if (interpretation.state === "blocked") {
-    return false;
-  }
-
-  const { valuesForCalculation, bannerContext } = interpretation;
-
-  if (
-    !valuesForCalculation ||
-    valuesForCalculation.length < 2 ||
-    !valuesForCalculation[0] ||
-    valuesForCalculation[0].length < 2
-  ) {
-    return false;
-  }
-
-  let bannerStructure = null;
-  if (calculationSettings.respectBannerStructure) {
-    bannerStructure = detectBannerStructure(bannerContext, calculationSettings);
-  }
-
-  return detectSignificanceMarkerOverflow(
-    valuesForCalculation[0].length,
-    calculationSettings,
-    bannerStructure
-  );
-}
-
-/**
- * Exact, read-only batch overflow pass for banner-aware runs.
- *
- * Interprets and banner-detects each eligible table (no writes) and returns
- * true as soon as one would overflow on its group-local required count. Errors
- * during preflight are ignored here — the per-table run reports them — so a
- * single bad table never blocks the decision.
- */
-async function detectBatchMarkerOverflowExact(eligible, calculationSettings) {
-  let overflow = false;
-
-  await Excel.run(async (context) => {
-    for (const candidate of eligible) {
-      try {
-        if (
-          await computeRangeMarkerOverflowInContext(
-            context,
-            candidate.sheetName,
-            candidate.rangeAddress,
-            calculationSettings
-          )
-        ) {
-          overflow = true;
-          return;
-        }
-      } catch (_) {
-        /* preflight read failure is non-fatal; per-table run handles it */
-      }
-    }
-  });
-
-  return overflow;
-}
-
-/**
- * Operation-level marker-overflow preflight for batch runs (current-sheet /
- * workbook). Decides BEFORE any table is written, so Stop leaves the whole
- * operation without partial results.
- *
- * Comparison-mode aware:
- * - previous-column mode uses arrow markers, never letter labels → no dialog;
- * - non-banner modes → conservative raw column-count gate;
- * - banner-aware mode → raw width is not meaningful (Total/label columns and
- *   per-group widths), so when the cheap gate says overflow is *possible* an
- *   exact read-only pass confirms it on the group-local required count.
- *
- * Returns true when the user chose to stop (caller must abort before writing
- * any table). On Continue it sets allowMultiCharacterMarkers on the shared
- * calculationSettings so every table uses multi-character markers.
- *
- * The per-table preflight inside runSignificanceForRangeInContext stays as a
- * safety net; because the shared decider's choice is cached here, it never
- * re-prompts.
- */
-async function preflightBatchMarkerOverflow(eligible, itemMap, calculationSettings, decider) {
-  // Previous-column mode never uses letter labels — capacity is irrelevant.
-  if (calculationSettings.compareWithPreviousColumn) {
-    return false;
-  }
-
-  const columnCounts = eligible.map((candidate) => {
-    const item = itemMap.get(`${candidate.sheetName}!${candidate.rangeAddress}`);
-    return item ? item.columnCount : undefined;
-  });
-
-  // Cheap gate first: if no table is even wider than the alphabet, nothing can
-  // overflow (the real required count is always <= raw column count).
-  if (!detectBatchMarkerOverflow(columnCounts, calculationSettings)) {
-    return false;
-  }
-
-  // A table is wide enough that overflow is possible. In banner-aware mode raw
-  // width over-counts (Total columns, per-group widths), so confirm with an
-  // exact read-only pass before prompting. Non-banner modes use the raw gate.
-  if (calculationSettings.respectBannerStructure) {
-    const exactOverflow = await detectBatchMarkerOverflowExact(eligible, calculationSettings);
-    if (!exactOverflow) {
-      return false;
-    }
-  }
-
-  if ((await decider.resolve()) === "stop") {
-    return true;
-  }
-
-  calculationSettings.allowMultiCharacterMarkers = true;
-  return false;
-}
 
 /**
  * Reads selected Excel range, detects metric blocks, calculates pairwise significance,

--- a/tests/core/run-preflight.test.mjs
+++ b/tests/core/run-preflight.test.mjs
@@ -1,0 +1,96 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { preflightBatchMarkerOverflow } from "../../src/taskpane/run-preflight.js";
+
+function createDecider(choice) {
+  let calls = 0;
+  return {
+    get calls() {
+      return calls;
+    },
+    async resolve() {
+      calls += 1;
+      return choice;
+    },
+  };
+}
+
+function createItemMap(columnCount) {
+  return new Map([
+    [
+      "Sheet1!A1:ZZ10",
+      {
+        columnCount,
+      },
+    ],
+  ]);
+}
+
+const eligible = [{ sheetName: "Sheet1", rangeAddress: "A1:ZZ10" }];
+
+describe("preflightBatchMarkerOverflow", () => {
+  it("skips marker-capacity prompts in previous-column mode", async () => {
+    const settings = { compareWithPreviousColumn: true };
+    const decider = createDecider("stop");
+
+    const stopped = await preflightBatchMarkerOverflow(
+      eligible,
+      createItemMap(200),
+      settings,
+      decider
+    );
+
+    assert.strictEqual(stopped, false);
+    assert.strictEqual(decider.calls, 0);
+    assert.strictEqual(settings.allowMultiCharacterMarkers, undefined);
+  });
+
+  it("does not prompt when the cheap column-count gate cannot overflow", async () => {
+    const settings = {};
+    const decider = createDecider("stop");
+
+    const stopped = await preflightBatchMarkerOverflow(
+      eligible,
+      createItemMap(3),
+      settings,
+      decider
+    );
+
+    assert.strictEqual(stopped, false);
+    assert.strictEqual(decider.calls, 0);
+    assert.strictEqual(settings.allowMultiCharacterMarkers, undefined);
+  });
+
+  it("returns stopped when the user stops a non-banner overflow", async () => {
+    const settings = {};
+    const decider = createDecider("stop");
+
+    const stopped = await preflightBatchMarkerOverflow(
+      eligible,
+      createItemMap(200),
+      settings,
+      decider
+    );
+
+    assert.strictEqual(stopped, true);
+    assert.strictEqual(decider.calls, 1);
+    assert.strictEqual(settings.allowMultiCharacterMarkers, undefined);
+  });
+
+  it("enables multi-character markers when the user continues a non-banner overflow", async () => {
+    const settings = {};
+    const decider = createDecider("continue");
+
+    const stopped = await preflightBatchMarkerOverflow(
+      eligible,
+      createItemMap(200),
+      settings,
+      decider
+    );
+
+    assert.strictEqual(stopped, false);
+    assert.strictEqual(decider.calls, 1);
+    assert.strictEqual(settings.allowMultiCharacterMarkers, true);
+  });
+});


### PR DESCRIPTION
## Summary

Extracts the Run batch marker-overflow preflight helpers from `src/taskpane/taskpane.js` into a dedicated `src/taskpane/run-preflight.js` module. This is intended to be behavior-preserving and does not start full Run pipeline extraction.

## Files changed

- `src/taskpane/run-preflight.js`
- `src/taskpane/taskpane.js`
- `tests/core/run-preflight.test.mjs`

## Functions moved

- `computeRangeMarkerOverflowInContext`
- `detectBatchMarkerOverflowExact`
- `preflightBatchMarkerOverflow`

## Functions intentionally left in `taskpane.js`

- `runSignificanceFromSelection`: manual selected-range Run orchestration and write sequencing.
- `runSignificanceForRangeInContext`: single-table Run pipeline and per-table overflow safety-net prompt remain intertwined with write preparation, banner setup, writer calls, footnote/recolor jobs, and final sync placement.
- `runSignificanceForRange`: thin wrapper around the single-table pipeline.
- `runAutoSignificance` and `runCurrentSheetSignificance`: batch Run handlers stay in place; they now import and call `preflightBatchMarkerOverflow`.
- Run report writing, footnote placement/update, banner marker writing, Excel writer calls, Clear/Check/Content/inventory logic: intentionally untouched per PR5A scope.

## Exported API

`src/taskpane/run-preflight.js` exports:

- `computeRangeMarkerOverflowInContext(context, sheetName, rangeAddress, calculationSettings)`
- `detectBatchMarkerOverflowExact(eligible, calculationSettings)`
- `preflightBatchMarkerOverflow(eligible, itemMap, calculationSettings, decider)`

## Dependencies passed/imported

The new module imports:

- `detectSignificanceMarkerOverflow` and `detectBatchMarkerOverflow` from `../core/significance`
- `detectBannerStructure` from `../core/banner-detector`
- `interpretSelectedRange` from `./selected-range-interpreter`

Dependencies passed explicitly:

- Excel `context`, `sheetName`, `rangeAddress`, and `calculationSettings` for the single-range read-only helper.
- `eligible`, `itemMap`, `calculationSettings`, and `decider` for batch preflight.

No broad taskpane state object is passed.

## Circular dependency check

Confirmed no circular dependency was introduced: `taskpane.js` imports `run-preflight.js`; `run-preflight.js` does not import `taskpane.js`.

## Context sync placement

Preserved existing read-only preflight `context.sync()` placement. No extra `context.sync()` calls were added inside table loops. The moved exact preflight still uses the same `Excel.run` loop and the same single-range load/sync behavior as before.

## Behavior notes

- Previous-column mode still skips marker-capacity prompts.
- Banner-aware mode still uses exact group-aware preflight after the cheap gate says overflow is possible.
- Stop still aborts batch runs before writes.
- Continue still mutates the shared operation settings with `allowMultiCharacterMarkers = true`.
- The shared decider still prevents repeated prompts in one operation.
- No production behavior changes intended.

## Validation results

- `npm test` passed: 502 tests.
- `npm run build` passed; webpack reported the existing taskpane bundle size warnings.
- `git diff --check` passed; Git emitted only CRLF working-copy notices.

## Manual smoke checklist

Not run in this local session; Excel smoke remains required before merge.

- [ ] Basic Manual Run works.
- [ ] Marker-overflow dialog opens when needed.
- [ ] Stop aborts before writing.
- [ ] Continue processes with multi-character markers.
- [ ] Previous-column comparison mode does not show marker-overflow dialog.
- [ ] Banner-aware mode only shows dialog when a group exceeds marker capacity.
- [ ] Current-table Run smoke.
- [ ] Current-sheet Run smoke.
- [ ] Workbook Run smoke.
- [ ] Clear still works.

## Technical debt / limitations

No known new technical debt. The banner-aware exact preflight remains Office-context dependent and is intentionally not covered by new unit tests with synthetic Office.js mocks; the PR adds focused pure-path tests for the exported batch decision behavior and leaves Excel smoke for the real read-only preflight path.