### PR TITLE
[codex] Document Run pipeline extraction contract

### DIFF
--- a/docs/REFACTOR_PLAN_2026.md
+++ b/docs/REFACTOR_PLAN_2026.md
@@ -67,6 +67,9 @@ This sequence prioritizes low-risk extractions before tackling the complex Run/C
 ### PR 4: Extract Run Pipeline (High Risk)
 **Goal:** Consolidate the calculation loop for manual and autorun flows.
 **Target Files:** `src/taskpane/taskpane.js`, `src/taskpane/run-pipeline.js` (new)
+**Contract:** See `docs/RUN_PIPELINE_CONTRACT.md` before moving Run code. That
+document records the current entry points, write barriers, job objects, report
+row expectations, and `context.sync` boundaries that extraction must preserve.
 **Action:**
 1.  Identify the ~100 lines of shared logic between `runSignificanceFromSelection` and `runSignificanceForRangeInContext`.
 2.  Extract into `runPipeline(context, range, values, text, interpretation, settings, decider)` in `run-pipeline.js`.

--- a/docs/RUN_PIPELINE_CONTRACT.md
+++ b/docs/RUN_PIPELINE_CONTRACT.md
@@ -1,0 +1,326 @@
+# Run Pipeline Contract
+
+This document records the current Run behavior that must be preserved before
+extracting a shared Run pipeline from `src/taskpane/taskpane.js`.
+
+PR5B is a contract and regression-coverage step only. It does not move
+`runSignificanceFromSelection`, `runSignificanceForRangeInContext`, the batch Run
+handlers, Excel writer calls, report writing, footnote writes, banner marker
+writes, design recolor execution, or `context.sync` boundaries.
+
+## Current Entry Points
+
+### Manual selected-range Run
+
+`runSignificanceFromSelection` is the stable first-class workflow:
+
+- reads settings from the taskpane;
+- reads exactly the user's current selected range;
+- blocks unsupported setting combinations before Excel writes;
+- rejects non-contiguous and unsafe broad selections;
+- interprets the selected range with `interpretSelectedRange`;
+- detects banner structure when banner-aware mode is enabled;
+- runs marker-overflow preflight before any table write;
+- detects calculation blocks and calculates significance;
+- writes calculated values/fills back through the Excel writer;
+- writes banner markers when banner-aware mode is enabled;
+- queues design recolor and footnote work after calculation;
+- applies design recolor before footnotes;
+- applies footnotes in a separate context after the data body write;
+- updates taskpane status and performance diagnostics.
+
+Manual Run must remain selected-range first. It must not scan the worksheet or
+workbook unless a future task explicitly changes that product behavior.
+
+### Current-table Run
+
+`runAutoCurrentTableSignificance` resolves the table under the active cell and
+delegates the table write to `runSignificanceForRange`. It also performs the
+pre-resolver selection guard, writes optional one-row Run report output, and
+applies returned design recolor and footnote jobs after the table pipeline
+finishes.
+
+### Current-sheet Run
+
+`runCurrentSheetSignificance` scans the active sheet inventory, filters eligible
+candidates, runs operation-level marker-overflow preflight before the first write,
+then processes tables through a shared-context batch with a per-table fallback.
+It accumulates Run report rows, status/progress lines, design recolor jobs, and
+footnote jobs. Recolor jobs are applied before footnote jobs after all table
+calculations finish.
+
+### Workbook Run
+
+`runAutoSignificance` mirrors current-sheet Run over workbook inventory. It
+skips generated sheets and non-eligible candidates, runs operation-level
+marker-overflow preflight before the first write, uses a workbook-level shared
+context where possible, falls back per table when needed, and writes optional Run
+report output.
+
+### Table pipeline
+
+`runSignificanceForRangeInContext` is the current reusable table executor for
+batch flows. It must remain callable inside an existing `Excel.run` context. It
+loads the source range, interprets the selected/table range, detects banners and
+calculation blocks, performs per-table marker-overflow preflight as a safety net,
+queues body and banner writes, and returns pure job objects for deferred design
+recolor and footnotes.
+
+`runSignificanceForRange` is only a wrapper that provides its own `Excel.run`
+context around `runSignificanceForRangeInContext`.
+
+## Boundary Contracts
+
+### Selected range interpretation
+
+Run callers rely on `interpretSelectedRange` to resolve the user's selected range
+or candidate range into exactly one supported state before mutation:
+
+- pass-through: the selected/candidate range is already the numeric data body;
+- normalized: safe surrounding context is trimmed to a numeric data body;
+- blocked: unsafe shape, ambiguous boundary, or unsupported broad selection.
+
+Run extraction must not bypass this guardrail, silently auto-trim unsupported
+shapes, or move blocking decisions after any Excel mutation.
+
+### Preflight marker overflow
+
+Marker-overflow preflight is a write barrier.
+
+- Manual Run checks the interpreted table before writing the data body.
+- Current-sheet and workbook Run call `preflightBatchMarkerOverflow` once before
+  any table write so Stop leaves the operation without partial results.
+- `runSignificanceForRangeInContext` keeps per-table preflight as a safety net.
+- A shared marker-overflow decider caches Stop/Continue per operation.
+- Continue mutates only the operation settings object by setting
+  `allowMultiCharacterMarkers = true`.
+- Previous-column mode must not prompt because it does not use letter labels.
+
+### Calculation block detection
+
+After interpretation and optional banner detection, Run detects metric rows and
+builds calculation blocks from the numeric data body and left labels. Extraction
+must preserve supported block behavior for proportions, means with spread/base,
+NPS structures, and banner-aware calculation pairs. Statistical formulas and
+marker assignment are outside the extraction scope.
+
+### Excel writer
+
+The Excel writer remains the only layer that writes significance values/fills
+back to the data body. Extraction must preserve numeric display conventions and
+must not convert the full selected range to text. Writer calls must remain after
+all preflight/blocking decisions for that table.
+
+### Banner marker updates
+
+Banner marker writing is separate from data-cell marker writing. Run computes or
+uses a banner label map, clears stale banner markers for the relevant header
+area, and queues replacement banner markers. Extraction must preserve the
+current banner-aware mode gates, label-map behavior, and final flush timing.
+
+### Footnote placement/update
+
+Run builds `FootnoteJob` objects from pure geometry and text. It must not insert
+footnote rows while there are pending table writes in the same sheet/workbook
+batch because row insertion can shift later candidate ranges. Batch flows collect
+jobs and apply them bottom-to-top per sheet after all calculations complete.
+Current-table Run applies its single footnote job after the table pipeline
+returns. Manual Run appends the processed local range suffix; auto-run callers do
+not.
+
+### Design recolor jobs
+
+Run builds `DesignRecolorJob` objects from pure geometry. Recolor writes do not
+shift rows, so they are applied after calculation and before footnote insertion.
+Extraction must keep `labelsOnLeftSide` disabled for recolor and must preserve
+the L-shaped rectangle contract: banner rows over data columns, adjacent label
+columns over data rows, corner untouched.
+
+### Run report rows
+
+Batch and current-table Run callers own report accumulation and optional report
+sheet writing. The table pipeline should return enough structured information to
+build a `RunReportRow`; it should not directly decide whether the generated Run
+report sheet is enabled. Report writing may stay in the taskpane until a later
+report-controller extraction.
+
+### Progress and status updates
+
+Run extraction must keep user-visible status timing:
+
+- running status appears before long work begins;
+- current-sheet/workbook progress updates after each eligible table;
+- Stop, skipped, blocked, and error messages remain visible;
+- final summary includes processed/skipped/error counts and relevant detail
+  lines;
+- report-write failures append/report separately and do not invalidate completed
+  calculations.
+
+### `context.sync` boundaries
+
+The current Run flow depends on explicit Office.js flush points:
+
+- load selected/source range metadata and values before interpretation;
+- flush table body, fill, and queued banner marker writes only after preflight
+  and calculation have completed;
+- keep batch table writes in a shared context where possible;
+- run design recolor and footnote jobs in their own contexts after calculation;
+- write optional Run report sheets after calculation/report-row accumulation.
+
+Future extraction must treat sync placement as part of the behavior contract, not
+an implementation detail to optimize casually.
+
+## Future Object Shapes
+
+The future extraction should use JSDoc/object-shape contracts in plain
+JavaScript. These names are proposed contracts, not current exported types.
+
+```js
+/**
+ * @typedef {object} RunPipelineInput
+ * @property {object} context Active Excel.run request context.
+ * @property {object} sourceRange Loaded or loadable Excel range proxy.
+ * @property {string} sheetName Sheet name for diagnostics/jobs.
+ * @property {string} rangeAddress Original selected/candidate range address.
+ * @property {object} calculationSettings Mutable per-operation settings.
+ * @property {MarkerOverflowDecision} markerOverflowDecider Shared decision cache.
+ * @property {RunPipelineCallbacks} callbacks UI/report/perf dependencies.
+ * @property {"manual"|"current-table"|"sheet"|"workbook"} scope Caller scope.
+ * @property {string} [processedScopeSuffix] Manual Run footnote suffix.
+ */
+
+/**
+ * @typedef {object} RunPipelineResult
+ * @property {"processed"|"skipped"|"blocked"|"stopped"|"error"} status
+ * @property {string} sheetName
+ * @property {string} rangeAddress Original requested range.
+ * @property {string} [processedRangeAddress] Actual normalized write target.
+ * @property {number} [blocksProcessed]
+ * @property {string} message User-facing or report-facing message.
+ * @property {RunTableResult} [table]
+ * @property {FootnoteJob|null} [footnoteJob]
+ * @property {DesignRecolorJob|null} [recolorJob]
+ * @property {object} [_phasesMs] Optional performance diagnostics.
+ */
+
+/**
+ * @typedef {object} RunTableResult
+ * @property {Array<Array<*>>} valuesForCalculation Interpreted data body.
+ * @property {Array<Array<*>>} leftLabelValues Row-label matrix.
+ * @property {object|null} bannerStructure Detected banner metadata.
+ * @property {Array<object>} calculationBlocks Blocks sent to significance logic.
+ * @property {object} writeTargetGeometry 0-based data-body coordinates.
+ * @property {Array<object>} selectedRangeWarnings Warning-only guardrails.
+ */
+
+/**
+ * @typedef {object} RunBatchResult
+ * @property {number} processed
+ * @property {number} skipped
+ * @property {number} errors
+ * @property {boolean} markerOverflowStopped
+ * @property {RunReportRow[]} reportRows
+ * @property {FootnoteJob[]} footnoteJobs
+ * @property {DesignRecolorJob[]} recolorJobs
+ * @property {string[]} detailLines
+ */
+
+/**
+ * @typedef {object} RunReportRow
+ * @property {string} sheetName
+ * @property {string} title
+ * @property {string} rangeAddress
+ * @property {"processed"|"skipped"|"blocked"|"stopped"|"error"} status
+ * @property {string} message
+ * @property {string} selectedBase
+ * @property {string} metricTypes
+ * @property {string|number} warnings
+ * @property {string|number} critical
+ * @property {string} warningDetails
+ * @property {string|number} blocksProcessed
+ */
+
+/**
+ * @typedef {object} FootnoteJob
+ * @property {string} sheetName Empty string is allowed for active worksheet jobs.
+ * @property {number} tableBottomRowIndex
+ * @property {number} tableLeftColIndex
+ * @property {number} tableRightColIndex
+ * @property {number} dataStartColIndex
+ * @property {string} footnoteCellValue Includes the invisible generated marker.
+ */
+
+/**
+ * @typedef {object} DesignRecolorJob
+ * @property {string} sheetName
+ * @property {string} color
+ * @property {Array<{rowIndex:number,columnIndex:number,rowCount:number,columnCount:number}>} rects
+ */
+
+/**
+ * @typedef {object} MarkerOverflowDecision
+ * @property {() => Promise<"continue"|"stop">} resolve
+ * @property {"continue"|"stop"|null} decision
+ */
+
+/**
+ * @typedef {object} RunPipelineCallbacks
+ * @property {(message:string) => void} setStatusMessage
+ * @property {(eventName:string, details?:object) => void} [perfLog]
+ * @property {(key:string, vars?:object) => string} t
+ * @property {(args:object) => string} [buildProgressStatus]
+ */
+```
+
+## Pure Coverage Added or Confirmed
+
+Existing pure coverage already protects these Run-adjacent contracts:
+
+- marker-overflow decider caching and in-flight prompt reuse;
+- non-banner batch marker-overflow Stop/Continue behavior;
+- running status and batch progress formatting;
+- selected-range guardrail message formatting;
+- footnote marker, suffix, span, placement, and removal helpers;
+- design recolor label-width and rectangle job helpers;
+- banner local significance label maps.
+
+PR5B strengthens `preflightBatchMarkerOverflow` coverage for mixed candidate
+widths and missing inventory metadata without requiring Office.js stubs or
+production extraction.
+
+## Missing Test Coverage
+
+These behaviors are intentionally not unit-tested in PR5B because doing so would
+require moving production Run code or building brittle Office.js doubles:
+
+- the full manual selected-range Run path;
+- `runSignificanceForRangeInContext` end-to-end table execution;
+- banner-aware exact marker-overflow preflight;
+- report-row creation inside current sheet/workbook Run loops;
+- context corruption fallback from shared-context batch to per-table run;
+- actual Excel writer, banner marker writer, report-sheet writer, design recolor
+  writer, and footnote insertion side effects;
+- exact `context.sync` ordering under real Excel.
+
+## Future Extraction Plan
+
+Recommended next implementation PR: extract only the shared per-table Run
+executor behind the object shapes above, leaving batch loops and generated sheet
+writers in `taskpane.js`. The PR should preserve all existing entry points and
+return `RunPipelineResult` objects that current callers can adapt to their
+existing status/report/job behavior.
+
+Future manual smoke coverage for Run extraction must include:
+
+1. Manual Run selected numeric range.
+2. Manual Run sloppy/full-table selection normalization.
+3. Current-table Run.
+4. Current-sheet Run.
+5. Workbook Run.
+6. Marker overflow Stop/Continue.
+7. Previous-column mode.
+8. Banner-aware mode.
+9. Footnote placement/update.
+10. Banner marker writing.
+11. Design recolor.
+12. Run report output.

--- a/tests/core/run-preflight.test.mjs
+++ b/tests/core/run-preflight.test.mjs
@@ -27,6 +27,15 @@ function createItemMap(columnCount) {
   ]);
 }
 
+function createItemMapFromCounts(entries) {
+  return new Map(
+    entries.map(([sheetName, rangeAddress, columnCount]) => [
+      `${sheetName}!${rangeAddress}`,
+      { columnCount },
+    ])
+  );
+}
+
 const eligible = [{ sheetName: "Sheet1", rangeAddress: "A1:ZZ10" }];
 
 describe("preflightBatchMarkerOverflow", () => {
@@ -92,5 +101,48 @@ describe("preflightBatchMarkerOverflow", () => {
     assert.strictEqual(stopped, false);
     assert.strictEqual(decider.calls, 1);
     assert.strictEqual(settings.allowMultiCharacterMarkers, true);
+  });
+
+  it("prompts when any eligible non-banner table exceeds marker capacity", async () => {
+    const settings = {};
+    const decider = createDecider("continue");
+    const mixedEligible = [
+      { sheetName: "Sheet1", rangeAddress: "A1:C10" },
+      { sheetName: "Sheet2", rangeAddress: "A1:ZZ10" },
+    ];
+
+    const stopped = await preflightBatchMarkerOverflow(
+      mixedEligible,
+      createItemMapFromCounts([
+        ["Sheet1", "A1:C10", 3],
+        ["Sheet2", "A1:ZZ10", 200],
+      ]),
+      settings,
+      decider
+    );
+
+    assert.strictEqual(stopped, false);
+    assert.strictEqual(decider.calls, 1);
+    assert.strictEqual(settings.allowMultiCharacterMarkers, true);
+  });
+
+  it("ignores missing inventory metadata when the known candidates cannot overflow", async () => {
+    const settings = {};
+    const decider = createDecider("stop");
+    const mixedEligible = [
+      { sheetName: "Sheet1", rangeAddress: "A1:C10" },
+      { sheetName: "Missing", rangeAddress: "A1:ZZ10" },
+    ];
+
+    const stopped = await preflightBatchMarkerOverflow(
+      mixedEligible,
+      createItemMapFromCounts([["Sheet1", "A1:C10", 3]]),
+      settings,
+      decider
+    );
+
+    assert.strictEqual(stopped, false);
+    assert.strictEqual(decider.calls, 0);
+    assert.strictEqual(settings.allowMultiCharacterMarkers, undefined);
   });
 });


### PR DESCRIPTION
## Summary

This PR adds PR5B guardrails before extracting the full Run pipeline. It documents the current Run pipeline boundaries and strengthens a small pure regression area in batch marker-overflow preflight. No production runtime code is changed.

## Files changed

- `docs/RUN_PIPELINE_CONTRACT.md` added.
- `docs/REFACTOR_PLAN_2026.md` updated with a pointer to the Run contract before PR4 extraction.
- `tests/core/run-preflight.test.mjs` updated with two pure batch preflight cases.

## Docs added/updated

`docs/RUN_PIPELINE_CONTRACT.md` now records:

- current Run entry points: manual selected range, current-table, current-sheet, workbook, and `runSignificanceForRangeInContext`;
- selected-range interpretation and marker-overflow preflight boundaries;
- calculation block detection, Excel writer, banner marker, footnote, design recolor, Run report, progress/status, and `context.sync` contracts;
- future JSDoc/object-shape contracts for `RunPipelineInput`, `RunPipelineResult`, `RunTableResult`, `RunBatchResult`, `RunReportRow`, `FootnoteJob`, `DesignRecolorJob`, `MarkerOverflowDecision`, and `RunPipelineCallbacks`;
- missing coverage that should wait for a future small extraction/test PR;
- required future Run smoke areas.

## Tests added/updated

Added pure `preflightBatchMarkerOverflow` regression coverage for:

- prompting when any eligible non-banner table exceeds marker capacity, even if earlier candidates are within capacity;
- ignoring missing inventory metadata when known candidates cannot overflow.

## Production code changed

No. This is a docs/tests/audit PR only.

## Explicit Run extraction contract summary

Future Run extraction should keep manual selected-range Run as the stable product workflow, preserve `interpretSelectedRange` as the write gate, keep marker-overflow Stop/Continue before writes, leave writer/banner/report/footnote/recolor side effects in their current boundaries unless explicitly extracted later, and treat current `context.sync` placement as behavior-sensitive.

## Missing test coverage found

Not forced in this PR because it would require production extraction or brittle Office.js doubles:

- full manual selected-range Run;
- `runSignificanceForRangeInContext` end-to-end table execution;
- banner-aware exact marker-overflow preflight;
- report-row creation inside current sheet/workbook Run loops;
- shared-context batch fallback behavior;
- actual Excel writer, banner marker writer, report writer, design recolor writer, and footnote insertion side effects;
- real Excel `context.sync` ordering.

## Recommended next implementation PR

Extract only the shared per-table Run executor behind the documented object shapes, leaving batch loops and generated sheet/report writers in `taskpane.js`. The first extraction PR should return `RunPipelineResult` objects and adapt existing callers without changing user-visible Run behavior.

## Validation results

- `npm test` passed: 504 tests.
- `npm run build` passed; webpack reported the existing taskpane asset-size warnings.
- `git diff --check` passed; Git printed LF-to-CRLF working-copy warnings for touched files only.

## Manual smoke notes

Manual smoke was not run because this PR changes docs/tests only. Future Run extraction must cover:

1. Manual Run selected numeric range.
2. Manual Run sloppy/full-table selection normalization.
3. Current-table Run.
4. Current-sheet Run.
5. Workbook Run.
6. Marker overflow Stop/Continue.
7. Previous-column mode.
8. Banner-aware mode.
9. Footnote placement/update.
10. Banner marker writing.
11. Design recolor.
12. Run report output.

## Assumptions / limitations

- No behavior changes are intended.
- No production helper export was added.
- Banner-aware exact preflight coverage is documented as a future extraction/test target rather than mocked here.