### PR TITLE
[codex] Extract run table pipeline executor

### DIFF
--- a/src/taskpane/run-pipeline.js
+++ b/src/taskpane/run-pipeline.js
@@ -1,0 +1,362 @@
+import {
+  createEmptyCellResultMatrix,
+  applyComparisonResultsToFullCellResultMatrix,
+  applySmallBaseRulesForCalculationBlock,
+  keepMarkersOnlyInAllowedRows,
+  detectSignificanceMarkerOverflow,
+} from "../core/significance";
+
+import {
+  detectMetricRowsFromLeftLabels,
+  buildCalculationBlocks,
+  getAllowedMarkerRowIndexes,
+} from "../core/metric-detector";
+
+import { writeCellResultsToSelectedRange } from "../core/excel-writer";
+
+import { detectBannerStructure } from "../core/banner-detector";
+
+import { buildDesignRecolorJob } from "../core/design-recolor";
+
+import { interpretSelectedRange } from "./selected-range-interpreter";
+
+import { perfNow, perfEnabled } from "./taskpane-performance";
+
+function requireRunPipelineDependency(dependencies, name) {
+  const dependency = dependencies[name];
+  if (typeof dependency !== "function") {
+    throw new Error(`run-pipeline dependency missing: ${name}`);
+  }
+  return dependency;
+}
+
+function resolveBannerRecolorRowCount(interpretation, dataStartRowIndex) {
+  const interpreted = interpretation.bannerRowsAboveData || 0;
+  if (interpreted > 0) return interpreted;
+  if (interpretation.state === "passThrough" && dataStartRowIndex > 0) return 1;
+  return 0;
+}
+
+/**
+ * Core significance pipeline for a single named range, using a caller-supplied
+ * Office.js RequestContext.
+ *
+ * Returns { status, blocksProcessed, message, rangeAddress }.
+ * status: "processed" | "skipped" | "blocked" | "stopped" | "error"
+ */
+export async function runSignificanceForRangeInContext(
+  context,
+  sheetName,
+  rangeAddress,
+  calculationSettings,
+  markerOverflowDecider = null,
+  dependencies = {}
+) {
+  const calculateBlockResults = requireRunPipelineDependency(dependencies, "calculateBlockResults");
+  const applyBannerMarkerUpdatesForRange = requireRunPipelineDependency(
+    dependencies,
+    "applyBannerMarkerUpdatesForRange"
+  );
+  const buildSignificanceFootnoteJob = requireRunPipelineDependency(
+    dependencies,
+    "buildSignificanceFootnoteJob"
+  );
+  const getFirstBannerStructureError = requireRunPipelineDependency(
+    dependencies,
+    "getFirstBannerStructureError"
+  );
+  const createMarkerOverflowDecider = requireRunPipelineDependency(
+    dependencies,
+    "createMarkerOverflowDecider"
+  );
+
+  const _p0 = perfNow();
+  const worksheet = context.workbook.worksheets.getItem(sheetName);
+  const sourceRange = worksheet.getRange(rangeAddress);
+
+  sourceRange.load(["values", "text", "rowIndex", "columnIndex", "rowCount", "columnCount"]);
+
+  await context.sync();
+  const _pLoad = perfNow();
+
+  const selectedValues = sourceRange.values;
+  const selectedText = sourceRange.text;
+
+  if (!selectedValues || selectedValues.length < 2 || selectedValues[0].length < 2) {
+    return { status: "skipped", message: "слишком мало данных", rangeAddress };
+  }
+
+  const interpretation = await interpretSelectedRange(
+    context,
+    sourceRange,
+    selectedValues,
+    selectedText,
+    calculationSettings
+  );
+
+  if (interpretation.state === "blocked") {
+    const codes =
+      interpretation.blockingReasons && interpretation.blockingReasons.length > 0
+        ? ` [${interpretation.blockingReasons.join(", ")}]`
+        : "";
+    return {
+      status: "blocked",
+      message: `${interpretation.blockingMessage}${codes}`,
+      rangeAddress,
+    };
+  }
+
+  const {
+    valuesForCalculation,
+    textForCalculation,
+    leftLabelValues,
+    bannerContext: interpretedBannerContext,
+  } = interpretation;
+
+  const { writeTargetRange } = interpretation;
+
+  if (
+    !valuesForCalculation ||
+    valuesForCalculation.length < 2 ||
+    !valuesForCalculation[0] ||
+    valuesForCalculation[0].length < 2
+  ) {
+    return { status: "skipped", message: "нет данных для расчёта", rangeAddress };
+  }
+
+  const _pInterp = perfNow();
+
+  // Compute write-target row/column indices from the already-loaded sourceRange
+  // properties rather than issuing a separate load+sync on writeTargetRange.
+  // sourceRange.rowIndex and .columnIndex are loaded in the sync above;
+  // interpretation.dataRowOffset / dataColOffset are pure-JS values from the
+  // normalization path, so no additional round-trip is required.
+  const targetStartRowIndex = sourceRange.rowIndex + interpretation.dataRowOffset;
+  const targetStartColIndex = sourceRange.columnIndex + interpretation.dataColOffset;
+
+  if (calculationSettings.writeBannerLetters && targetStartRowIndex === 0) {
+    return {
+      status: "skipped",
+      message: "данные в первой строке — баннер недоступен",
+      rangeAddress,
+    };
+  }
+
+  // Detect banner structure before any write so marker-overflow can be resolved
+  // up front (the dialog must appear before results are written).
+  let bannerStructure = null;
+
+  if (calculationSettings.respectBannerStructure) {
+    const bannerContext = interpretedBannerContext;
+    bannerStructure = detectBannerStructure(bannerContext, calculationSettings);
+    if (bannerContext && bannerContext.messages && bannerContext.messages.length > 0) {
+      bannerStructure.messages = [...bannerContext.messages, ...(bannerStructure.messages || [])];
+    }
+  }
+
+  // Marker-overflow preflight. When more comparable columns exist than
+  // single-character markers, ask once per operation. Stopping returns before
+  // any write so no partial results are written for this table.
+  if (
+    detectSignificanceMarkerOverflow(
+      valuesForCalculation[0].length,
+      calculationSettings,
+      bannerStructure
+    )
+  ) {
+    const activeDecider = markerOverflowDecider || createMarkerOverflowDecider();
+    if ((await activeDecider.resolve()) === "stop") {
+      return { status: "stopped", message: "расчёт остановлен — превышен лимит маркеров", rangeAddress };
+    }
+    // Mutate the (per-operation) settings so every table in the batch uses
+    // multi-character markers consistently after the user opts to continue.
+    calculationSettings.allowMultiCharacterMarkers = true;
+  }
+
+  writeTargetRange.values = valuesForCalculation;
+  writeTargetRange.format.font.bold = false;
+  writeTargetRange.format.fill.clear();
+  writeTargetRange.format.horizontalAlignment = "Center";
+  writeTargetRange.format.verticalAlignment = "Center";
+
+  // No intermediate sync here. The pre-write format ops and
+  // writeCellResultsToSelectedRange are all writes with no intervening Excel
+  // reads, so they can share the final context.sync below. Removing this
+  // round-trip saves one Office.js sync per table in the autorun batch loop.
+  const detectionResult = detectMetricRowsFromLeftLabels(valuesForCalculation, leftLabelValues);
+  const calculationBlocks = buildCalculationBlocks(detectionResult, { preferredBase: calculationSettings.preferredBase });
+
+  if (!calculationBlocks || calculationBlocks.length === 0) {
+    return { status: "skipped", message: "нет блоков расчёта", rangeAddress };
+  }
+
+  const fullCellResultMatrix = createEmptyCellResultMatrix(
+    valuesForCalculation.length,
+    valuesForCalculation[0].length
+  );
+
+  for (const calculationBlock of calculationBlocks) {
+    const smallBaseResult = applySmallBaseRulesForCalculationBlock(
+      valuesForCalculation,
+      calculationBlock,
+      fullCellResultMatrix,
+      calculationSettings
+    );
+
+    if (smallBaseResult.errorMessage) {
+      return { status: "error", message: smallBaseResult.errorMessage, rangeAddress };
+    }
+
+    const blockCalculationSettings = {
+      ...calculationSettings,
+      excludedColumnIndexes: smallBaseResult.excludedColumnIndexes,
+      bannerStructure,
+    };
+
+    const blockResults = calculateBlockResults(
+      valuesForCalculation,
+      calculationBlock,
+      blockCalculationSettings
+    );
+
+    const bannerStructureError = getFirstBannerStructureError(bannerStructure);
+
+    if (bannerStructureError) {
+      return { status: "error", message: bannerStructureError.text, rangeAddress };
+    }
+
+    if (!blockResults) {
+      continue;
+    }
+
+    applyComparisonResultsToFullCellResultMatrix(
+      blockResults,
+      fullCellResultMatrix,
+      blockCalculationSettings
+    );
+  }
+
+  const allowedMarkerRows = getAllowedMarkerRowIndexes(calculationBlocks);
+
+  keepMarkersOnlyInAllowedRows(fullCellResultMatrix, allowedMarkerRows);
+
+  const _pCalc = perfNow();
+
+  // Autorun never loads writeTargetRange.rowIndex / .columnIndex on the proxy
+  // (they're computed from the already-loaded sourceRange + offsets to save a
+  // round-trip). Pass them explicitly so the writer can use the chunked
+  // RangeAreas formatting path (ExcelApi 1.9).
+  const writerDetails = writeCellResultsToSelectedRange(
+    writeTargetRange,
+    textForCalculation,
+    fullCellResultMatrix,
+    detectionResult,
+    calculationSettings,
+    {
+      captureWriterDetails: perfEnabled(),
+      anchorRowIndex: targetStartRowIndex,
+      anchorColumnIndex: targetStartColIndex,
+    }
+  );
+
+  const _knownDims = {
+    rowIndex: targetStartRowIndex,
+    columnIndex: targetStartColIndex,
+    columnCount: valuesForCalculation[0].length,
+  };
+  const _pValueWrite = perfNow();
+  let _pStaleLeftClear = _pValueWrite;
+  let _pBannerClear = _pValueWrite;
+  let _pBannerWrite = _pValueWrite;
+  let bannerDetails = null;
+
+  if (calculationSettings.writeBannerLetters) {
+    // staleLeftClear phase: no separate sync needed.  The combined banner
+    // updater below receives sourceRange.columnIndex so its scan also covers
+    // any columns between the source start and the write target start,
+    // absorbing the former clearStaleBannerMarkersLeftOfWriteRange work.
+    _pStaleLeftClear = _pValueWrite;
+
+    // Combined clear + write in a single read/plan/write phase.  The first
+    // sync inside applyBannerMarkerUpdatesForRange reads the banner area and
+    // also flushes pending data-body writes; the queued marker writes are
+    // flushed by the final context.sync() below.  bannerClearMs measures the
+    // read+plan portion and bannerWriteMs measures the write portion so the
+    // perf log shape is preserved.
+    bannerDetails = await applyBannerMarkerUpdatesForRange(
+      context,
+      writeTargetRange,
+      calculationSettings,
+      bannerStructure,
+      _knownDims,
+      sourceRange.columnIndex
+    );
+    _pBannerClear = perfNow();
+    // No second sync inside the combined function; the final sync flushes
+    // queued writes.  bannerWriteMs is captured around that final sync below.
+    _pBannerWrite = _pBannerClear;
+  }
+
+  await context.sync();
+  const _pWrite = perfNow();
+  // After the final sync, attribute the time it took to flush queued banner
+  // writes (if any) to bannerWriteMs so the legacy log shape continues to
+  // separate "load / plan" cost from "write" cost.  When banner letters are
+  // disabled the final sync only flushes data writes and we leave
+  // bannerWriteMs at 0.
+  if (calculationSettings.writeBannerLetters) {
+    _pBannerWrite = _pWrite;
+  }
+
+  // Footnote job (collected, not applied here). Applying it now would insert a
+  // worksheet row that shifts every candidate range still queued in the batch.
+  const footnoteJob = buildSignificanceFootnoteJob({
+    sheetName,
+    dataStartRowIndex: targetStartRowIndex,
+    dataStartColIndex: targetStartColIndex,
+    dataRowCount: valuesForCalculation.length,
+    dataColCount: valuesForCalculation[0].length,
+    leftLabelValues,
+    adjacentLabelColumnCount: interpretation.adjacentLabelColumnCount,
+    calculationBlocks,
+    calculationSettings,
+  });
+
+  // Design recolor job (collected, not applied here). Like the footnote job it is
+  // pure geometry computed from the already-known interpretation; the run flow
+  // applies it after calculations (before footnote row insertions).
+  const recolorJob = buildDesignRecolorJob({
+    sheetName,
+    dataStartRowIndex: targetStartRowIndex,
+    dataStartColIndex: targetStartColIndex,
+    dataRowCount: valuesForCalculation.length,
+    dataColCount: valuesForCalculation[0].length,
+    adjacentLabelColumnCount: interpretation.adjacentLabelColumnCount,
+    bannerRowCount: resolveBannerRecolorRowCount(interpretation, targetStartRowIndex),
+    calculationSettings,
+  });
+
+  return {
+    status: "processed",
+    blocksProcessed: calculationBlocks.length,
+    message: `обработано блоков: ${calculationBlocks.length}`,
+    rangeAddress,
+    footnoteJob,
+    recolorJob,
+    _phasesMs: _p0 !== 0 ? {
+      loadMs: _pLoad - _p0,
+      interpMs: _pInterp - _pLoad,
+      calcMs: _pCalc - _pInterp,
+      writeMs: _pWrite - _pCalc,
+      writeDetails: {
+        valueWriteMs: _pValueWrite - _pCalc,
+        staleLeftClearMs: _pStaleLeftClear - _pValueWrite,
+        bannerClearMs: _pBannerClear - _pStaleLeftClear,
+        bannerWriteMs: _pBannerWrite - _pBannerClear,
+        finalSyncMs: calculationSettings.writeBannerLetters ? 0 : (_pWrite - _pBannerWrite),
+        ...(writerDetails ? { writerDetails } : {}),
+        ...(bannerDetails ? { bannerDetails } : {}),
+      },
+    } : null,
+  };
+}

--- a/src/taskpane/taskpane.js
+++ b/src/taskpane/taskpane.js
@@ -43,8 +43,6 @@ import {
 
 import { detectBannerStructure } from "../core/banner-detector";
 
-import { buildDesignRecolorJob } from "../core/design-recolor";
-
 import { hasEmptyDataRowGap, selectionHasMultiTableGap } from "../core/range-normalizer";
 
 import { filterWorkbookCandidates } from "../core/batch-candidate-filter";
@@ -58,6 +56,8 @@ import { t, setLanguage, loadSavedLanguage, applyI18n } from "./localization";
 import { createMarkerOverflowDecider } from "./taskpane-dialogs";
 
 import { preflightBatchMarkerOverflow } from "./run-preflight";
+
+import { runSignificanceForRangeInContext as runSignificanceForRangeInContextPipeline } from "./run-pipeline";
 
 import { refreshActionWarnings } from "./taskpane-action-warnings";
 
@@ -840,18 +840,16 @@ async function runSignificanceFromSelection() {
 }
 
 
-/**
- * Core significance pipeline for a single named range, using a caller-supplied
- * Office.js RequestContext.
- *
- * Extracted so sheet/workbook autorun loops can share one Excel.run context
- * across all tables, amortising per-context initialisation overhead. Callers
- * that need a self-contained execution unit use runSignificanceForRange below,
- * which wraps this function in its own Excel.run.
- *
- * Returns { status, blocksProcessed, message, rangeAddress }.
- * status: "processed" | "skipped" | "blocked" | "error"
- */
+function getRunPipelineDependencies() {
+  return {
+    applyBannerMarkerUpdatesForRange,
+    buildSignificanceFootnoteJob,
+    calculateBlockResults,
+    createMarkerOverflowDecider,
+    getFirstBannerStructureError,
+  };
+}
+
 async function runSignificanceForRangeInContext(
   context,
   sheetName,
@@ -859,297 +857,15 @@ async function runSignificanceForRangeInContext(
   calculationSettings,
   markerOverflowDecider = null
 ) {
-  const _p0 = perfNow();
-  const worksheet = context.workbook.worksheets.getItem(sheetName);
-  const sourceRange = worksheet.getRange(rangeAddress);
-
-  sourceRange.load(["values", "text", "rowIndex", "columnIndex", "rowCount", "columnCount"]);
-
-  await context.sync();
-  const _pLoad = perfNow();
-
-  const selectedValues = sourceRange.values;
-  const selectedText = sourceRange.text;
-
-  if (!selectedValues || selectedValues.length < 2 || selectedValues[0].length < 2) {
-    return { status: "skipped", message: "слишком мало данных", rangeAddress };
-  }
-
-  const interpretation = await interpretSelectedRange(
+  return runSignificanceForRangeInContextPipeline(
     context,
-    sourceRange,
-    selectedValues,
-    selectedText,
-    calculationSettings
-  );
-
-  if (interpretation.state === "blocked") {
-    const codes =
-      interpretation.blockingReasons && interpretation.blockingReasons.length > 0
-        ? ` [${interpretation.blockingReasons.join(", ")}]`
-        : "";
-    return {
-      status: "blocked",
-      message: `${interpretation.blockingMessage}${codes}`,
-      rangeAddress,
-    };
-  }
-
-  const {
-    valuesForCalculation,
-    textForCalculation,
-    leftLabelValues,
-    bannerContext: interpretedBannerContext,
-  } = interpretation;
-
-  const { writeTargetRange } = interpretation;
-
-  if (
-    !valuesForCalculation ||
-    valuesForCalculation.length < 2 ||
-    !valuesForCalculation[0] ||
-    valuesForCalculation[0].length < 2
-  ) {
-    return { status: "skipped", message: "нет данных для расчёта", rangeAddress };
-  }
-
-  const _pInterp = perfNow();
-
-  // Compute write-target row/column indices from the already-loaded sourceRange
-  // properties rather than issuing a separate load+sync on writeTargetRange.
-  // sourceRange.rowIndex and .columnIndex are loaded in the sync above;
-  // interpretation.dataRowOffset / dataColOffset are pure-JS values from the
-  // normalization path, so no additional round-trip is required.
-  const targetStartRowIndex = sourceRange.rowIndex + interpretation.dataRowOffset;
-  const targetStartColIndex = sourceRange.columnIndex + interpretation.dataColOffset;
-
-  if (calculationSettings.writeBannerLetters && targetStartRowIndex === 0) {
-    return {
-      status: "skipped",
-      message: "данные в первой строке — баннер недоступен",
-      rangeAddress,
-    };
-  }
-
-  // Detect banner structure before any write so marker-overflow can be resolved
-  // up front (the dialog must appear before results are written).
-  let bannerStructure = null;
-
-  if (calculationSettings.respectBannerStructure) {
-    const bannerContext = interpretedBannerContext;
-    bannerStructure = detectBannerStructure(bannerContext, calculationSettings);
-    if (bannerContext && bannerContext.messages && bannerContext.messages.length > 0) {
-      bannerStructure.messages = [...bannerContext.messages, ...(bannerStructure.messages || [])];
-    }
-  }
-
-  // Marker-overflow preflight. When more comparable columns exist than
-  // single-character markers, ask once per operation. Stopping returns before
-  // any write so no partial results are written for this table.
-  if (
-    detectSignificanceMarkerOverflow(
-      valuesForCalculation[0].length,
-      calculationSettings,
-      bannerStructure
-    )
-  ) {
-    const activeDecider = markerOverflowDecider || createMarkerOverflowDecider();
-    if ((await activeDecider.resolve()) === "stop") {
-      return { status: "stopped", message: "расчёт остановлен — превышен лимит маркеров", rangeAddress };
-    }
-    // Mutate the (per-operation) settings so every table in the batch uses
-    // multi-character markers consistently after the user opts to continue.
-    calculationSettings.allowMultiCharacterMarkers = true;
-  }
-
-  writeTargetRange.values = valuesForCalculation;
-  writeTargetRange.format.font.bold = false;
-  writeTargetRange.format.fill.clear();
-  writeTargetRange.format.horizontalAlignment = "Center";
-  writeTargetRange.format.verticalAlignment = "Center";
-
-  // No intermediate sync here. The pre-write format ops and
-  // writeCellResultsToSelectedRange are all writes with no intervening Excel
-  // reads, so they can share the final context.sync below. Removing this
-  // round-trip saves one Office.js sync per table in the autorun batch loop.
-  const detectionResult = detectMetricRowsFromLeftLabels(valuesForCalculation, leftLabelValues);
-  const calculationBlocks = buildCalculationBlocks(detectionResult, { preferredBase: calculationSettings.preferredBase });
-
-  if (!calculationBlocks || calculationBlocks.length === 0) {
-    return { status: "skipped", message: "нет блоков расчёта", rangeAddress };
-  }
-
-  const fullCellResultMatrix = createEmptyCellResultMatrix(
-    valuesForCalculation.length,
-    valuesForCalculation[0].length
-  );
-
-  for (const calculationBlock of calculationBlocks) {
-    const smallBaseResult = applySmallBaseRulesForCalculationBlock(
-      valuesForCalculation,
-      calculationBlock,
-      fullCellResultMatrix,
-      calculationSettings
-    );
-
-    if (smallBaseResult.errorMessage) {
-      return { status: "error", message: smallBaseResult.errorMessage, rangeAddress };
-    }
-
-    const blockCalculationSettings = {
-      ...calculationSettings,
-      excludedColumnIndexes: smallBaseResult.excludedColumnIndexes,
-      bannerStructure,
-    };
-
-    const blockResults = calculateBlockResults(
-      valuesForCalculation,
-      calculationBlock,
-      blockCalculationSettings
-    );
-
-    const bannerStructureError = getFirstBannerStructureError(bannerStructure);
-
-    if (bannerStructureError) {
-      return { status: "error", message: bannerStructureError.text, rangeAddress };
-    }
-
-    if (!blockResults) {
-      continue;
-    }
-
-    applyComparisonResultsToFullCellResultMatrix(
-      blockResults,
-      fullCellResultMatrix,
-      blockCalculationSettings
-    );
-  }
-
-  const allowedMarkerRows = getAllowedMarkerRowIndexes(calculationBlocks);
-
-  keepMarkersOnlyInAllowedRows(fullCellResultMatrix, allowedMarkerRows);
-
-  const _pCalc = perfNow();
-
-  // Autorun never loads writeTargetRange.rowIndex / .columnIndex on the proxy
-  // (they're computed from the already-loaded sourceRange + offsets to save a
-  // round-trip). Pass them explicitly so the writer can use the chunked
-  // RangeAreas formatting path (ExcelApi 1.9).
-  const writerDetails = writeCellResultsToSelectedRange(
-    writeTargetRange,
-    textForCalculation,
-    fullCellResultMatrix,
-    detectionResult,
-    calculationSettings,
-    {
-      captureWriterDetails: perfEnabled(),
-      anchorRowIndex: targetStartRowIndex,
-      anchorColumnIndex: targetStartColIndex,
-    }
-  );
-
-  const _knownDims = {
-    rowIndex: targetStartRowIndex,
-    columnIndex: targetStartColIndex,
-    columnCount: valuesForCalculation[0].length,
-  };
-  const _pValueWrite = perfNow();
-  let _pStaleLeftClear = _pValueWrite;
-  let _pBannerClear = _pValueWrite;
-  let _pBannerWrite = _pValueWrite;
-  let bannerDetails = null;
-
-  if (calculationSettings.writeBannerLetters) {
-    // staleLeftClear phase: no separate sync needed.  The combined banner
-    // updater below receives sourceRange.columnIndex so its scan also covers
-    // any columns between the source start and the write target start,
-    // absorbing the former clearStaleBannerMarkersLeftOfWriteRange work.
-    _pStaleLeftClear = _pValueWrite;
-
-    // Combined clear + write in a single read/plan/write phase.  The first
-    // sync inside applyBannerMarkerUpdatesForRange reads the banner area and
-    // also flushes pending data-body writes; the queued marker writes are
-    // flushed by the final context.sync() below.  bannerClearMs measures the
-    // read+plan portion and bannerWriteMs measures the write portion so the
-    // perf log shape is preserved.
-    bannerDetails = await applyBannerMarkerUpdatesForRange(
-      context,
-      writeTargetRange,
-      calculationSettings,
-      bannerStructure,
-      _knownDims,
-      sourceRange.columnIndex
-    );
-    _pBannerClear = perfNow();
-    // No second sync inside the combined function; the final sync flushes
-    // queued writes.  bannerWriteMs is captured around that final sync below.
-    _pBannerWrite = _pBannerClear;
-  }
-
-  await context.sync();
-  const _pWrite = perfNow();
-  // After the final sync, attribute the time it took to flush queued banner
-  // writes (if any) to bannerWriteMs so the legacy log shape continues to
-  // separate "load / plan" cost from "write" cost.  When banner letters are
-  // disabled the final sync only flushes data writes and we leave
-  // bannerWriteMs at 0.
-  if (calculationSettings.writeBannerLetters) {
-    _pBannerWrite = _pWrite;
-  }
-
-  // Footnote job (collected, not applied here). Applying it now would insert a
-  // worksheet row that shifts every candidate range still queued in the batch.
-  const footnoteJob = buildSignificanceFootnoteJob({
     sheetName,
-    dataStartRowIndex: targetStartRowIndex,
-    dataStartColIndex: targetStartColIndex,
-    dataRowCount: valuesForCalculation.length,
-    dataColCount: valuesForCalculation[0].length,
-    leftLabelValues,
-    adjacentLabelColumnCount: interpretation.adjacentLabelColumnCount,
-    calculationBlocks,
-    calculationSettings,
-  });
-
-  // Design recolor job (collected, not applied here). Like the footnote job it is
-  // pure geometry computed from the already-known interpretation; the run flow
-  // applies it after calculations (before footnote row insertions).
-  const recolorJob = buildDesignRecolorJob({
-    sheetName,
-    dataStartRowIndex: targetStartRowIndex,
-    dataStartColIndex: targetStartColIndex,
-    dataRowCount: valuesForCalculation.length,
-    dataColCount: valuesForCalculation[0].length,
-    adjacentLabelColumnCount: interpretation.adjacentLabelColumnCount,
-    bannerRowCount: resolveBannerRecolorRowCount(interpretation, targetStartRowIndex),
-    calculationSettings,
-  });
-
-  return {
-    status: "processed",
-    blocksProcessed: calculationBlocks.length,
-    message: `обработано блоков: ${calculationBlocks.length}`,
     rangeAddress,
-    footnoteJob,
-    recolorJob,
-    _phasesMs: _p0 !== 0 ? {
-      loadMs: _pLoad - _p0,
-      interpMs: _pInterp - _pLoad,
-      calcMs: _pCalc - _pInterp,
-      writeMs: _pWrite - _pCalc,
-      writeDetails: {
-        valueWriteMs: _pValueWrite - _pCalc,
-        staleLeftClearMs: _pStaleLeftClear - _pValueWrite,
-        bannerClearMs: _pBannerClear - _pStaleLeftClear,
-        bannerWriteMs: _pBannerWrite - _pBannerClear,
-        finalSyncMs: calculationSettings.writeBannerLetters ? 0 : (_pWrite - _pBannerWrite),
-        ...(writerDetails ? { writerDetails } : {}),
-        ...(bannerDetails ? { bannerDetails } : {}),
-      },
-    } : null,
-  };
+    calculationSettings,
+    markerOverflowDecider,
+    getRunPipelineDependencies()
+  );
 }
-
 
 /**
  * Runs the full significance pipeline for a single named range on a named sheet.
@@ -4660,23 +4376,6 @@ async function applyDesignRecolorJobsInOwnContext(jobs) {
     console.warn("RIT: не удалось перекрасить баннер и лейблы.", recolorErr);
   }
 }
-
-/**
- * Computes the effective banner-row count to recolor above a data body.
- *
- * - In a normalized selection the interpreter reports the exact banner band it
- *   detected inside the selection (excluding title/subtitle rows).
- * - In a pass-through selection (the user selected only the numeric data body)
- *   any banner sits in the sheet directly above the selection, so the single
- *   header row immediately above the data body is recolored when one exists.
- */
-function resolveBannerRecolorRowCount(interpretation, dataStartRowIndex) {
-  const interpreted = interpretation.bannerRowsAboveData || 0;
-  if (interpreted > 0) return interpreted;
-  if (interpretation.state === "passThrough" && dataStartRowIndex > 0) return 1;
-  return 0;
-}
-
 
 async function ensureInventoryContentWorksheet(context) {
   const worksheets = context.workbook.worksheets;


### PR DESCRIPTION
## Summary

Extracts the shared per-table Run executor behind the Run pipeline contract while preserving the current taskpane entry points and callers.

## Files changed

- `src/taskpane/run-pipeline.js`
- `src/taskpane/taskpane.js`

## Exact functions moved

- Moved the `runSignificanceForRangeInContext` executor body from `taskpane.js` into `src/taskpane/run-pipeline.js` and exported it there.
- Moved the tiny executor-only helper `resolveBannerRecolorRowCount` into `run-pipeline.js`.

## Functions intentionally left in `taskpane.js`

- `runSignificanceFromSelection`: manual selected-range Run remains owned by `taskpane.js` to avoid broadening this PR.
- `runSignificanceForRange`: remains a tiny Excel.run wrapper around the same local `runSignificanceForRangeInContext` compatibility function.
- Current-table/current-sheet/workbook Run handlers and batch loops: left in place so report/status/progress behavior is unchanged.
- Run report sheet writing, generated sheet/report writers, marker-overflow dialog helpers, run-preflight helpers, Clear/Check/Content/inventory logic, settings persistence, status/action warning rendering, Excel writer implementation, and statistical/core logic: intentionally not moved.
- `calculateBlockResults`, `applyBannerMarkerUpdatesForRange`, `buildSignificanceFootnoteJob`, and `getFirstBannerStructureError`: left local and passed explicitly because extracting them would broaden the review into dispatcher, banner writer, and footnote ownership.

## Exported API

`run-pipeline.js` exports:

```js
runSignificanceForRangeInContext(
  context,
  sheetName,
  rangeAddress,
  calculationSettings,
  markerOverflowDecider = null,
  dependencies = {}
)
```

`taskpane.js` keeps a same-signature compatibility wrapper so existing callers continue to call `runSignificanceForRangeInContext(...)` unchanged.

## Dependencies passed/imported

Explicit dependency object passed from `taskpane.js`:

- `applyBannerMarkerUpdatesForRange`
- `buildSignificanceFootnoteJob`
- `calculateBlockResults`
- `createMarkerOverflowDecider`
- `getFirstBannerStructureError`

`run-pipeline.js` imports only extracted/core modules:

- `../core/significance`
- `../core/metric-detector`
- `../core/excel-writer`
- `../core/banner-detector`
- `../core/design-recolor`
- `./selected-range-interpreter`
- `./taskpane-performance`

No broad taskpane state object is passed.

## Circular dependency check

Confirmed `run-pipeline.js` does not import `taskpane.js`. `taskpane.js` imports `run-pipeline.js`, and the new module imports only core/extracted taskpane modules, so this PR does not introduce a circular dependency.

## `context.sync` placement

Preserved the executor's existing sync placement:

- source range load sync before interpretation;
- no added sync before `writeCellResultsToSelectedRange`;
- existing banner updater sync behavior remains inside `applyBannerMarkerUpdatesForRange`;
- final table write sync remains after queued body/banner writes;
- wrapper adds no Office.js syncs and no loop-level syncs.

## Validation results

- `npm test` passed: 504 tests.
- `npm run build` passed. Webpack reported the existing taskpane bundle size warnings.
- `git diff --check --cached` passed.

## Manual smoke checklist

Excel smoke was not run by Codex in this environment and is required before merge:

- [ ] Manual Run selected numeric range.
- [ ] Manual Run sloppy/full-table selection normalization.
- [ ] Current-table Run.
- [ ] Current-sheet Run.
- [ ] Workbook Run.
- [ ] Marker overflow Stop/Continue.
- [ ] Previous-column mode.
- [ ] Banner-aware mode.
- [ ] Footnote placement/update.
- [ ] Banner marker writing.
- [ ] Design recolor.
- [ ] Run report output.
- [ ] Basic Clear smoke to confirm shared imports were not broken.

## Risks / limitations

- This is a behavior-preserving extraction, but it touches Run execution wiring, so real Excel smoke is still the main confidence gate.
- Several helper dependencies remain in `taskpane.js` intentionally; extracting them should be separate follow-up work if desired.