### PR TITLE
[codex] Extract run dispatcher helpers

### DIFF
--- a/src/taskpane/run-pipeline.js
+++ b/src/taskpane/run-pipeline.js
@@ -4,6 +4,10 @@ import {
   applySmallBaseRulesForCalculationBlock,
   keepMarkersOnlyInAllowedRows,
   detectSignificanceMarkerOverflow,
+  compareProportionRowsUsingBaseRow,
+  compareMeanBlockByRowIndexes,
+  compareNpsStructureBlockByRowIndexes,
+  compareNpsSpreadBlockByRowIndexes,
 } from "../core/significance";
 
 import {
@@ -38,6 +42,67 @@ function resolveBannerRecolorRowCount(interpretation, dataStartRowIndex) {
 }
 
 /**
+ * Calculates one detected metric block.
+ *
+ * PURPOSE:
+ * Keeps dispatcher logic close to the per-table Run executor.
+ * Each block type is routed to the correct core calculation function.
+ */
+export function calculateBlockResults(cleanedValues, calculationBlock, calculationSettings) {
+  if (calculationBlock.metricType === "proportion") {
+    return compareProportionRowsUsingBaseRow(
+      cleanedValues,
+      calculationBlock.valueRowIndexes,
+      calculationBlock.baseRowIndex,
+      calculationSettings
+    );
+  }
+
+  if (calculationBlock.metricType === "mean") {
+    return compareMeanBlockByRowIndexes(
+      cleanedValues,
+      calculationBlock.valueRowIndex,
+      calculationBlock.spreadRowIndex,
+      calculationBlock.baseRowIndex,
+      calculationBlock.spreadType,
+      calculationSettings
+    );
+  }
+
+  if (calculationBlock.metricType === "npsStructure") {
+    return compareNpsStructureBlockByRowIndexes(
+      cleanedValues,
+      calculationBlock.valueRowIndex,
+      calculationBlock.promotersRowIndex,
+      calculationBlock.detractorsRowIndex,
+      calculationBlock.baseRowIndex,
+      calculationSettings
+    );
+  }
+
+  if (calculationBlock.metricType === "npsSpread") {
+    return compareNpsSpreadBlockByRowIndexes(
+      cleanedValues,
+      calculationBlock.valueRowIndex,
+      calculationBlock.spreadRowIndex,
+      calculationBlock.baseRowIndex,
+      calculationBlock.spreadType,
+      calculationSettings
+    );
+  }
+
+  return null;
+}
+
+export function getFirstBannerStructureError(bannerStructure) {
+  if (!bannerStructure || !bannerStructure.messages) {
+    return null;
+  }
+
+  return bannerStructure.messages.find((message) => message.severity === "error") || null;
+}
+
+/**
  * Core significance pipeline for a single named range, using a caller-supplied
  * Office.js RequestContext.
  *
@@ -52,7 +117,6 @@ export async function runSignificanceForRangeInContext(
   markerOverflowDecider = null,
   dependencies = {}
 ) {
-  const calculateBlockResults = requireRunPipelineDependency(dependencies, "calculateBlockResults");
   const applyBannerMarkerUpdatesForRange = requireRunPipelineDependency(
     dependencies,
     "applyBannerMarkerUpdatesForRange"
@@ -60,10 +124,6 @@ export async function runSignificanceForRangeInContext(
   const buildSignificanceFootnoteJob = requireRunPipelineDependency(
     dependencies,
     "buildSignificanceFootnoteJob"
-  );
-  const getFirstBannerStructureError = requireRunPipelineDependency(
-    dependencies,
-    "getFirstBannerStructureError"
   );
   const createMarkerOverflowDecider = requireRunPipelineDependency(
     dependencies,

--- a/src/taskpane/taskpane.js
+++ b/src/taskpane/taskpane.js
@@ -10,10 +10,6 @@ import {
   applyComparisonResultsToFullCellResultMatrix,
   applySmallBaseRulesForCalculationBlock,
   keepMarkersOnlyInAllowedRows,
-  compareProportionRowsUsingBaseRow,
-  compareMeanBlockByRowIndexes,
-  compareNpsStructureBlockByRowIndexes,
-  compareNpsSpreadBlockByRowIndexes,
   generateSignificanceLabels,
   buildBannerLocalSignificanceLabelMap,
   isSignificanceMarkerLabel,
@@ -57,7 +53,11 @@ import { createMarkerOverflowDecider } from "./taskpane-dialogs";
 
 import { preflightBatchMarkerOverflow } from "./run-preflight";
 
-import { runSignificanceForRangeInContext as runSignificanceForRangeInContextPipeline } from "./run-pipeline";
+import {
+  calculateBlockResults,
+  getFirstBannerStructureError,
+  runSignificanceForRangeInContext as runSignificanceForRangeInContextPipeline,
+} from "./run-pipeline";
 
 import { refreshActionWarnings } from "./taskpane-action-warnings";
 
@@ -844,9 +844,7 @@ function getRunPipelineDependencies() {
   return {
     applyBannerMarkerUpdatesForRange,
     buildSignificanceFootnoteJob,
-    calculateBlockResults,
     createMarkerOverflowDecider,
-    getFirstBannerStructureError,
   };
 }
 
@@ -2986,60 +2984,6 @@ async function runWorkbookCheck() {
     }
   }
 }
-
-/**
- * Calculates one detected metric block.
- *
- * PURPOSE:
- * Keeps dispatcher logic out of runSignificanceFromSelection().
- * Each block type is routed to the correct core calculation function.
- */
-function calculateBlockResults(cleanedValues, calculationBlock, calculationSettings) {
-  if (calculationBlock.metricType === "proportion") {
-    return compareProportionRowsUsingBaseRow(
-      cleanedValues,
-      calculationBlock.valueRowIndexes,
-      calculationBlock.baseRowIndex,
-      calculationSettings
-    );
-  }
-
-  if (calculationBlock.metricType === "mean") {
-    return compareMeanBlockByRowIndexes(
-      cleanedValues,
-      calculationBlock.valueRowIndex,
-      calculationBlock.spreadRowIndex,
-      calculationBlock.baseRowIndex,
-      calculationBlock.spreadType,
-      calculationSettings
-    );
-  }
-
-  if (calculationBlock.metricType === "npsStructure") {
-    return compareNpsStructureBlockByRowIndexes(
-      cleanedValues,
-      calculationBlock.valueRowIndex,
-      calculationBlock.promotersRowIndex,
-      calculationBlock.detractorsRowIndex,
-      calculationBlock.baseRowIndex,
-      calculationSettings
-    );
-  }
-
-  if (calculationBlock.metricType === "npsSpread") {
-    return compareNpsSpreadBlockByRowIndexes(
-      cleanedValues,
-      calculationBlock.valueRowIndex,
-      calculationBlock.spreadRowIndex,
-      calculationBlock.baseRowIndex,
-      calculationBlock.spreadType,
-      calculationSettings
-    );
-  }
-
-  return null;
-}
-
 
 /**
  * Read-only check pipeline for a named range inside an existing Excel.run context.
@@ -5661,14 +5605,6 @@ function initializeBannerStructureSettings() {
   }
 
   refreshSettingsPanelState();
-}
-
-function getFirstBannerStructureError(bannerStructure) {
-  if (!bannerStructure || !bannerStructure.messages) {
-    return null;
-  }
-
-  return bannerStructure.messages.find((message) => message.severity === "error") || null;
 }
 
 /**


### PR DESCRIPTION
## Summary

Extracts the Run calculation dispatcher helpers from `src/taskpane/taskpane.js` into `src/taskpane/run-pipeline.js`, where the shared per-table Run executor already uses them.

No production behavior changes are intended. Statistical formulas, marker behavior, banner marker writing, footnote writing, design recolor execution, selected-range interpretation/normalization, batch loops, report writing, and `context.sync` placement are unchanged.

## Files changed

- `src/taskpane/run-pipeline.js`
- `src/taskpane/taskpane.js`

## Exact functions moved

- `calculateBlockResults(cleanedValues, calculationBlock, calculationSettings)`
- `getFirstBannerStructureError(bannerStructure)`

`calculateBlockResults` now lives beside the per-table executor and imports the same core significance functions it previously called from `taskpane.js`.

## Functions intentionally left in taskpane.js

- `applyBannerMarkerUpdatesForRange` and banner marker writer/helpers: still taskpane-owned because they are tied to banner marker write planning and taskpane-local banner helper functions.
- `buildSignificanceFootnoteJob` and footnote placement/update helpers: still taskpane-owned because this PR does not move footnote construction, placement, or update behavior.
- `createMarkerOverflowDecider`: still taskpane-owned because it belongs to dialog/UI prompting.
- `runSignificanceFromSelection`: not moved; manual selected-range Run remains stable and taskpane-owned.
- `runSignificanceForRange` wrapper, current-table/current-sheet/workbook Run handlers, batch loops, Run report writing, design recolor execution, Clear/Check/Content/inventory logic, and Excel writer/statistical implementations: intentionally out of scope.

## Dependency object before/after

Before `taskpane.js` passed:

```js
{
  applyBannerMarkerUpdatesForRange,
  buildSignificanceFootnoteJob,
  calculateBlockResults,
  createMarkerOverflowDecider,
  getFirstBannerStructureError,
}
```

After `taskpane.js` passes:

```js
{
  applyBannerMarkerUpdatesForRange,
  buildSignificanceFootnoteJob,
  createMarkerOverflowDecider,
}
```

Manual selected-range Run still imports and calls `calculateBlockResults` and `getFirstBannerStructureError` from `run-pipeline.js` so behavior remains aligned while ownership moves.

## Partial-selection bug investigation note

Known bug investigated before coding: very wide manual Run selection with partial banner + full body selected, row labels and top banner level outside selection, first banner group using vertically merged cells, later groups using two full banner levels, and the third/top level outside selection. Reported effects: no significance calculation and banner cells lose fill/color.

Likely area: selected-range interpretation/normalization before calculation, especially `normalizeSelectedRange()` in `src/core/range-normalizer.js` and the `interpretSelectedRange()` adapter in `src/taskpane/selected-range-interpreter.js`. The relevant branch appears to be the structural decomposition path that chooses pass-through vs normalized, detects banner rows/body start, strips label/empty columns, builds aligned `bannerContext`, and falls back to loading banner rows above the resolved data body. The symptom sounds consistent with the selection being interpreted as the data body or as an incorrectly normalized banner/body split before the calculation dispatcher runs.

This PR does not touch that area. It does not change selected-range normalization, interpretation behavior, banner detection logic, banner marker writing, marker clearing, or Excel write targets. The bug appears unrelated to the calculation dispatcher extraction, and this extraction should not make it harder to diagnose because the moved helpers only run after interpretation, banner structure detection, block detection, and marker-overflow preflight setup.

## Architecture checks

- `run-pipeline.js` still does not import `taskpane.js`.
- `taskpane.js` imports `run-pipeline.js`.
- No circular dependency is introduced: `run-pipeline.js` imports core modules plus `selected-range-interpreter` and `taskpane-performance`; neither imports `taskpane.js`.
- `context.sync` placement was unchanged.
- Result shapes and marker/statistical behavior are unchanged.

## Validation results

- `npm test` passed: 504 tests.
- `npm run build` passed. Existing webpack bundle-size warnings remain.
- `git diff --check` passed.

## Manual smoke checklist

Excel smoke remains required because this touches Run execution wiring:

- [ ] Manual Run selected numeric range.
- [ ] Manual Run sloppy/full-table selection normalization.
- [ ] Current-table Run.
- [ ] Current-sheet Run.
- [ ] Workbook Run.
- [ ] Previous-column mode.
- [ ] Banner-aware mode.
- [ ] Marker overflow Stop/Continue.
- [ ] Footnote placement/update.
- [ ] Banner marker writing.
- [ ] Design recolor.
- [ ] Run report output.
- [ ] Basic Clear smoke.

## Risks discovered

- `calculateBlockResults` and `getFirstBannerStructureError` are used by both the extracted per-table executor and the still-taskpane-owned manual selected-range Run path. To keep behavior shared, they are exported from `run-pipeline.js` and imported by `taskpane.js` instead of duplicating logic.
- No new pure tests were added; the helper export is primarily ownership/wiring, and existing unit coverage plus build validation covered the import graph without introducing Office.js mocks.