### PR TITLE
[codex] Clean up run pipeline extraction leftovers

### DIFF
--- a/docs/REFACTOR_PLAN_2026.md
+++ b/docs/REFACTOR_PLAN_2026.md
@@ -5,17 +5,21 @@ Significantly lighten `src/taskpane/taskpane.js` by extracting distinct responsi
 
 ## Current State & Diagnostics
 
-`src/taskpane/taskpane.js` is currently acting as a "God Object," inline-implementing the sequence of core logic calls for Run, Check, and Clear, while also managing UI initialization and performance aggregation.
+`src/taskpane/taskpane.js` is still the main taskpane orchestrator, but parts of
+the original inline responsibilities have been extracted. Run per-table executor
+logic now lives in `src/taskpane/run-pipeline.js`, Clear pipeline logic now lives
+in `src/taskpane/clear-pipeline.js`, and settings/performance helpers have moved
+to their dedicated modules.
 
 ### Key Layering Violations to Address
-1.  **Duplicate Pipelines:** `runSignificanceFromSelection` (manual run) and `runSignificanceForRangeInContext` (auto run) contain duplicated logic for interpreting ranges, checking overflow, detecting metrics, and calculating blocks.
+1.  **Remaining Run Split:** `runSignificanceFromSelection` (manual run) still contains its selected-range calculation flow, while the autorun per-table executor lives in `run-pipeline.js`. Further extraction must stay behavior-preserving and must not change selected-range normalization.
 2.  **Duplicate Normalization:** `clearSignificanceFromSelection` and `clearSignificanceForRangeInContext` duplicate `detectEmbeddedLabelColumns` and `detectLeadingEmptyColumns` logic found in `selected-range-interpreter.js` to resolve the clear target.
 3.  **UI in Orchestrator:** Tooltip mapping, checkbox bindings, and performance aggregators reside in `taskpane.js` instead of their respective modules (`taskpane-settings.js` and `taskpane-performance.js`).
 
 ## Proposed Architecture (Taskpane Layer)
 
 -   `src/taskpane/taskpane.js`: Lean UI controller. Wires events (`Office.onReady`), binds button clicks, and orchestrates high-level flows by calling pipelines.
--   `src/taskpane/run-pipeline.js`: Shared executor for manual and auto Run flows. Handles interpretation, significance calculations, and formatting.
+-   `src/taskpane/run-pipeline.js`: Shared per-table Run executor for autorun flows, plus dispatcher helpers used by the manual Run path. Handles interpretation, significance calculations, and formatting for extracted table execution.
 -   `src/taskpane/clear-pipeline.js`: Shared executor for manual and auto Clear flows.
 -   `src/taskpane/batch-controller.js`: Manages workbook/worksheet loops and batch result accumulation.
 -   `src/taskpane/report-controller.js`: Manages the creation and population of `Content` and `Run report` sheets.
@@ -64,16 +68,16 @@ This sequence prioritizes low-risk extractions before tackling the complex Run/C
 1.  Extract `clearSignificanceForRangeInContext` and the core clearing loop from `clearSignificanceFromSelection` into `src/taskpane/clear-pipeline.js`.
 2.  Update `taskpane.js` to call the pipeline.
 
-### PR 4: Extract Run Pipeline (High Risk)
+### PR 4: Extract Run Pipeline (High Risk, partially completed by PR #328/#329)
 **Goal:** Consolidate the calculation loop for manual and autorun flows.
 **Target Files:** `src/taskpane/taskpane.js`, `src/taskpane/run-pipeline.js` (new)
 **Contract:** See `docs/RUN_PIPELINE_CONTRACT.md` before moving Run code. That
 document records the current entry points, write barriers, job objects, report
 row expectations, and `context.sync` boundaries that extraction must preserve.
 **Action:**
-1.  Identify the ~100 lines of shared logic between `runSignificanceFromSelection` and `runSignificanceForRangeInContext`.
-2.  Extract into `runPipeline(context, range, values, text, interpretation, settings, decider)` in `run-pipeline.js`.
-3.  Update `taskpane.js` orchestrators to call this pipeline.
+1.  PR #328 extracted the shared per-table executor to `run-pipeline.js`.
+2.  PR #329 moved `calculateBlockResults` and `getFirstBannerStructureError` to `run-pipeline.js`.
+3.  Remaining Run cleanup should be small, audited, and behavior-preserving before any further helper extraction.
 **Critical Guardrails:** The `markerOverflowDecider` logic must remain capable of pausing Excel execution via UI dialog without breaking batch promises. Do not change `context.sync` placement.
 **Testing:** Exhaustive manual smoke testing of Run and Autorun. Run all existing unit tests.
 

--- a/docs/RUN_PIPELINE_CONTRACT.md
+++ b/docs/RUN_PIPELINE_CONTRACT.md
@@ -1,12 +1,14 @@
 # Run Pipeline Contract
 
 This document records the current Run behavior that must be preserved before
-extracting a shared Run pipeline from `src/taskpane/taskpane.js`.
+and after extracting shared Run pipeline code from `src/taskpane/taskpane.js`.
 
-PR5B is a contract and regression-coverage step only. It does not move
-`runSignificanceFromSelection`, `runSignificanceForRangeInContext`, the batch Run
-handlers, Excel writer calls, report writing, footnote writes, banner marker
-writes, design recolor execution, or `context.sync` boundaries.
+PR #327 documented the contract, PR #328 extracted the shared per-table Run
+executor to `src/taskpane/run-pipeline.js`, and PR #329 moved the Run dispatcher
+helpers there. The contract remains behavior-preservation first: batch Run
+handlers, report writing, footnote writes, banner marker writes, design recolor
+execution, and `context.sync` boundaries should not move unless a later task
+explicitly scopes that work.
 
 ## Current Entry Points
 
@@ -60,14 +62,14 @@ report output.
 ### Table pipeline
 
 `runSignificanceForRangeInContext` is the current reusable table executor for
-batch flows. It must remain callable inside an existing `Excel.run` context. It
-loads the source range, interprets the selected/table range, detects banners and
-calculation blocks, performs per-table marker-overflow preflight as a safety net,
-queues body and banner writes, and returns pure job objects for deferred design
-recolor and footnotes.
+batch flows and lives in `src/taskpane/run-pipeline.js`. It must remain callable
+inside an existing `Excel.run` context. It loads the source range, interprets the
+selected/table range, detects banners and calculation blocks, performs per-table
+marker-overflow preflight as a safety net, queues body and banner writes, and
+returns pure job objects for deferred design recolor and footnotes.
 
 `runSignificanceForRange` is only a wrapper that provides its own `Excel.run`
-context around `runSignificanceForRangeInContext`.
+context around the extracted per-table executor.
 
 ## Boundary Contracts
 
@@ -284,9 +286,8 @@ Existing pure coverage already protects these Run-adjacent contracts:
 - design recolor label-width and rectangle job helpers;
 - banner local significance label maps.
 
-PR5B strengthens `preflightBatchMarkerOverflow` coverage for mixed candidate
-widths and missing inventory metadata without requiring Office.js stubs or
-production extraction.
+PR #327 strengthened `preflightBatchMarkerOverflow` coverage for mixed candidate
+widths and missing inventory metadata without requiring Office.js stubs.
 
 ## Missing Test Coverage
 
@@ -302,13 +303,14 @@ require moving production Run code or building brittle Office.js doubles:
   writer, and footnote insertion side effects;
 - exact `context.sync` ordering under real Excel.
 
-## Future Extraction Plan
+## Current Extraction Status
 
-Recommended next implementation PR: extract only the shared per-table Run
-executor behind the object shapes above, leaving batch loops and generated sheet
-writers in `taskpane.js`. The PR should preserve all existing entry points and
-return `RunPipelineResult` objects that current callers can adapt to their
-existing status/report/job behavior.
+PR #328 extracted the shared per-table Run executor behind the object shapes
+above, leaving batch loops and generated sheet writers in `taskpane.js`. PR #329
+moved `calculateBlockResults` and `getFirstBannerStructureError` into
+`src/taskpane/run-pipeline.js`. Later extraction should preserve all existing
+entry points and current status/report/job behavior unless explicitly scoped
+otherwise.
 
 Future manual smoke coverage for Run extraction must include:
 

--- a/src/taskpane/taskpane.js
+++ b/src/taskpane/taskpane.js
@@ -840,14 +840,6 @@ async function runSignificanceFromSelection() {
 }
 
 
-function getRunPipelineDependencies() {
-  return {
-    applyBannerMarkerUpdatesForRange,
-    buildSignificanceFootnoteJob,
-    createMarkerOverflowDecider,
-  };
-}
-
 async function runSignificanceForRangeInContext(
   context,
   sheetName,
@@ -861,17 +853,21 @@ async function runSignificanceForRangeInContext(
     rangeAddress,
     calculationSettings,
     markerOverflowDecider,
-    getRunPipelineDependencies()
+    {
+      applyBannerMarkerUpdatesForRange,
+      buildSignificanceFootnoteJob,
+      createMarkerOverflowDecider,
+    }
   );
 }
 
 /**
  * Runs the full significance pipeline for a single named range on a named sheet.
  *
- * Thin wrapper around runSignificanceForRangeInContext that provides its own
- * Excel.run context. Used by current-table autorun and as a per-table fallback
- * when the shared-context batch in sheet/workbook autorun encounters an
- * Office.js error that corrupts the shared context.
+ * Thin wrapper around the extracted per-table Run executor that provides its
+ * own Excel.run context. Used by current-table autorun and as a per-table
+ * fallback when the shared-context batch in sheet/workbook autorun encounters
+ * an Office.js error that corrupts the shared context.
  *
  * Returns { status, blocksProcessed, message, rangeAddress }.
  * status: "processed" | "skipped" | "blocked" | "error"


### PR DESCRIPTION
## Summary

PR5E cleanup/audit after the Run pipeline extraction.

Files changed:
- `src/taskpane/taskpane.js`
- `docs/RUN_PIPELINE_CONTRACT.md`
- `docs/REFACTOR_PLAN_2026.md`

Cleanup performed:
- Removed the one-use `getRunPipelineDependencies()` helper and passed the dependency object directly from the local `runSignificanceForRangeInContext` wrapper.
- Updated the `runSignificanceForRange` wrapper comment so it points at the extracted per-table Run executor instead of implying the executor still lives in `taskpane.js`.
- Updated `docs/RUN_PIPELINE_CONTRACT.md` to reflect PR #328/#329 extraction status and current executor location.
- Updated `docs/REFACTOR_PLAN_2026.md` to stop describing the pre-#328 Run state as current.

## Helpers intentionally left

- Core significance imports in `taskpane.js` remain because manual selected-range Run and banner marker cleanup still use them.
- Core metric-detector imports in `taskpane.js` remain because manual selected-range Run and preview/inventory helpers still use them.
- `calculateBlockResults` and `getFirstBannerStructureError` remain imported into `taskpane.js` because manual selected-range Run still calls the extracted dispatcher helpers.
- `runSignificanceFromSelection`, current-table/current-sheet/workbook Run handlers, banner marker writer/helpers, footnote helpers, and report output paths were intentionally not moved.

## Scope confirmation

No production behavior changes intended. This PR does not touch selected-range interpretation/normalization, marker behavior, statistical formulas, `context.sync` placement, Excel writer behavior, Clear/Check/Content/inventory logic, or Run report output.

Known manual Run partial-selection bug was not touched or fixed in this PR.

## Validation

- `npm test` passed: 504 tests.
- `npm run build` passed with existing webpack bundle-size warnings for `taskpane.js`.
- `git diff --check` passed; Git reported line-ending normalization warnings only.

## Manual smoke note

Manual smoke not run for this cleanup-only PR. Recommended smoke after review:
- Basic Manual Run smoke.
- Current-table Run smoke.
- Basic Clear smoke.