### PR TITLE
[codex] Extract run footnote job builder

### DIFF
--- a/src/taskpane/run-footnotes.js
+++ b/src/taskpane/run-footnotes.js
@@ -1,0 +1,72 @@
+import {
+  collectStatisticTypeLabels,
+  buildSignificanceFootnoteCellValue,
+  resolveFootnoteSpan,
+} from "../core/significance-footnote";
+
+/**
+ * Builds a footnote job for a single processed table, or null when the footnote
+ * setting is off / geometry is unusable.
+ *
+ * Geometry is sheet-absolute and 0-based:
+ *   - dataStartRowIndex / dataStartColIndex: top-left of the data body.
+ *   - dataRowCount / dataColCount: data body dimensions.
+ *   - leftLabelValues: label columns immediately left of the data body. Their
+ *     width sets how far left the merged footnote extends (the "full table width
+ *     including label columns").
+ *
+ * Returns null when the footnote setting is off. The feature is explicitly
+ * incompatible with "labels on left side" mode (labels are not adjacent to the
+ * data, so a footnote cannot span the table correctly): readCalculationSettings-
+ * FromPanel already forces addTableFootnote=false in that mode, and this extra
+ * guard makes the rule independent of the caller.
+ *
+ * processedScopeSuffix is an optional, already-formatted detail (e.g.
+ * " Обработано: B12:F34.") appended to the visible footnote text. It is
+ * supplied only by Manual Run; auto-run callers omit it so their footnote text
+ * is unchanged.
+ */
+export function buildSignificanceFootnoteJob({
+  sheetName,
+  dataStartRowIndex,
+  dataStartColIndex,
+  dataRowCount,
+  dataColCount,
+  leftLabelValues,
+  adjacentLabelColumnCount,
+  calculationBlocks,
+  calculationSettings,
+  processedScopeSuffix,
+}) {
+  if (!calculationSettings.addTableFootnote) return null;
+  if (calculationSettings.labelsOnLeftSide) return null;
+  if (!Number.isFinite(dataStartRowIndex) || !Number.isFinite(dataStartColIndex)) return null;
+  if (!(dataRowCount > 0) || !(dataColCount > 0)) return null;
+
+  const labelColumns =
+    Array.isArray(leftLabelValues) && Array.isArray(leftLabelValues[0]) ? leftLabelValues[0].length : 0;
+
+  const { tableLeftColIndex, tableRightColIndex } = resolveFootnoteSpan({
+    dataStartColIndex,
+    dataColCount,
+    labelColumns,
+    adjacentLabelColumnCount,
+  });
+  const tableBottomRowIndex = dataStartRowIndex + dataRowCount - 1;
+
+  const footnoteCellValue = buildSignificanceFootnoteCellValue({
+    confidenceLevel: calculationSettings.confidenceLevel,
+    oneTailedTest: calculationSettings.oneTailedTest,
+    statisticLabels: collectStatisticTypeLabels(calculationBlocks),
+    scopeDetail: processedScopeSuffix,
+  });
+
+  return {
+    sheetName,
+    tableBottomRowIndex,
+    tableLeftColIndex,
+    tableRightColIndex,
+    dataStartColIndex,
+    footnoteCellValue,
+  };
+}

--- a/src/taskpane/run-pipeline.js
+++ b/src/taskpane/run-pipeline.js
@@ -26,6 +26,8 @@ import { interpretSelectedRange } from "./selected-range-interpreter";
 
 import { perfNow, perfEnabled } from "./taskpane-performance";
 
+import { buildSignificanceFootnoteJob } from "./run-footnotes";
+
 function requireRunPipelineDependency(dependencies, name) {
   const dependency = dependencies[name];
   if (typeof dependency !== "function") {
@@ -120,10 +122,6 @@ export async function runSignificanceForRangeInContext(
   const applyBannerMarkerUpdatesForRange = requireRunPipelineDependency(
     dependencies,
     "applyBannerMarkerUpdatesForRange"
-  );
-  const buildSignificanceFootnoteJob = requireRunPipelineDependency(
-    dependencies,
-    "buildSignificanceFootnoteJob"
   );
   const createMarkerOverflowDecider = requireRunPipelineDependency(
     dependencies,

--- a/src/taskpane/taskpane.js
+++ b/src/taskpane/taskpane.js
@@ -29,10 +29,7 @@ import { buildTablePreviewModel } from "../core/table-preview-model";
 import { scanWorksheetForTables } from "../core/table-inventory-scanner";
 
 import {
-  collectStatisticTypeLabels,
-  buildSignificanceFootnoteCellValue,
   buildProcessedRangeFootnoteSuffix,
-  resolveFootnoteSpan,
   resolveFootnotePlacement,
   FOOTNOTE_SCAN_WINDOW_ROWS,
 } from "../core/significance-footnote";
@@ -58,6 +55,8 @@ import {
   getFirstBannerStructureError,
   runSignificanceForRangeInContext as runSignificanceForRangeInContextPipeline,
 } from "./run-pipeline";
+
+import { buildSignificanceFootnoteJob } from "./run-footnotes";
 
 import { refreshActionWarnings } from "./taskpane-action-warnings";
 
@@ -855,7 +854,6 @@ async function runSignificanceForRangeInContext(
     markerOverflowDecider,
     {
       applyBannerMarkerUpdatesForRange,
-      buildSignificanceFootnoteJob,
       createMarkerOverflowDecider,
     }
   );
@@ -4031,77 +4029,6 @@ async function ensureBacklinkRows(context, sheetResults, contentRowMap) {
 // from the already-known ranges) and applies them AFTER all calculations finish,
 // bottom-to-top per worksheet so earlier insertions never shift a not-yet-applied
 // job's row index.
-
-/**
- * Builds a footnote job for a single processed table, or null when the footnote
- * setting is off / geometry is unusable.
- *
- * Geometry is sheet-absolute and 0-based:
- *   - dataStartRowIndex / dataStartColIndex: top-left of the data body.
- *   - dataRowCount / dataColCount: data body dimensions.
- *   - leftLabelValues: label columns immediately left of the data body. Their
- *     width sets how far left the merged footnote extends (the "full table width
- *     including label columns").
- *
- * Returns null when the footnote setting is off. The feature is explicitly
- * incompatible with "labels on left side" mode (labels are not adjacent to the
- * data, so a footnote cannot span the table correctly): readCalculationSettings-
- * FromPanel already forces addTableFootnote=false in that mode, and this extra
- * guard makes the rule independent of the caller.
- *
- * processedScopeSuffix (issue #308) is an optional, already-formatted detail
- * (e.g. " Обработано: B12:F34.") appended to the visible footnote text. It is
- * supplied only by Manual Run; auto-run callers omit it so their footnote text
- * is unchanged.
- */
-function buildSignificanceFootnoteJob({
-  sheetName,
-  dataStartRowIndex,
-  dataStartColIndex,
-  dataRowCount,
-  dataColCount,
-  leftLabelValues,
-  adjacentLabelColumnCount,
-  calculationBlocks,
-  calculationSettings,
-  processedScopeSuffix,
-}) {
-  if (!calculationSettings.addTableFootnote) return null;
-  if (calculationSettings.labelsOnLeftSide) return null;
-  if (!Number.isFinite(dataStartRowIndex) || !Number.isFinite(dataStartColIndex)) return null;
-  if (!(dataRowCount > 0) || !(dataColCount > 0)) return null;
-
-  // Visual table left edge: the wider of the loaded label width and the
-  // interpreter's adjacent label-area width, so a stripped structural gap column
-  // between labels and data (normalized autorun) is still spanned. See
-  // resolveFootnoteSpan.
-  const labelColumns =
-    Array.isArray(leftLabelValues) && Array.isArray(leftLabelValues[0]) ? leftLabelValues[0].length : 0;
-
-  const { tableLeftColIndex, tableRightColIndex } = resolveFootnoteSpan({
-    dataStartColIndex,
-    dataColCount,
-    labelColumns,
-    adjacentLabelColumnCount,
-  });
-  const tableBottomRowIndex = dataStartRowIndex + dataRowCount - 1;
-
-  const footnoteCellValue = buildSignificanceFootnoteCellValue({
-    confidenceLevel: calculationSettings.confidenceLevel,
-    oneTailedTest: calculationSettings.oneTailedTest,
-    statisticLabels: collectStatisticTypeLabels(calculationBlocks),
-    scopeDetail: processedScopeSuffix,
-  });
-
-  return {
-    sheetName,
-    tableBottomRowIndex,
-    tableLeftColIndex,
-    tableRightColIndex,
-    dataStartColIndex,
-    footnoteCellValue,
-  };
-}
 
 /**
  * Inserts or updates a single footnote row for one table.

--- a/tests/core/run-footnotes.test.mjs
+++ b/tests/core/run-footnotes.test.mjs
@@ -1,0 +1,89 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { buildSignificanceFootnoteJob } from "../../src/taskpane/run-footnotes.js";
+import {
+  SIGNIFICANCE_FOOTNOTE_MARKER,
+  isGeneratedSignificanceFootnoteRow,
+} from "../../src/core/significance-footnote.js";
+
+const baseSettings = {
+  addTableFootnote: true,
+  labelsOnLeftSide: false,
+  confidenceLevel: "95",
+  oneTailedTest: false,
+};
+
+function buildJob(overrides = {}) {
+  return buildSignificanceFootnoteJob({
+    sheetName: "Sheet1",
+    dataStartRowIndex: 10,
+    dataStartColIndex: 4,
+    dataRowCount: 3,
+    dataColCount: 4,
+    leftLabelValues: [["Label"], ["Base"], ["Value"]],
+    adjacentLabelColumnCount: 1,
+    calculationBlocks: [{ metricType: "proportion" }],
+    calculationSettings: baseSettings,
+    ...overrides,
+  });
+}
+
+describe("run footnote job builder", () => {
+  it("returns null when the table footnote setting is disabled", () => {
+    assert.strictEqual(
+      buildJob({
+        calculationSettings: {
+          ...baseSettings,
+          addTableFootnote: false,
+        },
+      }),
+      null
+    );
+  });
+
+  it("returns null when labels-on-left mode is enabled", () => {
+    assert.strictEqual(
+      buildJob({
+        calculationSettings: {
+          ...baseSettings,
+          labelsOnLeftSide: true,
+        },
+      }),
+      null
+    );
+  });
+
+  it("builds the expected job shape for valid data geometry", () => {
+    const job = buildJob();
+
+    assert.deepStrictEqual(Object.keys(job), [
+      "sheetName",
+      "tableBottomRowIndex",
+      "tableLeftColIndex",
+      "tableRightColIndex",
+      "dataStartColIndex",
+      "footnoteCellValue",
+    ]);
+    assert.strictEqual(job.sheetName, "Sheet1");
+    assert.strictEqual(job.tableBottomRowIndex, 12);
+    assert.strictEqual(job.tableLeftColIndex, 3);
+    assert.strictEqual(job.tableRightColIndex, 7);
+    assert.strictEqual(job.dataStartColIndex, 4);
+    assert.ok(isGeneratedSignificanceFootnoteRow(job.footnoteCellValue));
+    assert.strictEqual(
+      job.footnoteCellValue.slice(SIGNIFICANCE_FOOTNOTE_MARKER.length),
+      "Уровень значимости: 95%; тест: двусторонний; статистика: Z-критерий для долей."
+    );
+  });
+
+  it("includes the manual processed range suffix when supplied", () => {
+    const job = buildJob({
+      processedScopeSuffix: " Обработано: B12:F34.",
+    });
+
+    assert.strictEqual(
+      job.footnoteCellValue.slice(SIGNIFICANCE_FOOTNOTE_MARKER.length),
+      "Уровень значимости: 95%; тест: двусторонний; статистика: Z-критерий для долей. Обработано: B12:F34."
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Moved the pure Run significance footnote job construction helper out of `taskpane.js` into `src/taskpane/run-footnotes.js`.
- Updated `run-pipeline.js` to import and use the moved helper directly, so it no longer receives `buildSignificanceFootnoteJob` from `taskpane.js`.
- Added focused pure tests for the exported job builder.

## Files changed
- `src/taskpane/run-footnotes.js`
- `src/taskpane/run-pipeline.js`
- `src/taskpane/taskpane.js`
- `tests/core/run-footnotes.test.mjs`

## Exact functions moved
- `buildSignificanceFootnoteJob` moved from `src/taskpane/taskpane.js` to `src/taskpane/run-footnotes.js`.

## Functions intentionally left in taskpane.js
- `applySignificanceFootnoteJobs`, `applySignificanceFootnoteJobsInOwnContext`, and `writeOrInsertSignificanceFootnoteRow` stay in `taskpane.js` because they perform actual Office.js footnote insertion/update work.
- `applyBannerMarkerUpdatesForRange` stays in `taskpane.js` because banner marker writing is outside this PR5F footnote-job-builder scope.
- `runSignificanceFromSelection`, `runSignificanceForRange`, current-table/current-sheet/workbook handlers, batch loops, report writing, selected-range interpretation/normalization, marker-overflow preflight/dialog logic, Clear/Check/Content/inventory logic, Excel writer behavior, and statistical formulas were intentionally not moved or changed.

## Dependency object before/after
Before `taskpane.js` passed these dependencies into `run-pipeline.js`:
- `applyBannerMarkerUpdatesForRange`
- `buildSignificanceFootnoteJob`
- `createMarkerOverflowDecider`

After this PR it passes only:
- `applyBannerMarkerUpdatesForRange`
- `createMarkerOverflowDecider`

## Footnote job shape preservation
The moved builder still returns the same job object shape:
- `sheetName`
- `tableBottomRowIndex`
- `tableLeftColIndex`
- `tableRightColIndex`
- `dataStartColIndex`
- `footnoteCellValue`

Manual Run still supplies `processedScopeSuffix`, so the processed-range suffix remains included when available. Auto Run callers still omit it, preserving the existing auto footnote text behavior.

## Scope confirmations
- Actual footnote application/insertion was not moved.
- Context sync placement was not changed; this PR adds no Excel reads, writes, or syncs.
- The known manual partial-selection bug was not touched.
- No selected-range normalization, banner marker writer, Excel writer, or statistical formula changes are intended.

## Validation results
- `npm test` passed: 508 tests passing.
- `npm run build` passed; webpack emitted the existing taskpane bundle size warnings.
- `git diff --check` passed; only line-ending warnings from Git were reported.

## Tests added
- `tests/core/run-footnotes.test.mjs`
  - footnote disabled -> `null`
  - labels-on-left incompatible setting -> `null`
  - valid data geometry -> expected job shape
  - manual processed range suffix remains included when supplied

## Manual smoke checklist
Not executed in this environment; Excel manual smoke still needs human verification:
- [ ] Manual Run with footnote enabled.
- [ ] Manual Run footnote includes processed range suffix as before.
- [ ] Current-table Run with footnote enabled.
- [ ] Current-sheet/workbook Run with footnotes enabled.
- [ ] Footnote update/replacement still works.
- [ ] Basic Manual Run without footnote still works.
- [ ] Basic Clear smoke.

## Assumptions / limitations
- This is an architecture-only extraction; no production behavior changes are intended.
- The known partial-selection bug remains out of scope by design.