### PR TITLE
[codex] Finish Run footnote dependency cleanup

### DIFF
--- a/src/taskpane/run-footnotes.js
+++ b/src/taskpane/run-footnotes.js
@@ -1,8 +1,14 @@
+/* global console, Excel */
+
 import {
   collectStatisticTypeLabels,
   buildSignificanceFootnoteCellValue,
   resolveFootnoteSpan,
+  resolveFootnotePlacement,
+  FOOTNOTE_SCAN_WINDOW_ROWS,
 } from "../core/significance-footnote";
+
+import { LABEL_SCAN_COLUMNS_LEFT } from "../core/metric-detector";
 
 /**
  * Builds a footnote job for a single processed table, or null when the footnote
@@ -69,4 +75,153 @@ export function buildSignificanceFootnoteJob({
     dataStartColIndex,
     footnoteCellValue,
   };
+}
+
+// ─── Significance settings footnote application ──────────────────────────────
+//
+// When the "Добавлять подпись под таблицей" setting is on, each PROCESSED table
+// gets one footnote row inserted directly below it, merged across the full table
+// width (label columns + data columns). Skipped/blocked/error tables get nothing.
+//
+// IMPORTANT ordering rule (see issue #281): footnotes must NOT be inserted while
+// calculations are still running, because inserting a worksheet row shifts every
+// candidate range below it and corrupts the ranges still queued for calculation.
+// Instead, each run flow collects footnote "jobs" (pure geometry + text, computed
+// from the already-known ranges) and applies them AFTER all calculations finish,
+// bottom-to-top per worksheet so earlier insertions never shift a not-yet-applied
+// job's row index.
+
+/**
+ * Inserts or updates a single footnote row for one table.
+ *
+ * A small bounded window of rows below the table body is scanned (values loaded
+ * across a span that also covers a couple of columns to the LEFT, so the marker
+ * is seen even when a label/data blank-gap column shifts the merged footnote's
+ * anchor). Placement is decided by the pure resolveFootnotePlacement helper:
+ *
+ *  - if a generated RIT footnote already exists for the table (marker-based), it
+ *    is updated in place — no new row, no duplicate;
+ *  - ordinary user note rows directly below the table are skipped, and the
+ *    generated footnote is inserted BELOW them (never overwriting them);
+ *  - otherwise a brand-new worksheet row is inserted so nothing is overwritten.
+ *
+ * The footnote cells are merged across exactly [tableLeftColIndex .. tableRightColIndex].
+ */
+export async function writeOrInsertSignificanceFootnoteRow(context, worksheet, job) {
+  const { tableBottomRowIndex, tableLeftColIndex, tableRightColIndex, dataStartColIndex, footnoteCellValue } = job;
+  const width = tableRightColIndex - tableLeftColIndex + 1;
+  if (width < 1) return;
+
+  const firstRowBelowTable = tableBottomRowIndex + 1;
+
+  // Scan a span starting a few columns LEFT of the table so a left-offset marker
+  // (from a run whose label/gap geometry differed) is still detected.
+  const scanStartCol = Math.max(0, tableLeftColIndex - LABEL_SCAN_COLUMNS_LEFT);
+  const scanColCount = tableRightColIndex - scanStartCol + 1;
+  const dataColRef = Number.isFinite(dataStartColIndex) ? dataStartColIndex : tableLeftColIndex;
+  const dataColStartOffset = dataColRef - scanStartCol;
+
+  // Load the bounded window of rows below the table to decide placement.
+  const scanRange = worksheet.getRangeByIndexes(
+    firstRowBelowTable,
+    scanStartCol,
+    FOOTNOTE_SCAN_WINDOW_ROWS,
+    scanColCount
+  );
+  scanRange.load("values");
+  await context.sync();
+
+  const placement = resolveFootnotePlacement(
+    scanRange.values,
+    firstRowBelowTable,
+    dataColStartOffset
+  );
+  const footnoteRowIndex = placement.rowIndex;
+
+  if (placement.mode === "insert") {
+    // Insert a new blank row so nothing existing below the table is overwritten.
+    worksheet
+      .getRangeByIndexes(footnoteRowIndex, 0, 1, 1)
+      .getEntireRow()
+      .insert(Excel.InsertShiftDirection.down);
+    await context.sync();
+  } else {
+    // Updating an existing generated footnote row in place: clear the full scan
+    // span first so a prior merge and any left-offset marker cell are removed
+    // before the row is rewritten at the current geometry. The row is RIT's own
+    // generated footnote row, so clearing its span never touches user content.
+    const priorRange = worksheet.getRangeByIndexes(footnoteRowIndex, scanStartCol, 1, scanColCount);
+    priorRange.unmerge();
+    priorRange.clear(Excel.ClearApplyTo.contents);
+    await context.sync();
+  }
+
+  const footnoteRange = worksheet.getRangeByIndexes(footnoteRowIndex, tableLeftColIndex, 1, width);
+
+  // Clear any prior merge first: a merged range rejects multi-cell writes, and an
+  // existing footnote from a previous run may already be merged across this span.
+  footnoteRange.unmerge();
+  await context.sync();
+
+  const leftCell = worksheet.getRangeByIndexes(footnoteRowIndex, tableLeftColIndex, 1, 1);
+  leftCell.values = [[footnoteCellValue]];
+
+  if (width > 1) {
+    footnoteRange.merge();
+  }
+
+  footnoteRange.format.font.italic = true;
+  footnoteRange.format.font.bold = false;
+  footnoteRange.format.fill.clear();
+  footnoteRange.format.horizontalAlignment = "Left";
+  footnoteRange.format.verticalAlignment = "Center";
+  await context.sync();
+}
+
+/**
+ * Applies a list of footnote jobs. Jobs are grouped per worksheet and applied
+ * bottom-to-top (descending table bottom row) so that inserting a footnote row
+ * for a lower table never shifts the row index of a higher table still pending.
+ *
+ * Tolerant: a failure on one footnote is logged and skipped; it never aborts the
+ * Run itself (calculations have already completed and been written at this point).
+ */
+export async function applySignificanceFootnoteJobs(context, jobs) {
+  if (!Array.isArray(jobs) || jobs.length === 0) return;
+
+  const jobsBySheet = new Map();
+  for (const job of jobs) {
+    if (!job || !job.sheetName) continue;
+    if (!jobsBySheet.has(job.sheetName)) jobsBySheet.set(job.sheetName, []);
+    jobsBySheet.get(job.sheetName).push(job);
+  }
+
+  for (const [sheetName, sheetJobs] of jobsBySheet) {
+    const worksheet = context.workbook.worksheets.getItem(sheetName);
+    const sorted = sheetJobs
+      .slice()
+      .sort((a, b) => b.tableBottomRowIndex - a.tableBottomRowIndex);
+    for (const job of sorted) {
+      try {
+        await writeOrInsertSignificanceFootnoteRow(context, worksheet, job);
+      } catch (footnoteErr) {
+        console.warn("RIT: не удалось записать подпись под таблицей.", footnoteErr);
+      }
+    }
+  }
+}
+
+/**
+ * Convenience wrapper that applies footnote jobs inside their own Excel.run.
+ * Used by run flows whose calculations completed in a different context.
+ */
+export async function applySignificanceFootnoteJobsInOwnContext(jobs) {
+  if (!Array.isArray(jobs) || jobs.length === 0) return;
+  try {
+    await Excel.run(async (context) => {
+      await applySignificanceFootnoteJobs(context, jobs);
+    });
+  } catch (footnoteErr) {
+    console.warn("RIT: не удалось записать подписи под таблицами.", footnoteErr);
+  }
 }

--- a/src/taskpane/run-pipeline.js
+++ b/src/taskpane/run-pipeline.js
@@ -28,6 +28,8 @@ import { perfNow, perfEnabled } from "./taskpane-performance";
 
 import { buildSignificanceFootnoteJob } from "./run-footnotes";
 
+import { createMarkerOverflowDecider } from "./taskpane-dialogs";
+
 function requireRunPipelineDependency(dependencies, name) {
   const dependency = dependencies[name];
   if (typeof dependency !== "function") {
@@ -122,10 +124,6 @@ export async function runSignificanceForRangeInContext(
   const applyBannerMarkerUpdatesForRange = requireRunPipelineDependency(
     dependencies,
     "applyBannerMarkerUpdatesForRange"
-  );
-  const createMarkerOverflowDecider = requireRunPipelineDependency(
-    dependencies,
-    "createMarkerOverflowDecider"
   );
 
   const _p0 = perfNow();

--- a/src/taskpane/taskpane.js
+++ b/src/taskpane/taskpane.js
@@ -20,7 +20,6 @@ import {
   detectMetricRowsFromLeftLabels,
   buildCalculationBlocks,
   getAllowedMarkerRowIndexes,
-  LABEL_SCAN_COLUMNS_LEFT,
 } from "../core/metric-detector";
 
 import { writeCellResultsToSelectedRange } from "../core/excel-writer";
@@ -30,8 +29,6 @@ import { scanWorksheetForTables } from "../core/table-inventory-scanner";
 
 import {
   buildProcessedRangeFootnoteSuffix,
-  resolveFootnotePlacement,
-  FOOTNOTE_SCAN_WINDOW_ROWS,
 } from "../core/significance-footnote";
 
 import { detectBannerStructure } from "../core/banner-detector";
@@ -56,7 +53,11 @@ import {
   runSignificanceForRangeInContext as runSignificanceForRangeInContextPipeline,
 } from "./run-pipeline";
 
-import { buildSignificanceFootnoteJob } from "./run-footnotes";
+import {
+  buildSignificanceFootnoteJob,
+  applySignificanceFootnoteJobsInOwnContext,
+  writeOrInsertSignificanceFootnoteRow,
+} from "./run-footnotes";
 
 import { refreshActionWarnings } from "./taskpane-action-warnings";
 
@@ -854,7 +855,6 @@ async function runSignificanceForRangeInContext(
     markerOverflowDecider,
     {
       applyBannerMarkerUpdatesForRange,
-      createMarkerOverflowDecider,
     }
   );
 }
@@ -4013,155 +4013,6 @@ async function ensureBacklinkRows(context, sheetResults, contentRowMap) {
         candidate.backlinkState
       );
     }
-  }
-}
-
-// ─── Significance settings footnote ────────────────────────────────────────────
-//
-// When the "Добавлять подпись под таблицей" setting is on, each PROCESSED table
-// gets one footnote row inserted directly below it, merged across the full table
-// width (label columns + data columns). Skipped/blocked/error tables get nothing.
-//
-// IMPORTANT ordering rule (see issue #281): footnotes must NOT be inserted while
-// calculations are still running, because inserting a worksheet row shifts every
-// candidate range below it and corrupts the ranges still queued for calculation.
-// Instead, each run flow collects footnote "jobs" (pure geometry + text, computed
-// from the already-known ranges) and applies them AFTER all calculations finish,
-// bottom-to-top per worksheet so earlier insertions never shift a not-yet-applied
-// job's row index.
-
-/**
- * Inserts or updates a single footnote row for one table.
- *
- * A small bounded window of rows below the table body is scanned (values loaded
- * across a span that also covers a couple of columns to the LEFT, so the marker
- * is seen even when a label/data blank-gap column shifts the merged footnote's
- * anchor). Placement is decided by the pure resolveFootnotePlacement helper:
- *
- *  - if a generated RIT footnote already exists for the table (marker-based), it
- *    is updated in place — no new row, no duplicate;
- *  - ordinary user note rows directly below the table are skipped, and the
- *    generated footnote is inserted BELOW them (never overwriting them);
- *  - otherwise a brand-new worksheet row is inserted so nothing is overwritten.
- *
- * The footnote cells are merged across exactly [tableLeftColIndex .. tableRightColIndex].
- */
-async function writeOrInsertSignificanceFootnoteRow(context, worksheet, job) {
-  const { tableBottomRowIndex, tableLeftColIndex, tableRightColIndex, dataStartColIndex, footnoteCellValue } = job;
-  const width = tableRightColIndex - tableLeftColIndex + 1;
-  if (width < 1) return;
-
-  const firstRowBelowTable = tableBottomRowIndex + 1;
-
-  // Scan a span starting a few columns LEFT of the table so a left-offset marker
-  // (from a run whose label/gap geometry differed) is still detected.
-  const scanStartCol = Math.max(0, tableLeftColIndex - LABEL_SCAN_COLUMNS_LEFT);
-  const scanColCount = tableRightColIndex - scanStartCol + 1;
-  const dataColRef = Number.isFinite(dataStartColIndex) ? dataStartColIndex : tableLeftColIndex;
-  const dataColStartOffset = dataColRef - scanStartCol;
-
-  // Load the bounded window of rows below the table to decide placement.
-  const scanRange = worksheet.getRangeByIndexes(
-    firstRowBelowTable,
-    scanStartCol,
-    FOOTNOTE_SCAN_WINDOW_ROWS,
-    scanColCount
-  );
-  scanRange.load("values");
-  await context.sync();
-
-  const placement = resolveFootnotePlacement(
-    scanRange.values,
-    firstRowBelowTable,
-    dataColStartOffset
-  );
-  const footnoteRowIndex = placement.rowIndex;
-
-  if (placement.mode === "insert") {
-    // Insert a new blank row so nothing existing below the table is overwritten.
-    worksheet
-      .getRangeByIndexes(footnoteRowIndex, 0, 1, 1)
-      .getEntireRow()
-      .insert(Excel.InsertShiftDirection.down);
-    await context.sync();
-  } else {
-    // Updating an existing generated footnote row in place: clear the full scan
-    // span first so a prior merge and any left-offset marker cell are removed
-    // before the row is rewritten at the current geometry. The row is RIT's own
-    // generated footnote row, so clearing its span never touches user content.
-    const priorRange = worksheet.getRangeByIndexes(footnoteRowIndex, scanStartCol, 1, scanColCount);
-    priorRange.unmerge();
-    priorRange.clear(Excel.ClearApplyTo.contents);
-    await context.sync();
-  }
-
-  const footnoteRange = worksheet.getRangeByIndexes(footnoteRowIndex, tableLeftColIndex, 1, width);
-
-  // Clear any prior merge first: a merged range rejects multi-cell writes, and an
-  // existing footnote from a previous run may already be merged across this span.
-  footnoteRange.unmerge();
-  await context.sync();
-
-  const leftCell = worksheet.getRangeByIndexes(footnoteRowIndex, tableLeftColIndex, 1, 1);
-  leftCell.values = [[footnoteCellValue]];
-
-  if (width > 1) {
-    footnoteRange.merge();
-  }
-
-  footnoteRange.format.font.italic = true;
-  footnoteRange.format.font.bold = false;
-  footnoteRange.format.fill.clear();
-  footnoteRange.format.horizontalAlignment = "Left";
-  footnoteRange.format.verticalAlignment = "Center";
-  await context.sync();
-}
-
-/**
- * Applies a list of footnote jobs. Jobs are grouped per worksheet and applied
- * bottom-to-top (descending table bottom row) so that inserting a footnote row
- * for a lower table never shifts the row index of a higher table still pending.
- *
- * Tolerant: a failure on one footnote is logged and skipped; it never aborts the
- * Run itself (calculations have already completed and been written at this point).
- */
-async function applySignificanceFootnoteJobs(context, jobs) {
-  if (!Array.isArray(jobs) || jobs.length === 0) return;
-
-  const jobsBySheet = new Map();
-  for (const job of jobs) {
-    if (!job || !job.sheetName) continue;
-    if (!jobsBySheet.has(job.sheetName)) jobsBySheet.set(job.sheetName, []);
-    jobsBySheet.get(job.sheetName).push(job);
-  }
-
-  for (const [sheetName, sheetJobs] of jobsBySheet) {
-    const worksheet = context.workbook.worksheets.getItem(sheetName);
-    const sorted = sheetJobs
-      .slice()
-      .sort((a, b) => b.tableBottomRowIndex - a.tableBottomRowIndex);
-    for (const job of sorted) {
-      try {
-        await writeOrInsertSignificanceFootnoteRow(context, worksheet, job);
-      } catch (footnoteErr) {
-        console.warn("RIT: не удалось записать подпись под таблицей.", footnoteErr);
-      }
-    }
-  }
-}
-
-/**
- * Convenience wrapper that applies footnote jobs inside their own Excel.run.
- * Used by run flows whose calculations completed in a different context.
- */
-async function applySignificanceFootnoteJobsInOwnContext(jobs) {
-  if (!Array.isArray(jobs) || jobs.length === 0) return;
-  try {
-    await Excel.run(async (context) => {
-      await applySignificanceFootnoteJobs(context, jobs);
-    });
-  } catch (footnoteErr) {
-    console.warn("RIT: не удалось записать подписи под таблицами.", footnoteErr);
   }
 }
 


### PR DESCRIPTION
## Summary

Finish architecture refactor PR5G by removing one leftover Run pipeline dependency injection and moving generated Run significance footnote application helpers out of `taskpane.js`.

## Files changed

- `src/taskpane/run-pipeline.js`
- `src/taskpane/run-footnotes.js`
- `src/taskpane/taskpane.js`

## Exact functions moved

Moved from `taskpane.js` to `run-footnotes.js`:

- `writeOrInsertSignificanceFootnoteRow`
- `applySignificanceFootnoteJobs`
- `applySignificanceFootnoteJobsInOwnContext`

Also moved the direct helper dependencies required by those functions into `run-footnotes.js` imports:

- `resolveFootnotePlacement`
- `FOOTNOTE_SCAN_WINDOW_ROWS`
- `LABEL_SCAN_COLUMNS_LEFT`

## Functions intentionally left in `taskpane.js`

- `applyBannerMarkerUpdatesForRange`: intentionally left because this PR must not move the banner marker writer/helpers.
- `runSignificanceFromSelection`: manual Run handler remains in `taskpane.js` per scope.
- `runSignificanceForRange` / `runSignificanceForRangeInContext` wrappers: left in `taskpane.js` so current-table/current-sheet/workbook Run handlers keep their existing orchestration.
- Batch loops and Run report writing: left in `taskpane.js`; not part of PR5G.
- Selected-range interpretation/normalization, Clear/Check/Content/inventory logic, Excel writer, and statistical formulas: untouched by scope.

## Dependency object before/after

Before, `taskpane.js` passed this dependency object into `run-pipeline.js`:

```js
{
  applyBannerMarkerUpdatesForRange,
  createMarkerOverflowDecider,
}
```

After, `taskpane.js` passes only:

```js
{
  applyBannerMarkerUpdatesForRange,
}
```

`run-pipeline.js` now imports `createMarkerOverflowDecider` directly from `taskpane-dialogs.js`.

## Footnote behavior preservation notes

- Footnote job object shape is unchanged.
- Manual Run still builds the processed range suffix with `buildProcessedRangeFootnoteSuffix(writeTargetRange.address)` before constructing the job.
- Auto Run footnote job construction remains in `run-pipeline.js` via `buildSignificanceFootnoteJob`.
- Existing update/replacement behavior is preserved by moving `resolveFootnotePlacement` usage unchanged.
- Per-sheet footnote jobs are still sorted bottom-to-top by descending `tableBottomRowIndex` before application.
- `context.sync()` placement inside the moved helpers is preserved exactly; no new sync calls were added inside loops.
- Footnote failures are still logged and tolerated so completed Run calculations are not aborted.

## Scope confirmations

- Banner marker writer was not moved.
- Known manual Run partial-selection bug was not touched.
- No circular dependency introduced: `run-pipeline.js` imports `taskpane-dialogs.js`; `run-footnotes.js` imports only core helpers/constants and does not import `taskpane.js`; `taskpane.js` imports the moved helpers from `run-footnotes.js`.
- `run-pipeline.js` still does not import `taskpane.js`.
- `run-footnotes.js` does not import `taskpane.js`.

## Validation results

- `npm test` passed: 508 tests passing.
- `npm run build` passed. Webpack reported the existing taskpane bundle-size warnings.
- `git diff --check` passed. Git printed line-ending normalization warnings for the touched files.

## Tests added

No tests added. This was an Office.js-aware helper move with no newly exported pure behavior; existing `run-footnotes` and core footnote tests cover the pure job/placement behavior.

## Manual smoke checklist

Not run in Codex; requires Excel smoke testing.

- [ ] Manual Run with footnote enabled.
- [ ] Manual Run footnote includes processed range suffix as before.
- [ ] Current-table Run with footnote enabled.
- [ ] Current-sheet/workbook Run with multiple footnotes enabled.
- [ ] Footnote update/replacement still works and does not duplicate generated footnotes.
- [ ] Footnotes are still applied bottom-to-top and do not shift later tables.
- [ ] Marker overflow Stop/Continue still works.
- [ ] Basic Manual Run without footnote still works.
- [ ] Basic Clear smoke.
